### PR TITLE
implement validateToken and wire it up in ApiServer

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/RRM.java
+++ b/src/main/java/com/facebook/openwifirrm/RRM.java
@@ -113,7 +113,8 @@ public class RRM {
 			UCentralUtils.generateServiceKey(config.serviceConfig),
 			deviceDataManager,
 			configManager,
-			modeler
+			modeler,
+			client
 		);
 		ProvMonitor provMonitor =
 			config.moduleConfig.provMonitorParams.useVenues

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.facebook.openwifirrm.ucentral.UCentralClient;
 import org.reflections.Reflections;
 import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
@@ -97,6 +98,9 @@ public class ApiServer implements Runnable {
 	/** The Modeler module instance. */
 	private final Modeler modeler;
 
+	/** The uCentral Client instance. */
+	private final UCentralClient client;
+
 	/** The Gson instance. */
 	private final Gson gson = new Gson();
 
@@ -112,13 +116,15 @@ public class ApiServer implements Runnable {
 		String serviceKey,
 		DeviceDataManager deviceDataManager,
 		ConfigManager configManager,
-		Modeler modeler
+		Modeler modeler,
+		UCentralClient client
 	) {
 		this.params = params;
 		this.serviceKey = serviceKey;
 		this.deviceDataManager = deviceDataManager;
 		this.configManager = configManager;
 		this.modeler = modeler;
+		this.client = client;
 	}
 
 	@Override
@@ -246,10 +252,9 @@ public class ApiServer implements Runnable {
 			if (authHeader != null && authHeader.startsWith(AUTH_PREFIX)) {
 				String token = authHeader.substring(AUTH_PREFIX.length());
 				if (!token.isEmpty()) {
-					// TODO send token to uCentralSec (and cache reply)
-					// - /api/v1/validateToken
-					// - /api/v1/validateSubToken
-					boolean valid = true;
+					// The below only checks /api/v1/validateToken and caches it as necessary.
+					// TODO - /api/v1/validateSubToken still has to be implemented.
+					boolean valid = this.client.validateToken(token);
 					if (valid) {
 						// auth success
 						return true;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/AclTemplate.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/AclTemplate.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+public class AclTemplate {
+    public boolean Read;
+    public boolean ReadWrite;
+    public boolean ReadWriteCreate;
+    public boolean Delete;
+    public boolean PortalLogin;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/MfaAuthInfo.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/MfaAuthInfo.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+public class MfaAuthInfo {
+    public boolean enabled;
+    public String method;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/MobilePhoneNumber.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/MobilePhoneNumber.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+public class MobilePhoneNumber {
+    public String number;
+    public boolean verified;
+    public boolean primary;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/TokenValidationResult.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/TokenValidationResult.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+public class TokenValidationResult {
+    public UserInfo userInfo;
+    public WebTokenResult tokenInfo;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/UserInfo.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/UserInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+import java.util.List;
+
+public class UserInfo {
+    public String id;
+    public String name;
+    public String description;
+    public String avatar;
+    public String email;
+    public boolean validated;
+    public String validationEmail;
+    public long validationDate;
+    public long created;
+    public String validationURI;
+    public long lastPasswordChange;
+    public long lastEmailCheck;
+    public long lastLogin;
+    public String currentLoginURI;
+    public String currentPassword;
+    public List<String> lastPasswords;
+    public boolean waitingForEmailCheck;
+    public List<NoteInfo> notes;
+    public String location;
+    public String owner;
+    public boolean suspended;
+    public boolean blacklisted;
+    public String locale;
+    public String userRole;
+    public String oauthType;
+    public String oauthUserInfo;
+    public String securityPolicy;
+    public long securityPolicyChange;
+    public long modified;
+    public UserLoginLoginExtensions userTypeProprietaryInfo;
+    public String signingUp;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/UserLoginLoginExtensions.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/UserLoginLoginExtensions.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+import java.util.List;
+
+public class UserLoginLoginExtensions {
+    public List<MobilePhoneNumber> mobiles;
+    public String authenticatorSecret;
+    public MfaAuthInfo mfa;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/WebTokenAclTemplate.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/WebTokenAclTemplate.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+public class WebTokenAclTemplate {
+    public AclTemplate aclTemplate;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/WebTokenResult.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/WebTokenResult.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+public class WebTokenResult {
+    public String access_token;
+    public String refresh_token;
+    public String token_type;
+    public int expires_in;
+    public int idle_timeout;
+    public String username;
+    public long created;
+    public boolean userMustChangePassword;
+    public int errorCode;
+    public WebTokenAclTemplate aclTemplate;
+    public long lastRefresh;
+}

--- a/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
@@ -114,7 +114,8 @@ public class ApiServerTest {
 			UCentralUtils.generateServiceKey(rrmConfig.serviceConfig),
 			deviceDataManager,
 			configManager,
-			modeler
+			modeler,
+			client
 		);
 		try {
 			server.run();


### PR DESCRIPTION
Implement `validateToken` in `uCentralClient` and call from ApiServer to make sure that the request is valid. 

Generated a token, then tested

```
$ curl -k -H "Accept: application/json" -H "Authorization: Bearer SOME_GOOD_TOKEN" -i 'localhost:16789/api/v1/getTopology'
HTTP/1.1 200 OK
Date: Thu, 28 Jul 2022 21:42:08 GMT
Server:
Content-Type: application/json
Transfer-Encoding: chunked

# resp

$ curl -k -H "Accept: application/json" -H "Authorization: Bearer SOME_BAD_TOKEN" -i 'localhost:16789/api/v1/getTopology'
HTTP/1.1 403 Forbidden
Date: Thu, 28 Jul 2022 21:42:14 GMT
Server:
Content-Type: text/html;charset=utf-8
Transfer-Encoding: chunked
```