### PR TITLE
[WIFI-9979] Sync to owprov venues and RRM config

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -92,7 +92,7 @@ public class ProvMonitor implements Runnable {
 
 	/** Run single iteration of application logic. */
 	private void runImpl() {
-		if (!client.isInitialized()) {
+		if (!client.isProvInitialized()) {
 			logger.trace("Waiting for uCentral client");
 			return;
 		}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
@@ -266,6 +266,20 @@ public class UCentralClient {
 		return true;
 	}
 
+	/**
+	 * Return true if this service has learned the owprov endpoint, along with
+	 * API keys (if necessary).
+	 */
+	public boolean isProvInitialized() {
+		if (!serviceEndpoints.containsKey(OWPROV_SERVICE)) {
+			return false;
+		};
+		if (usePublicEndpoints && accessToken == null) {
+			return false;
+		}
+		return true;
+	}
+
 	/** Send a GET request. */
 	private HttpResponse<String> httpGet(String endpoint, String service) {
 		return httpGet(endpoint, service, null);

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
@@ -30,6 +30,9 @@ import com.facebook.openwifirrm.ucentral.gw.models.ServiceEvent;
 import com.facebook.openwifirrm.ucentral.gw.models.StatisticsRecords;
 import com.facebook.openwifirrm.ucentral.gw.models.SystemInfoResults;
 import com.facebook.openwifirrm.ucentral.gw.models.WifiScanRequest;
+import com.facebook.openwifirrm.ucentral.prov.models.EntityList;
+import com.facebook.openwifirrm.ucentral.prov.models.InventoryTagList;
+import com.facebook.openwifirrm.ucentral.prov.models.SerialNumberList;
 import com.facebook.openwifirrm.ucentral.prov.models.VenueList;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -499,8 +502,49 @@ public class UCentralClient {
 		}
 	}
 
-	/** Launch a get venues command. */
-	public VenueList getVenues() {
+	/** Retrieve a list of inventory from owprov. */
+	public InventoryTagList getProvInventory() {
+		HttpResponse<String> response = httpGet("inventory", OWPROV_SERVICE);
+		if (!response.isSuccess()) {
+			logger.error("Error: {}", response.getBody());
+			return null;
+		}
+		try {
+			return gson.fromJson(response.getBody(), InventoryTagList.class);
+		} catch (JsonSyntaxException e) {
+			String errMsg = String.format(
+				"Failed to deserialize to InventoryTagList: %s",
+				response.getBody()
+			);
+			logger.error(errMsg, e);
+			return null;
+		}
+	}
+
+	/** Retrieve a list of inventory with RRM enabled from owprov. */
+	public SerialNumberList getProvInventoryForRRM() {
+		Map<String, Object> parameters = new HashMap<>();
+		parameters.put("rrmOnly", true);
+		HttpResponse<String> response =
+			httpGet("inventory", OWPROV_SERVICE, parameters);
+		if (!response.isSuccess()) {
+			logger.error("Error: {}", response.getBody());
+			return null;
+		}
+		try {
+			return gson.fromJson(response.getBody(), SerialNumberList.class);
+		} catch (JsonSyntaxException e) {
+			String errMsg = String.format(
+				"Failed to deserialize to SerialNumberList: %s",
+				response.getBody()
+			);
+			logger.error(errMsg, e);
+			return null;
+		}
+	}
+
+	/** Retrieve a list of venues from owprov. */
+	public VenueList getProvVenues() {
 		HttpResponse<String> response = httpGet("venue", OWPROV_SERVICE);
 		if (!response.isSuccess()) {
 			logger.error("Error: {}", response.getBody());
@@ -511,6 +555,24 @@ public class UCentralClient {
 		} catch (JsonSyntaxException e) {
 			String errMsg = String.format(
 				"Failed to deserialize to VenueList: %s", response.getBody()
+			);
+			logger.error(errMsg, e);
+			return null;
+		}
+	}
+
+	/** Retrieve a list of entities from owprov. */
+	public EntityList getProvEntities() {
+		HttpResponse<String> response = httpGet("entity", OWPROV_SERVICE);
+		if (!response.isSuccess()) {
+			logger.error("Error: {}", response.getBody());
+			return null;
+		}
+		try {
+			return gson.fromJson(response.getBody(), EntityList.class);
+		} catch (JsonSyntaxException e) {
+			String errMsg = String.format(
+				"Failed to deserialize to EntityList: %s", response.getBody()
 			);
 			logger.error(errMsg, e);
 			return null;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/DeviceRules.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/DeviceRules.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.prov.models;
+
+public class DeviceRules {
+	public String rcOnly;
+	public String rrm;
+	public String firmwareUpgrade;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/DiGraph.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/DiGraph.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.prov.models;
+
+import java.util.ArrayList;
+
+public class DiGraph extends ArrayList<DiGraphEntry> {
+	private static final long serialVersionUID = 2729678598385863942L;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/DiGraphEntry.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/DiGraphEntry.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.prov.models;
+
+public class DiGraphEntry {
+	public String parent;
+	public String child;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/Entity.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/Entity.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import com.facebook.openwifirrm.ucentral.gw.models.NoteInfo;
 
-public class Venue {
+public class Entity {
 	// from ObjectInfo
 	public String id;
 	public String name;
@@ -22,22 +22,21 @@ public class Venue {
 	public long modified;
 	public List<Long> tags;
 
-	public String entity;
 	public String parent;
 	public List<String> children;
-	public String managementPolicy;
-	public List<String> devices;
-	public DiGraph topology;
-	public String design;
-	//public String deviceConfiguration;  // TODO wrong in OpenAPI (array?)
+	public List<String> venues;
 	public List<String> contacts;
-	public String location;
-	public DeviceRules deviceRules;
-	public List<String> sourceIP;
+	public List<String> locations;
+	public String managementPolicy;
+	//public String deviceConfiguration;  // TODO wrong in OpenAPI (array?)
+	public List<String> devices;
 	public List<String> managementPolicies;
-	public List<String> managementRoles;
 	public List<String> variables;
+	public List<String> managementRoles;
 	public List<String> maps;
 	public List<String> configurations;
-	public List<String> boards;
+	public DeviceRules deviceRules;
+	public List<String> sourceIP;
+	public boolean defaultEntity;
+	public String type;
 }

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/EntityList.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/EntityList.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.prov.models;
+
+import java.util.List;
+
+public class EntityList {
+	public List<Entity> entities;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/InventoryTag.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/InventoryTag.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import com.facebook.openwifirrm.ucentral.gw.models.NoteInfo;
 
-public class Venue {
+public class InventoryTag {
 	// from ObjectInfo
 	public String id;
 	public String name;
@@ -22,22 +22,19 @@ public class Venue {
 	public long modified;
 	public List<Long> tags;
 
+	public String serialNumber;
+	public String deviceType;
+	public String venue;
 	public String entity;
-	public String parent;
-	public List<String> children;
-	public String managementPolicy;
-	public List<String> devices;
-	public DiGraph topology;
-	public String design;
-	//public String deviceConfiguration;  // TODO wrong in OpenAPI (array?)
-	public List<String> contacts;
+	public String subscriber;
+	public String qrCode;
+	public String geoCode;
 	public String location;
+	public String contact;
+	public String deviceConfiguration;
 	public DeviceRules deviceRules;
-	public List<String> sourceIP;
-	public List<String> managementPolicies;
-	public List<String> managementRoles;
-	public List<String> variables;
-	public List<String> maps;
-	public List<String> configurations;
-	public List<String> boards;
+	public String managementPolicy;
+	public String state;
+	public String devClass;
+	public String locale;
 }

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/InventoryTagList.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/InventoryTagList.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.prov.models;
+
+import java.util.List;
+
+public class InventoryTagList {
+	public List<InventoryTag> taglist;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/SerialNumberList.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/models/SerialNumberList.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.prov.models;
+
+import java.util.List;
+
+public class SerialNumberList {
+	public List<String> serialNumbers;
+}

--- a/src/test/java/com/facebook/openwifirrm/modules/ProvMonitorTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ProvMonitorTest.java
@@ -8,28 +8,16 @@
 
 package com.facebook.openwifirrm.modules;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import com.facebook.openwifirrm.DeviceDataManager;
-import com.facebook.openwifirrm.DeviceTopology;
 import com.facebook.openwifirrm.RRMConfig;
-import com.facebook.openwifirrm.modules.ConfigManager;
-import com.facebook.openwifirrm.modules.DataCollector;
-import com.facebook.openwifirrm.modules.Modeler;
-import com.facebook.openwifirrm.modules.ProvMonitor;
 import com.facebook.openwifirrm.mysql.DatabaseManager;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
-import com.facebook.openwifirrm.ucentral.prov.models.Venue;
-import com.facebook.openwifirrm.ucentral.prov.models.VenueList;
 
 public class ProvMonitorTest {
 	/** Test device data manager. */
@@ -85,29 +73,7 @@ public class ProvMonitorTest {
 
 	@Test
 	@Order(1)
-	void test_buildTopology() throws Exception {
-		// First test case - empty VenueList
-		VenueList venueList = new VenueList();
-		venueList.venues = List.of();
-		DeviceTopology topo = provMonitor.buildTopology(venueList);
-		assertTrue(topo.isEmpty());
-
-		// Second test case - filled VenueList
-		Venue venue1 = new Venue();
-		venue1.id = "id1";
-		venue1.entity = "entity1";
-		venue1.entity = "zone1";
-		venue1.devices = List.of("device1", "device2");
-
-		Venue venue2 = new Venue();
-		venue2.id = "id2";
-		venue2.entity = "entity2";
-		venue2.entity = "zone2";
-		venue2.devices = List.of("device3");
-
-		venueList.venues = List.of(venue1, venue2);
-		topo = provMonitor.buildTopology(venueList);
-		assertEquals(2, topo.size());
-		assertEquals(2, topo.get("id1").size());
+	void test_syncDataToProv() throws Exception {
+		// TODO
 	}
 }


### PR DESCRIPTION
Sync RRM topology and device configs with owprov venues and RRM configs. This is a first working version only and the design may change later. See examples below for an illustration of how this data is translated.

This PR contains a lot of models translated from owprov OpenAPI definition @ https://github.com/Telecominfraproject/wlan-cloud-owprov/blob/5945d02b3de3df100616bd8599914cd6faba000d/openapi/owprov.yaml.

![image](https://user-images.githubusercontent.com/39203126/178387326-da11f028-b379-4939-b612-99499988a2d6.png)

```
2022-07-11T18:09:48.220 INFO  [ProvMonitor:146] - Synced topology with owprov: 4 zone(s), 5 total device(s)
2022-07-11T18:09:48.225 INFO  [ProvMonitor:170] - Synced device configs with owprov: RRM enabled on 2/5 device(s)
```

`topology.json`
```json
{
  "%OWPROV_UNKNOWN_VENUE%": [
    "00000000000c"
  ],
  "sub-ven-A-1-i": [
    "00000000000e"
  ],
  "ven-A-1": [
    "00000000000a",
    "00000000000d"
  ],
  "ven-A-2": [
    "00000000000b"
  ]
}
```

`device_config.json`
```json
{
  "apConfig": {
    "00000000000a": {
      "enableRRM": false,
      "enableConfig": false,
      "enableWifiScan": false
    },
    "00000000000b": {
      "enableRRM": false,
      "enableConfig": false,
      "enableWifiScan": false
    },
    "00000000000c": {
      "enableRRM": false,
      "enableConfig": false,
      "enableWifiScan": false
    },
    "00000000000d": {
      "enableRRM": true,
      "enableConfig": true,
      "enableWifiScan": true
    },
    "00000000000e": {
      "enableRRM": true,
      "enableConfig": true,
      "enableWifiScan": true
    }
  },
  "zoneConfig": {},
  "networkConfig": {}
}
```
