### PR TITLE
Fix internal auth, default RRM config, and module init loops

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -34,7 +34,7 @@ public class RRMConfig {
 		 * Private endpoint for the RRM service
 		 * (<tt>SERVICECONFIG_PRIVATEENDPOINT</tt>)
 		 */
-		public String privateEndpoint = "https://owrrm.wlan.local:17006";
+		public String privateEndpoint = "http://owrrm.wlan.local:16789";  // see ApiServerParams.httpPort
 
 		/**
 		 * Public endpoint for the RRM service
@@ -296,7 +296,7 @@ public class RRMConfig {
 			 * Enable HTTP basic auth?
 			 * (<tt>APISERVERPARAMS_USEBASICAUTH</tt>)
 			 */
-			public boolean useBasicAuth = true;
+			public boolean useBasicAuth = false;
 
 			/**
 			 * The HTTP basic auth username (if enabled)
@@ -335,7 +335,7 @@ public class RRMConfig {
 			 * Sync interval, in ms, for owprov venue information etc.
 			 * (<tt>PROVMONITORPARAMS_SYNCINTERVALMS</tt>)
 			 */
-			 public int syncIntervalMs = 300000;
+			public int syncIntervalMs = 300000;
 		}
 
 		/** ProvMonitor parameters. */

--- a/src/main/java/com/facebook/openwifirrm/modules/ConfigManager.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ConfigManager.java
@@ -153,8 +153,14 @@ public class ConfigManager implements Runnable {
 	private void runImpl() {
 		if (!client.isInitialized()) {
 			logger.trace("Waiting for ucentral client");
-			return;
+			try {
+				Thread.sleep(2000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
 		}
+
 		// Fetch device list
 		List<DeviceWithStatus> devices = client.getDevices();
 		if (devices == null) {

--- a/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
@@ -187,8 +187,14 @@ public class DataCollector implements Runnable {
 	private void runImpl() {
 		if (!client.isInitialized()) {
 			logger.trace("Waiting for ucentral client");
-			return;
+			try {
+				Thread.sleep(2000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
 		}
+
 		// Fetch device list
 		List<DeviceWithStatus> devices = client.getDevices();
 		if (devices == null) {

--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -92,9 +92,14 @@ public class ProvMonitor implements Runnable {
 
 	/** Run single iteration of application logic. */
 	private void runImpl() {
-		if (!client.isProvInitialized()) {
+		while (!client.isProvInitialized()) {
 			logger.trace("Waiting for uCentral client");
-			return;
+			try {
+				Thread.sleep(2000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
 		}
 
 		// Fetch data from owprov

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
@@ -319,7 +319,7 @@ public class UCentralClient {
 			}
 		} else {
 			req
-				.header("X-API-KEY", this.getApiKey(OWGW_SERVICE))
+				.header("X-API-KEY", this.getApiKey(service))
 				.header("X-INTERNAL-NAME", this.rrmEndpoint);
 		}
 		if (parameters != null) {
@@ -363,7 +363,7 @@ public class UCentralClient {
 			}
 		} else {
 			req
-				.header("X-API-KEY", this.getApiKey(OWGW_SERVICE))
+				.header("X-API-KEY", this.getApiKey(service))
 				.header("X-INTERNAL-NAME", this.rrmEndpoint);
 		}
 		if (body != null) {


### PR DESCRIPTION
- Pass correct "X-API-KEY" when using internal endpoints (messed up during rebase)
- Use default private endpoint which corresponds to HTTP port used (can be changed later, but should be consistent)
- Turn off HTTP basic auth by default
- Modules now do a *short* wait-loop while waiting for endpoints, as the regular application loops may be very long
- Consolidate some spammy debug logs