### PR TITLE
Support connecting to public OWF endpoints

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -154,7 +154,11 @@ public class Launcher implements Callable<Integer> {
 
 		// Instantiate clients
 		UCentralClient client = new UCentralClient(
+			config.uCentralConfig.usePublicEndpoints,
 			config.uCentralConfig.privateEndpoint,
+			config.uCentralConfig.uCentralSecPublicEndpoint,
+			config.uCentralConfig.username,
+			config.uCentralConfig.password,
 			config.uCentralConfig.uCentralSocketParams
 		);
 		UCentralKafkaConsumer consumer;

--- a/src/main/java/com/facebook/openwifirrm/RRM.java
+++ b/src/main/java/com/facebook/openwifirrm/RRM.java
@@ -8,6 +8,16 @@
 
 package com.facebook.openwifirrm;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.facebook.openwifirrm.modules.ApiServer;
 import com.facebook.openwifirrm.modules.ConfigManager;
 import com.facebook.openwifirrm.modules.DataCollector;
@@ -16,15 +26,7 @@ import com.facebook.openwifirrm.mysql.DatabaseManager;
 import com.facebook.openwifirrm.ucentral.KafkaConsumerRunner;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
+import com.facebook.openwifirrm.ucentral.gw.models.SystemInfoResults;
 
 /**
  * RRM service runner.
@@ -61,6 +63,24 @@ public class RRM {
 		UCentralKafkaConsumer consumer,
 		DatabaseManager dbManager
 	) {
+		// If using public endpoints, log into uCentral now
+		if (config.uCentralConfig.usePublicEndpoints) {
+			// uCentral login
+			if (!client.login()) {
+				logger.error("uCentral login failed! Terminating...");
+				return false;
+			}
+			// Check that uCentralGw is actually alive
+			SystemInfoResults systemInfo = client.getSystemInfo();
+			if (systemInfo == null) {
+				logger.error(
+					"Failed to fetch uCentralGw system info. Terminating..."
+				);
+				return false;
+			}
+			logger.info("uCentralGw version: {}", systemInfo.version);
+		}
+
 		// Instantiate modules
 		ConfigManager configManager = new ConfigManager(
 			config.moduleConfig.configManagerParams, deviceDataManager, client

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -19,22 +19,34 @@ public class RRMConfig {
 	 */
 	public class UCentralConfig {
 		/**
-		 * uCentralSec host
-		 * (<tt>UCENTRALCONFIG_UCENTRALSECHOST</tt>)
+		 * If set, use public service endpoints instead of private ones
+		 * (<tt>UCENTRALCONFIG_USEPUBLICENDPOINTS</tt>)
 		 */
-		public String uCentralSecHost = "127.0.0.1";
+		public boolean usePublicEndpoints = false;
 
 		/**
-		 * uCentralSec port
-		 * (<tt>UCENTRALCONFIG_UCENTRALSECPORT</tt>)
-		 */
-		public int uCentralSecPort = 17001;
-
-		/**
-		 * uCentralSec private microservice endpoint
+		 * Private endpoint for the RRM service (used as "X-INTERNAL-NAME")
 		 * (<tt>UCENTRALCONFIG_PRIVATEENDPOINT</tt>)
 		 */
 		public String privateEndpoint = "https://owrrm.wlan.local:17006";
+
+		/**
+		 * uCentralSec public endpoint
+		 * (<tt>UCENTRALCONFIG_UCENTRALSECPUBLICENDPOINT</tt>)
+		 */
+		public String uCentralSecPublicEndpoint = "";
+
+		/**
+		 * uCentral username (for public endpoints only)
+		 * (<tt>UCENTRALCONFIG_USERNAME</tt>)
+		 */
+		public String username = "tip@ucentral.com";
+
+		/**
+		 * uCentral password (for public endpoints only)
+		 * (<tt>UCENTRALCONFIG_PASSWORD</tt>)
+		 */
+		public String password = "";
 
 		/**
 		 * uCentral socket parameters
@@ -279,14 +291,20 @@ public class RRMConfig {
 
 		/* UCentralConfig */
 		UCentralConfig uCentralConfig = config.uCentralConfig;
-		if ((v = env.get("UCENTRALCONFIG_UCENTRALSECHOST")) != null) {
-			uCentralConfig.uCentralSecHost = v;
-		}
-		if ((v = env.get("UCENTRALCONFIG_UCENTRALSECPORT")) != null) {
-			uCentralConfig.uCentralSecPort = Integer.parseInt(v);
+		if ((v = env.get("UCENTRALCONFIG_USEPUBLICENDPOINTS")) != null) {
+			uCentralConfig.usePublicEndpoints = Boolean.parseBoolean(v);
 		}
 		if ((v = env.get("UCENTRALCONFIG_PRIVATEENDPOINT")) != null) {
 			uCentralConfig.privateEndpoint = v;
+		}
+		if ((v = env.get("UCENTRALCONFIG_UCENTRALSECPUBLICENDPOINT")) != null) {
+			uCentralConfig.uCentralSecPublicEndpoint = v;
+		}
+		if ((v = env.get("UCENTRALCONFIG_USERNAME")) != null) {
+			uCentralConfig.username = v;
+		}
+		if ((v = env.get("UCENTRALCONFIG_PASSWORD")) != null) {
+			uCentralConfig.password = v;
 		}
 		UCentralConfig.UCentralSocketParams uCentralSocketParams =
 			config.uCentralConfig.uCentralSocketParams;

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -16,7 +16,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import com.facebook.openwifirrm.ucentral.gw.models.ServiceEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +30,7 @@ import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.UCentralUtils.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.gw.models.DeviceCapabilities;
 import com.facebook.openwifirrm.ucentral.gw.models.DeviceWithStatus;
+import com.facebook.openwifirrm.ucentral.gw.models.ServiceEvent;
 import com.facebook.openwifirrm.ucentral.gw.models.StatisticsRecords;
 import com.facebook.openwifirrm.ucentral.models.State;
 import com.google.gson.Gson;
@@ -212,9 +212,11 @@ public class Modeler implements Runnable {
 			try {
 				Thread.sleep(2000);
 			} catch (InterruptedException e) {
-				e.printStackTrace();
+				Thread.currentThread().interrupt();
+				return;
 			}
 		}
+
 		// TODO: backfill data from database?
 
 		// Fetch state from uCentralGw


### PR DESCRIPTION
Signed-off-by: Jeffrey Han <39203126+elludraon@users.noreply.github.com>

Partial revert of #1. Re-add public service endpoints as an option primarily for development purposes.

`UCentralConfig` now looks like this:
- Public:
```
  "uCentralConfig": {
    "usePublicEndpoints": true,
    "privateEndpoint": "https://owrrm.wlan.local:17006",
    "uCentralSecPublicEndpoint": "https://owsec.example.com",
    "username": "tip@ucentral.com",
    "password": "password"
  }
```
- Private:
```
  "uCentralConfig": {
    "usePublicEndpoints": false,
    "privateEndpoint": "https://owrrm.wlan.local:17006"
  }
```

Add description of each process in `UCentralClient` class-level javadoc.
