### PR TITLE
Wait until all the subscribed topics have been created

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralKafkaConsumer.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralKafkaConsumer.java
@@ -139,23 +139,23 @@ public class UCentralKafkaConsumer {
 	/** Subscribe to topic(s). */
 	public void subscribe() {
 		List<String> subscribeTopics = Arrays.asList(stateTopic, wifiScanTopic, serviceEventsTopic)
-			.stream()
-			.filter(t -> t != null && !t.isEmpty())
-			.collect(Collectors.toList());
+				.stream()
+				.filter(t -> t != null && !t.isEmpty())
+				.collect(Collectors.toList());
 		Map<String, List<PartitionInfo>> topics = consumer.listTopics(POLL_TIMEOUT);
-		List<String> topicsList = topics.keySet().stream().collect(Collectors.toList());
 		logger.info("Found topics: {}", String.join(", ", topics.keySet()));
-		while(!topicsList.containsAll(subscribeTopics)){
-			List<String> lastTopics = topicsList;
-			List<String> missingTopics = subscribeTopics.stream().filter(el -> !lastTopics.contains(el)).collect(Collectors.toList());
-			logger.info("Waiting for creation of topics: {}", String.join(", ", missingTopics));
-			try{
+		while (!topics.keySet().containsAll(subscribeTopics)) {
+			logger.info(
+					"Waiting for Kafka topics (received=[{}], required=[{}])",
+					String.join(", ", topics.keySet()),
+					String.join(", ", subscribeTopics)
+			);
+			try {
 				Thread.sleep(1000);
-			}catch(InterruptedException e){
-				e.printStackTrace();
+			} catch (InterruptedException e) {
+				throw new RuntimeException("Interrupted while waiting for Kafka topics", e);
 			}
 			topics = consumer.listTopics(POLL_TIMEOUT);
-			topicsList = topics.keySet().stream().collect(Collectors.toList());
 		}
 		consumer.subscribe(subscribeTopics, new ConsumerRebalanceListener() {
 			@Override


### PR DESCRIPTION
Waits until all the subscribed topics have been created. Prints out a message to show which topics have not been created. To create a topic, send a message on that topic.

Test-Plan:

1. I added a topic to the subscribeTopics list called "testtopic", but wifiscans topic also had not been created yet so I was able to test it twice.
2. Start the app, observe it will wait for the required topics to be created
3. If you added a test topic (because all the others have been created) - you can use the kafka console producer to push a message :

Run this command
```
docker compose exec -it kafka  /opt/bitnami/kafka/bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic testtopic
```
the console will appear to hang, it's waiting for input. Type in some random junk and hit enter. This will push to the topic.