### PR TITLE
[WIFI-9987] Fix and stub SDK auth

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -22,6 +22,7 @@ import com.facebook.openwifirrm.mysql.DatabaseManager;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaProducer;
+import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -153,9 +154,12 @@ public class Launcher implements Callable<Integer> {
 				: DEFAULT_DEVICE_LAYERED_CONFIG_FILE
 		);
 
+		String serviceKey =
+			UCentralUtils.generateServiceKey(config.serviceConfig);
+
 		// Instantiate clients
 		UCentralClient client = new UCentralClient(
-			config.serviceConfig.privateEndpoint,
+			config.serviceConfig.publicEndpoint,
 			config.uCentralConfig.usePublicEndpoints,
 			config.uCentralConfig.uCentralSecPublicEndpoint,
 			config.uCentralConfig.username,
@@ -184,6 +188,7 @@ public class Launcher implements Callable<Integer> {
 				config.serviceConfig.name,
 				RRM.VERSION,
 				config.serviceConfig.id,
+				serviceKey,
 				config.serviceConfig.privateEndpoint,
 				config.serviceConfig.publicEndpoint
 			);

--- a/src/main/java/com/facebook/openwifirrm/RRM.java
+++ b/src/main/java/com/facebook/openwifirrm/RRM.java
@@ -28,6 +28,7 @@ import com.facebook.openwifirrm.ucentral.KafkaRunner;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaProducer;
+import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.gw.models.SystemInfoResults;
 
 /**
@@ -109,6 +110,7 @@ public class RRM {
 		);
 		ApiServer apiServer = new ApiServer(
 			config.moduleConfig.apiServerParams,
+			UCentralUtils.generateServiceKey(config.serviceConfig),
 			deviceDataManager,
 			configManager,
 			modeler

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -309,6 +309,13 @@ public class RRMConfig {
 			 * (<tt>APISERVERPARAMS_BASICAUTHPASSWORD</tt>)
 			 */
 			public String basicAuthPassword = "openwifi";
+
+			/**
+			 * Enable OpenWiFi authentication via tokens (external) and API keys
+			 * (internal)
+			 * (<tt>APISERVERPARAMS_USEOPENWIFIAUTH</tt>)
+			 */
+			public boolean useOpenWifiAuth = false;
 		}
 
 		/** ApiServer parameters. */
@@ -473,6 +480,9 @@ public class RRMConfig {
 		}
 		if ((v = env.get("APISERVERPARAMS_BASICAUTHPASSWORD")) != null) {
 			apiServerParams.basicAuthPassword = v;
+		}
+		if ((v = env.get("APISERVERPARAMS_USEOPENWIFIAUTH")) != null) {
+			apiServerParams.useOpenWifiAuth = Boolean.parseBoolean(v);
 		}
 		ModuleConfig.ProvMonitorParams provManagerParams =
 			config.moduleConfig.provMonitorParams;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
@@ -65,8 +65,8 @@ import kong.unirest.UnirestException;
  * For private endpoint communication:
  * <ul>
  *   <li>
- *     Use Kafka "system_endpoints" topic to get the private endpoint and the
- *     key to use in the "X-API-KEY" header for each service
+ *     Use Kafka "system_endpoints" topic to find the private endpoint and API
+ *     key for each service
  *   </li>
  * </ul>
  */
