### PR TITLE
feat: add configOnEventOnly service config

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -165,7 +165,8 @@ public class RRMConfig {
 			public int updateIntervalMs = 5000;
 
 			/**
-			 * The expected device statistics interval, in seconds
+			 * The expected device statistics interval, in seconds (or -1 to
+			 * disable managing this value)
 			 * (<tt>DATACOLLECTORPARAMS_DEVICESTATSINTERVALSEC</tt>)
 			 */
 			public int deviceStatsIntervalSec = 60;
@@ -211,8 +212,15 @@ public class RRMConfig {
 			public boolean configEnabled = true;
 
 			/**
+			 * If set, device config changes will only be pushed on events
+			 * (e.g. RRM algorithm execution, config API calls)
+			 * (<tt>CONFIGMANAGERPARAMS_CONFIGONEVENTONLY</tt>)
+			 */
+			public boolean configOnEventOnly = false;
+
+			/**
 			 * The debounce interval for reconfiguring the same device, in
-			 * seconds
+			 * seconds (or -1 to disable)
 			 * (<tt>CONFIGMANAGERPARAMS_CONFIGDEBOUNCEINTERVALSEC</tt>)
 			 */
 			public int configDebounceIntervalSec = 30;
@@ -364,6 +372,9 @@ public class RRMConfig {
 		}
 		if ((v = env.get("CONFIGMANAGERPARAMS_CONFIGENABLED")) != null) {
 			configManagerParams.configEnabled = Boolean.parseBoolean(v);
+		}
+		if ((v = env.get("CONFIGMANAGERPARAMS_CONFIGONEVENTONLY")) != null) {
+			configManagerParams.configOnEventOnly = Boolean.parseBoolean(v);
 		}
 		if ((v = env.get("CONFIGMANAGERPARAMS_CONFIGDEBOUNCEINTERVALSEC")) != null) {
 			configManagerParams.configDebounceIntervalSec = Integer.parseInt(v);

--- a/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import com.facebook.openwifirrm.ucentral.gw.models.ServiceEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +37,7 @@ import com.facebook.openwifirrm.ucentral.UCentralUtils.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.gw.models.CommandInfo;
 import com.facebook.openwifirrm.ucentral.gw.models.DeviceCapabilities;
 import com.facebook.openwifirrm.ucentral.gw.models.DeviceWithStatus;
+import com.facebook.openwifirrm.ucentral.gw.models.ServiceEvent;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -121,6 +121,13 @@ public class DataCollector implements Runnable {
 		configManager.addConfigListener(
 			getClass().getSimpleName(),
 			new ConfigManager.ConfigListener() {
+				@Override
+				public void receiveDeviceConfig(
+					String serialNumber, UCentralApConfiguration config
+				) {
+					// do nothing
+				}
+
 				@Override
 				public boolean processDeviceConfig(
 					String serialNumber, UCentralApConfiguration config
@@ -224,6 +231,9 @@ public class DataCollector implements Runnable {
 
 		// Check stats interval
 		final int STATS_INTERVAL_S = params.deviceStatsIntervalSec;
+		if (STATS_INTERVAL_S < 1) {
+			return false;  // unmanaged
+		}
 		int currentStatsInterval = config.getStatisticsInterval();
 		if (currentStatsInterval != STATS_INTERVAL_S) {
 			logger.info(

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -16,7 +16,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import com.facebook.openwifirrm.ucentral.gw.models.ServiceEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +30,7 @@ import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.UCentralUtils.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.gw.models.DeviceCapabilities;
 import com.facebook.openwifirrm.ucentral.gw.models.DeviceWithStatus;
+import com.facebook.openwifirrm.ucentral.gw.models.ServiceEvent;
 import com.facebook.openwifirrm.ucentral.gw.models.StatisticsRecords;
 import com.facebook.openwifirrm.ucentral.models.State;
 import com.google.gson.Gson;
@@ -133,10 +133,16 @@ public class Modeler implements Runnable {
 			getClass().getSimpleName(),
 			new ConfigManager.ConfigListener() {
 				@Override
-				public boolean processDeviceConfig(
+				public void receiveDeviceConfig(
 					String serialNumber, UCentralApConfiguration config
 				) {
 					updateDeviceConfig(serialNumber, config);
+				}
+
+				@Override
+				public boolean processDeviceConfig(
+					String serialNumber, UCentralApConfiguration config
+				) {
 					return false;
 				}
 			}


### PR DESCRIPTION
Add a new field to `RRMConfig`: `moduleParams.configManagerParams.configOnEventOnly` (`CONFIGMANAGERPARAMS_CONFIGONEVENTONLY`). When set, config updates will only be pushed on *events*, which currently include RRM algorithm executions (`ChannelOptimizer.applyConfig()`, `TPC.applyConfig()`) and config API calls.

Details:
- The "event" flag is set via `ConfigManager.wakeUp()`.
- Split `ConfigListener` callbacks into 2 separate methods for mutators/non-mutators.
- Unrelated: also allow disabling some other features via `RRMConfig`.