### PR TITLE
feat: optionally read RRMConfig from env vars

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -6,9 +6,10 @@ This document provides high-level implementation details of the RRM service.
 the `RRM` class to run all *modules* (details below). Many of these will run in
 their own threads and implement the standard `Runnable` interface.
 
-The application takes a JSON-serialized `RRMConfig` object as service config
-(default `settings.json`). This file is created dynamically, and any new/missing
-fields are appended automatically. All fields are documented in Javadoc.
+The service configuration model is specified in the `RRMConfig` class, which can
+be provided either via environment variables or as a JSON-serialized file. When
+using the static file option, any new/missing fields are appended automatically.
+All fields are documented in Javadoc.
 
 The device topology, `DeviceTopology`, is specified as groupings of APs into
 disjoint "RF zones" (default `topology.json`). For example:

--- a/README.md
+++ b/README.md
@@ -23,11 +23,18 @@ $ java -jar openwifi-rrm.jar [-h]
 ```
 The command-line interface is implemented using [picocli].
 
-Service configuration is done via a JSON file (default `settings.json`) and will
-require the following data:
-* uCentral credentials (`uCentralConfig`)
-* Kafka broker URL (`kafkaConfig`)
-* MySQL database credentials (`databaseConfig`)
+To start the service, use the `run` command while providing configuration via
+either environment variables (`--config-env`) or a static JSON file
+(`--config-file`, default `settings.json`). The following data is *required*:
+* uCentral credentials
+    * Env: `UCENTRALCONFIG_PRIVATEENDPOINT`
+    * JSON: `uCentralConfig` structure
+* Kafka broker URL
+    * Env: `KAFKACONFIG_BOOTSTRAPSERVER`
+    * JSON: `kafkaConfig` structure
+* MySQL database credentials
+    * Env: `DATABASECONFIG_SERVER`, `DATABASECONFIG_USER`, `DATABASECONFIG_PASSWORD`
+    * JSON: `databaseConfig` structure
 
 ## Docker
 Docker builds can be launched using the provided [Dockerfile](Dockerfile).

--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -115,6 +115,12 @@ public class Launcher implements Callable<Integer> {
 		File configFile,
 
 		@Option(
+			names = { "--config-env" },
+			description = "Read RRM config from environment variables (overrides --config-file)"
+		)
+		boolean configEnv,
+
+		@Option(
 			names = { "-t", "--topology-file" },
 			paramLabel = "<FILE>",
 			description = "Device topology file"
@@ -129,9 +135,16 @@ public class Launcher implements Callable<Integer> {
 		File deviceLayeredConfigFile
 	) throws Exception {
 		// Read local files
-		RRMConfig config = readRRMConfig(
-			configFile != null ? configFile : DEFAULT_CONFIG_FILE
-		);
+		RRMConfig config;
+		if (configEnv) {
+			logger.info("Loading config from environment variables...");
+			config = RRMConfig.fromEnv(System.getenv());
+		} else {
+			config = readRRMConfig(
+				configFile != null ? configFile : DEFAULT_CONFIG_FILE
+			);
+		}
+
 		DeviceDataManager deviceDataManager = new DeviceDataManager(
 			topologyFile != null ? topologyFile : DEFAULT_TOPOLOGY_FILE,
 			deviceLayeredConfigFile != null

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -8,6 +8,8 @@
 
 package com.facebook.openwifirrm;
 
+import java.util.Map;
+
 /**
  * RRM service configuration model.
  */
@@ -16,26 +18,44 @@ public class RRMConfig {
 	 * uCentral configuration.
 	 */
 	public class UCentralConfig {
-		/** uCentralSec host */
+		/**
+		 * uCentralSec host
+		 * (<tt>UCENTRALCONFIG_UCENTRALSECHOST</tt>)
+		 */
 		public String uCentralSecHost = "127.0.0.1";
 
-		/** uCentralSec port */
+		/**
+		 * uCentralSec port
+		 * (<tt>UCENTRALCONFIG_UCENTRALSECPORT</tt>)
+		 */
 		public int uCentralSecPort = 17001;
 
-		/** uCentralSec private microservice endpoint */
+		/**
+		 * uCentralSec private microservice endpoint
+		 * (<tt>UCENTRALCONFIG_PRIVATEENDPOINT</tt>)
+		 */
 		public String privateEndpoint = "https://owrrm.wlan.local:17006";
 
 		/**
 		 * uCentral socket parameters
 		 */
 		public class UCentralSocketParams {
-			/** Connection timeout for all requests, in ms */
+			/**
+			 * Connection timeout for all requests, in ms
+			 * (<tt>UCENTRALSOCKETPARAMS_CONNECTTIMEOUTMS</tt>)
+			 */
 			public int connectTimeoutMs = 2000;
 
-			/** Socket timeout for all requests, in ms */
+			/**
+			 * Socket timeout for all requests, in ms
+			 * (<tt>UCENTRALSOCKETPARAMS_SOCKETTIMEOUTMS</tt>)
+			 */
 			public int socketTimeoutMs = 15000;
 
-			/** Socket timeout for wifi scan requests, in ms */
+			/**
+			 * Socket timeout for wifi scan requests, in ms
+			 * (<tt>UCENTRALSOCKETPARAMS_WIFISCANTIMEOUTMS</tt>)
+			 */
 			public int wifiScanTimeoutMs = 45000;
 		}
 
@@ -51,22 +71,41 @@ public class RRMConfig {
 	 * uCentral Kafka configuration.
 	 */
 	public class KafkaConfig {
-		/** Kafka bootstrap host:port, or empty to disable */
+		/**
+		 * Kafka bootstrap host:port, or empty to disable
+		 * (<tt>KAFKACONFIG_BOOTSTRAPSERVER</tt>)
+		 */
 		public String bootstrapServer = "127.0.0.1:9093";
 
-		/** Kafka topic holding uCentral state */
+		/**
+		 * Kafka topic holding uCentral state
+		 * (<tt>KAFKACONFIG_STATETOPIC</tt>)
+		 */
 		public String stateTopic = "state";
 
-		/** Kafka topic holding uCentral wifi scan results */
+		/**
+		 * Kafka topic holding uCentral wifi scan results
+		 * (<tt>KAFKACONFIG_WIFISCANTOPIC</tt>)
+		 */
 		public String wifiScanTopic = "wifiscan";
 
-		/** Kafka topic holding uCentral microservice events. Used for detecting API keys and internal endpoints.  */
+		/**
+		 * Kafka topic holding uCentral microservice events.
+		 * Used for detecting API keys and internal endpoints.
+		 * (<tt>KAFKACONFIG_SERVICEEVENTSTOPIC</tt>)
+		 */
 		public String serviceEventsTopic = "service_events";
 
-		/** Kafka consumer group ID */
+		/**
+		 * Kafka consumer group ID
+		 * (<tt>KAFKACONFIG_GROUPID</tt>)
+		 */
 		public String groupId = "rrm-service";
 
-		/** Kafka "auto.offset.reset" config ["earliest", "latest"] */
+		/**
+		 * Kafka "auto.offset.reset" config ["earliest", "latest"]
+		 * (<tt>KAFKACONFIG_AUTOOFFSETRESET</tt>)
+		 */
 		public String autoOffsetReset = "latest";
 	}
 
@@ -77,19 +116,34 @@ public class RRMConfig {
 	 * Database configuration.
 	 */
 	public class DatabaseConfig {
-		/** MySQL database host:port, or empty to disable */
+		/**
+		 * MySQL database host:port, or empty to disable
+		 * (<tt>DATABASECONFIG_SERVER</tt>)
+		 */
 		public String server = "127.0.0.1:3306";
 
-		/** MySQL database user */
+		/**
+		 * MySQL database user
+		 * (<tt>DATABASECONFIG_USER</tt>)
+		 */
 		public String user = "root";
 
-		/** MySQL database password */
+		/**
+		 * MySQL database password
+		 * (<tt>DATABASECONFIG_PASSWORD</tt>)
+		 */
 		public String password = "openwifi";
 
-		/** MySQL database name */
+		/**
+		 * MySQL database name
+		 * (<tt>DATABASECONFIG_DBNAME</tt>)
+		 */
 		public String dbName = "rrm";
 
-		/** Data retention interval in days (0 to disable) */
+		/**
+		 * Data retention interval in days (0 to disable)
+		 * (<tt>DATABASECONFIG_DATARETENTIONINTERVALDAYS</tt>)
+		 */
 		public int dataRetentionIntervalDays = 14;
 	}
 
@@ -104,22 +158,35 @@ public class RRMConfig {
 		 * DataCollector parameters.
 		 */
 		public class DataCollectorParams {
-			/** The main logic loop interval (i.e. sleep time), in ms. */
+			/**
+			 * The main logic loop interval (i.e. sleep time), in ms
+			 * (<tt>DATACOLLECTORPARAMS_UPDATEINTERVALMS</tt>)
+			 */
 			public int updateIntervalMs = 5000;
 
-			/** The expected device statistics interval, in seconds. */
+			/**
+			 * The expected device statistics interval, in seconds
+			 * (<tt>DATACOLLECTORPARAMS_DEVICESTATSINTERVALSEC</tt>)
+			 */
 			public int deviceStatsIntervalSec = 60;
 
 			/**
 			 * The wifi scan interval (per device), in seconds (or -1 to disable
-			 * automatic scans).
+			 * automatic scans)
+			 * (<tt>DATACOLLECTORPARAMS_WIFISCANINTERVALSEC</tt>)
 			 */
 			public int wifiScanIntervalSec = 60;
 
-			/** The capabilities request interval (per device), in seconds */
+			/**
+			 * The capabilities request interval (per device), in seconds
+			 * (<tt>DATACOLLECTORPARAMS_CAPABILITIESINTERVALSEC</tt>)
+			 */
 			public int capabilitiesIntervalSec = 3600;
 
-			/** Number of executor threads for async tasks (ex. wifi scans). */
+			/**
+			 * Number of executor threads for async tasks (ex. wifi scans)
+			 * (<tt>DATACOLLECTORPARAMS_EXECUTORTHREADCOUNT</tt>)
+			 */
 			public int executorThreadCount = 3;
 		}
 
@@ -131,15 +198,22 @@ public class RRMConfig {
 		 * ConfigManager parameters.
 		 */
 		public class ConfigManagerParams {
-			/** The main logic loop interval (i.e. sleep time), in ms. */
+			/**
+			 * The main logic loop interval (i.e. sleep time), in ms
+			 * (<tt>CONFIGMANAGERPARAMS_UPDATEINTERVALMS</tt>)
+			 */
 			public int updateIntervalMs = 60000;
 
-			/** Enable pushing device config changes? */
+			/**
+			 * Enable pushing device config changes?
+			 * (<tt>CONFIGMANAGERPARAMS_CONFIGENABLED</tt>)
+			 */
 			public boolean configEnabled = true;
 
 			/**
 			 * The debounce interval for reconfiguring the same device, in
-			 * seconds.
+			 * seconds
+			 * (<tt>CONFIGMANAGERPARAMS_CONFIGDEBOUNCEINTERVALSEC</tt>)
 			 */
 			public int configDebounceIntervalSec = 30;
 		}
@@ -152,7 +226,10 @@ public class RRMConfig {
 		 * Modeler parameters.
 		 */
 		public class ModelerParams {
-			/** Maximum rounds of wifi scan results to store per device. */
+			/**
+			 * Maximum rounds of wifi scan results to store per device
+			 * (<tt>MODELERPARAMS_WIFISCANBUFFERSIZE</tt>)
+			 */
 			public int wifiScanBufferSize = 10;
 		}
 
@@ -163,16 +240,28 @@ public class RRMConfig {
 		 * ApiServer parameters.
 		 */
 		public class ApiServerParams {
-			/** The HTTP port to listen on, or -1 to disable. */
+			/**
+			 * The HTTP port to listen on, or -1 to disable
+			 * (<tt>APISERVERPARAMS_HTTPPORT</tt>)
+			 */
 			public int httpPort = 16789;
 
-			/** Enable HTTP basic auth? */
+			/**
+			 * Enable HTTP basic auth?
+			 * (<tt>APISERVERPARAMS_USEBASICAUTH</tt>)
+			 */
 			public boolean useBasicAuth = true;
 
-			/** The HTTP basic auth username (if enabled). */
+			/**
+			 * The HTTP basic auth username (if enabled)
+			 * (<tt>APISERVERPARAMS_BASICAUTHUSER</tt>)
+			 */
 			public String basicAuthUser = "admin";
 
-			/** The HTTP basic auth password (if enabled). */
+			/**
+			 * The HTTP basic auth password (if enabled)
+			 * (<tt>APISERVERPARAMS_BASICAUTHPASSWORD</tt>)
+			 */
 			public String basicAuthPassword = "openwifi";
 		}
 
@@ -182,4 +271,123 @@ public class RRMConfig {
 
 	/** Module configuration. */
 	public ModuleConfig moduleConfig = new ModuleConfig();
+
+	/** Construct RRMConfig from environment variables. */
+	public static RRMConfig fromEnv(Map<String, String> env) {
+		RRMConfig config = new RRMConfig();
+		String v;
+
+		/* UCentralConfig */
+		UCentralConfig uCentralConfig = config.uCentralConfig;
+		if ((v = env.get("UCENTRALCONFIG_UCENTRALSECHOST")) != null) {
+			uCentralConfig.uCentralSecHost = v;
+		}
+		if ((v = env.get("UCENTRALCONFIG_UCENTRALSECPORT")) != null) {
+			uCentralConfig.uCentralSecPort = Integer.parseInt(v);
+		}
+		if ((v = env.get("UCENTRALCONFIG_PRIVATEENDPOINT")) != null) {
+			uCentralConfig.privateEndpoint = v;
+		}
+		UCentralConfig.UCentralSocketParams uCentralSocketParams =
+			config.uCentralConfig.uCentralSocketParams;
+		if ((v = env.get("UCENTRALSOCKETPARAMS_CONNECTTIMEOUTMS")) != null) {
+			uCentralSocketParams.connectTimeoutMs = Integer.parseInt(v);
+		}
+		if ((v = env.get("UCENTRALSOCKETPARAMS_SOCKETTIMEOUTMS")) != null) {
+			uCentralSocketParams.socketTimeoutMs = Integer.parseInt(v);
+		}
+		if ((v = env.get("UCENTRALSOCKETPARAMS_WIFISCANTIMEOUTMS")) != null) {
+			uCentralSocketParams.wifiScanTimeoutMs = Integer.parseInt(v);
+		}
+
+		/* KafkaConfig */
+		KafkaConfig kafkaConfig = config.kafkaConfig;
+		if ((v = env.get("KAFKACONFIG_BOOTSTRAPSERVER")) != null) {
+			kafkaConfig.bootstrapServer = v;
+		}
+		if ((v = env.get("KAFKACONFIG_STATETOPIC")) != null) {
+			kafkaConfig.stateTopic = v;
+		}
+		if ((v = env.get("KAFKACONFIG_WIFISCANTOPIC")) != null) {
+			kafkaConfig.wifiScanTopic = v;
+		}
+		if ((v = env.get("KAFKACONFIG_SERVICEEVENTSTOPIC")) != null) {
+			kafkaConfig.serviceEventsTopic = v;
+		}
+		if ((v = env.get("KAFKACONFIG_GROUPID")) != null) {
+			kafkaConfig.groupId = v;
+		}
+		if ((v = env.get("KAFKACONFIG_AUTOOFFSETRESET")) != null) {
+			kafkaConfig.autoOffsetReset = v;
+		}
+
+		/* DatabaseConfig */
+		DatabaseConfig databaseConfig = config.databaseConfig;
+		if ((v = env.get("DATABASECONFIG_SERVER")) != null) {
+			databaseConfig.server = v;
+		}
+		if ((v = env.get("DATABASECONFIG_USER")) != null) {
+			databaseConfig.user = v;
+		}
+		if ((v = env.get("DATABASECONFIG_PASSWORD")) != null) {
+			databaseConfig.password = v;
+		}
+		if ((v = env.get("DATABASECONFIG_DBNAME")) != null) {
+			databaseConfig.dbName = v;
+		}
+		if ((v = env.get("DATABASECONFIG_DATARETENTIONINTERVALDAYS")) != null) {
+			databaseConfig.dataRetentionIntervalDays = Integer.parseInt(v);
+		}
+
+		/* ModuleConfig */
+		ModuleConfig.DataCollectorParams dataCollectorParams =
+			config.moduleConfig.dataCollectorParams;
+		if ((v = env.get("DATACOLLECTORPARAMS_UPDATEINTERVALMS")) != null) {
+			dataCollectorParams.updateIntervalMs = Integer.parseInt(v);
+		}
+		if ((v = env.get("DATACOLLECTORPARAMS_DEVICESTATSINTERVALSEC")) != null) {
+			dataCollectorParams.deviceStatsIntervalSec = Integer.parseInt(v);
+		}
+		if ((v = env.get("DATACOLLECTORPARAMS_WIFISCANINTERVALSEC")) != null) {
+			dataCollectorParams.wifiScanIntervalSec = Integer.parseInt(v);
+		}
+		if ((v = env.get("DATACOLLECTORPARAMS_CAPABILITIESINTERVALSEC")) != null) {
+			dataCollectorParams.capabilitiesIntervalSec = Integer.parseInt(v);
+		}
+		if ((v = env.get("DATACOLLECTORPARAMS_EXECUTORTHREADCOUNT")) != null) {
+			dataCollectorParams.executorThreadCount = Integer.parseInt(v);
+		}
+		ModuleConfig.ConfigManagerParams configManagerParams =
+			config.moduleConfig.configManagerParams;
+		if ((v = env.get("CONFIGMANAGERPARAMS_UPDATEINTERVALMS")) != null) {
+			configManagerParams.updateIntervalMs = Integer.parseInt(v);
+		}
+		if ((v = env.get("CONFIGMANAGERPARAMS_CONFIGENABLED")) != null) {
+			configManagerParams.configEnabled = Boolean.parseBoolean(v);
+		}
+		if ((v = env.get("CONFIGMANAGERPARAMS_CONFIGDEBOUNCEINTERVALSEC")) != null) {
+			configManagerParams.configDebounceIntervalSec = Integer.parseInt(v);
+		}
+		ModuleConfig.ModelerParams modelerParams =
+			config.moduleConfig.modelerParams;
+		if ((v = env.get("MODELERPARAMS_WIFISCANBUFFERSIZE")) != null) {
+			modelerParams.wifiScanBufferSize = Integer.parseInt(v);
+		}
+		ModuleConfig.ApiServerParams apiServerParams =
+			config.moduleConfig.apiServerParams;
+		if ((v = env.get("APISERVERPARAMS_HTTPPORT")) != null) {
+			apiServerParams.httpPort = Integer.parseInt(v);
+		}
+		if ((v = env.get("APISERVERPARAMS_USEBASICAUTH")) != null) {
+			apiServerParams.useBasicAuth = Boolean.parseBoolean(v);
+		}
+		if ((v = env.get("APISERVERPARAMS_BASICAUTHUSER")) != null) {
+			apiServerParams.basicAuthUser = v;
+		}
+		if ((v = env.get("APISERVERPARAMS_BASICAUTHPASSWORD")) != null) {
+			apiServerParams.basicAuthPassword = v;
+		}
+
+		return config;
+	}
 }

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.facebook.openwifirrm.ucentral.gw.models.CommandInfo;


### PR DESCRIPTION
See #2 for context. Allow reading `RRMConfig` from environment variables by starting the service with `run --config-env`. The old method of using a static JSON file is still supported. These modes cannot be used together.