@@ -107,8 +107,8 @@ public class UCentralClient {
 	/** Gson instance */
 	private final Gson gson = new Gson();
 
-	/** The RRM private endpoint. */
-	private final String privateEndpoint;
+	/** The RRM public endpoint. */
+	private final String rrmEndpoint;
 
 	/** Whether to use public endpoints. */
 	private boolean usePublicEndpoints;
@@ -133,7 +133,7 @@ public class UCentralClient {
 
 	/**
 	 * Constructor.
-	 * @param privateEndpoint advertise the RRM private endpoint to the SDK
+	 * @param rrmEndpoint advertise this RRM endpoint to the SDK
 	 * @param usePublicEndpoints whether to use public or private endpoints
 	 * @param uCentralSecPublicEndpoint the uCentralSec public endpoint
 	 *        (if needed)
@@ -142,14 +142,14 @@ public class UCentralClient {
 	 * @param socketParams Socket parameters
 	 */
 	public UCentralClient(
-		String privateEndpoint,
+		String rrmEndpoint,
 		boolean usePublicEndpoints,
 		String uCentralSecPublicEndpoint,
 		String username,
 		String password,
 		UCentralSocketParams socketParams
 	) {
-		this.privateEndpoint = privateEndpoint;
+		this.rrmEndpoint = rrmEndpoint;
 		this.usePublicEndpoints = usePublicEndpoints;
 		this.username = username;
 		this.password = password;
@@ -320,7 +320,7 @@ public class UCentralClient {
 		} else {
 			req
 				.header("X-API-KEY", this.getApiKey(OWGW_SERVICE))
-				.header("X-INTERNAL-NAME", this.privateEndpoint);
+				.header("X-INTERNAL-NAME", this.rrmEndpoint);
 		}
 		if (parameters != null) {
 			return req.queryString(parameters).asString();
@@ -364,7 +364,7 @@ public class UCentralClient {
 		} else {
 			req
 				.header("X-API-KEY", this.getApiKey(OWGW_SERVICE))
-				.header("X-INTERNAL-NAME", this.privateEndpoint);
+				.header("X-INTERNAL-NAME", this.rrmEndpoint);
 		}
 		if (body != null) {
 			req.header("Content-Type", "application/json");

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralKafkaProducer.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralKafkaProducer.java
@@ -8,8 +8,6 @@
 
 package com.facebook.openwifirrm.ucentral;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Properties;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -20,7 +18,6 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.facebook.openwifirrm.Utils;
 import com.facebook.openwifirrm.ucentral.gw.models.ServiceEvent;
 import com.google.gson.Gson;
 
@@ -42,13 +39,12 @@ public class UCentralKafkaProducer {
 	private final String serviceVersion;
 	/** The service ID. */
 	private final long serviceId;
+	/** The service key. */
+	private final String serviceKey;
 	/** The private service endpoint. */
 	private final String privateEndpoint;
 	/** The public service endpoint. */
 	private final String publicEndpoint;
-
-	/** The service key (generated). */
-	private final String serviceKey;
 
 	/** The Gson instance. */
 	private final Gson gson = new Gson();
@@ -60,6 +56,7 @@ public class UCentralKafkaProducer {
 	 * @param serviceType the service name
 	 * @param serviceVersion the service version
 	 * @param serviceId the service ID
+	 * @param serviceKey the service key
 	 * @param privateEndpoint the private service endpoint
 	 * @param publicEndpoint the public service endpoint
 	 */
@@ -69,6 +66,7 @@ public class UCentralKafkaProducer {
 		String serviceType,
 		String serviceVersion,
 		long serviceId,
+		String serviceKey,
 		String privateEndpoint,
 		String publicEndpoint
 	) {
@@ -76,10 +74,9 @@ public class UCentralKafkaProducer {
 		this.serviceType = serviceType;
 		this.serviceVersion = serviceVersion;
 		this.serviceId = serviceId;
+		this.serviceKey = serviceKey;
 		this.privateEndpoint = privateEndpoint;
 		this.publicEndpoint = publicEndpoint;
-
-		this.serviceKey = generateServiceKey();
 
 		// Set properties
 		Properties props = new Properties();
@@ -96,19 +93,6 @@ public class UCentralKafkaProducer {
 		// Create producer instance
 		this.producer = new KafkaProducer<>(props);
 		logger.info("Using Kafka bootstrap server: {}", bootstrapServer);
-	}
-
-	/** Generate the service key. */
-	private String generateServiceKey() {
-		try {
-			MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
-			sha256.update(publicEndpoint.getBytes());
-			sha256.update(privateEndpoint.getBytes());
-			return Utils.bytesToHex(sha256.digest());
-		} catch (NoSuchAlgorithmException e) {
-			logger.error("Unable to generate service key", e);
-			return "";
-		}
 	}
 
 	/** Publish a service event. */

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -8,6 +8,8 @@
 
 package com.facebook.openwifirrm.ucentral;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -19,6 +21,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.facebook.openwifirrm.RRMConfig;
+import com.facebook.openwifirrm.Utils;
 import com.facebook.openwifirrm.ucentral.models.State;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -301,5 +305,18 @@ public class UCentralUtils {
 		    }
 		}
 		return bssidMap;
+	}
+
+	/** Generate the RRM service key. */
+	public static String generateServiceKey(RRMConfig.ServiceConfig serviceConfig) {
+		try {
+			MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+			sha256.update(serviceConfig.publicEndpoint.getBytes());
+			sha256.update(serviceConfig.privateEndpoint.getBytes());
+			return Utils.bytesToHex(sha256.digest());
+		} catch (NoSuchAlgorithmException e) {
+			logger.error("Unable to generate service key", e);
+			return "";
+		}
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
@@ -35,6 +35,7 @@ import com.facebook.openwifirrm.RRMConfig;
 import com.facebook.openwifirrm.mysql.DatabaseManager;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
+import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.google.gson.Gson;
 
 import kong.unirest.HttpResponse;
@@ -110,6 +111,7 @@ public class ApiServerTest {
 		// Instantiate ApiServer
 		this.server = new ApiServer(
 			rrmConfig.moduleConfig.apiServerParams,
+			UCentralUtils.generateServiceKey(rrmConfig.serviceConfig),
 			deviceDataManager,
 			configManager,
 			modeler


### PR DESCRIPTION
Fix HTTP headers passed when using internal/private endpoints: "X-INTERNAL-NAME" now sends the RRM public endpoint instead of the private endpoint.

Stub out authentication for incoming API requests, which is enabled based on `ApiServerParams.useOpenWifiAuth` (default false). This validates HTTP headers when using both private endpoints (partially implemented, checks "X-API-KEY") and public endpoints (not implemented, should validate token).