### PR TITLE
[WIFI-9980] Add RRM scheduler

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -78,7 +78,12 @@ following endpoints:
 * `/api/v1/<method>` - RRM API methods
 
 ### owprov Monitor
-`ProvMonitor` handles sync with the owprov service.
+`ProvMonitor` handles sync with the owprov service when it is desirable to use
+their topology ("venues") and certain device configuration fields.
+
+### Scheduler
+`RRMScheduler` uses the [Quartz Job Scheduler] to schedule RRM algorithms to run
+per zone with different intervals and parameters.
 
 ## Optimizers
 The *optimizers* implement the RRM algorithms, which are described in
@@ -97,3 +102,4 @@ The *optimizers* implement the RRM algorithms, which are described in
 [Spark]: https://sparkjava.com/
 [Swagger UI]: https://swagger.io/tools/swagger-ui/
 [Swagger Core]: https://github.com/swagger-api/swagger-core
+[Quartz Job Scheduler]: https://www.quartz-scheduler.org/

--- a/pom.xml
+++ b/pom.xml
@@ -155,5 +155,10 @@
       <artifactId>reflections</artifactId>
       <version>0.10.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+      <version>2.3.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/facebook/openwifirrm/DeviceConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceConfig.java
@@ -27,6 +27,9 @@ public class DeviceConfig {
 	/** Whether RRM algorithms are enabled */
 	public Boolean enableRRM;
 
+	/** The RRM schedule (if enabled), only applied at the zone or network layer */
+	public RRMSchedule schedule;
+
 	/** Whether pushing device config is enabled */
 	public Boolean enableConfig;
 
@@ -77,6 +80,7 @@ public class DeviceConfig {
 		DeviceConfig config = new DeviceConfig();
 
 		config.enableRRM = true;
+		config.schedule = null;
 		config.enableConfig = true;
 		config.enableWifiScan = true;
 		config.boundary = null;

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -254,7 +254,7 @@ public class RRMConfig {
 			 * (e.g. RRM algorithm execution, config API calls)
 			 * (<tt>CONFIGMANAGERPARAMS_CONFIGONEVENTONLY</tt>)
 			 */
-			public boolean configOnEventOnly = false;
+			public boolean configOnEventOnly = true;
 
 			/**
 			 * The debounce interval for reconfiguring the same device, in
@@ -340,6 +340,20 @@ public class RRMConfig {
 
 		/** ProvMonitor parameters. */
 		public ProvMonitorParams provMonitorParams = new ProvMonitorParams();
+
+		/**
+		 * RRMScheduler parameters.
+		 */
+		public class RRMSchedulerParams {
+			/**
+			 * Thread pool size for executing jobs
+			 * (<tt>SCHEDULERPARAMS_THREADCOUNT</tt>)
+			 */
+			public int threadCount = 2;
+		}
+
+		/** RRMScheduler parameters. */
+		public RRMSchedulerParams schedulerParams = new RRMSchedulerParams();
 	}
 
 	/** Module configuration. */
@@ -491,6 +505,11 @@ public class RRMConfig {
 		}
 		if ((v = env.get("PROVMONITORPARAMS_SYNCINTERVALMS")) != null) {
 			provManagerParams.syncIntervalMs = Integer.parseInt(v);
+		}
+		ModuleConfig.RRMSchedulerParams schedulerParams =
+			config.moduleConfig.schedulerParams;
+		if ((v = env.get("SCHEDULERPARAMS_THREADCOUNT")) != null) {
+			schedulerParams.threadCount = Integer.parseInt(v);
 		}
 
 		return config;

--- a/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RRM schedule config.
+ */
+public class RRMSchedule {
+	/**
+	 * The interval at which RRM should be run.
+	 *
+	 * This field expects a cron-like format as defined by the Quartz Job
+	 * Scheduler (CronTrigger):
+	 * https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html
+	 */
+	public String cron;
+
+	/**
+	 * The list of RRM algorithms to run.
+	 *
+	 * If empty, all algorithms will be run using default settings.
+	 */
+	public List<RRMAlgorithm> algorithms;
+
+	/** RRM algorithm name and arguments. */
+	public static class RRMAlgorithm {
+		/** The algorithm name. */
+		public String name;
+
+		/** The algorithm arguments. */
+		public Map<String, String> args;
+
+		/** Constructor. */
+		public RRMAlgorithm(String name, Map<String, String> args) {
+			this.name = name;
+			this.args = args;
+		}
+	}
+}

--- a/src/main/java/com/facebook/openwifirrm/Utils.java
+++ b/src/main/java/com/facebook/openwifirrm/Utils.java
@@ -28,6 +28,9 @@ public class Utils {
 	/** Hex value array for use in {@link #longToMac(long)}. */
 	private static final char[] HEX_VALUES = "0123456789abcdef".toCharArray();
 
+	/** The gson instance. */
+	private static final Gson gson = new Gson();
+
 	// This class should not be instantiated.
 	private Utils() {}
 
@@ -117,5 +120,10 @@ public class Utils {
 			c[i*2 + 1] = HEX_VALUES[v & 0xf];
 		}
 		return new String(c);
+	}
+
+	/** Return a deep copy using gson. DO NOT USE if performance is critical. */
+	public static <T> T deepCopy(T obj, Class<T> classOfT) {
+		return gson.fromJson(gson.toJson(obj), classOfT);
 	}
 }

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -21,7 +21,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import com.facebook.openwifirrm.ucentral.UCentralClient;
 import org.reflections.Reflections;
 import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
@@ -42,6 +41,7 @@ import com.facebook.openwifirrm.optimizers.RandomChannelInitializer;
 import com.facebook.openwifirrm.optimizers.RandomTxPowerInitializer;
 import com.facebook.openwifirrm.optimizers.TPC;
 import com.facebook.openwifirrm.optimizers.UnmanagedApAwareChannelOptimizer;
+import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.gw.models.SystemInfoResults;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -101,6 +101,9 @@ public class ApiServer implements Runnable {
 	/** The uCentral Client instance. */
 	private final UCentralClient client;
 
+	/** The RRM scheduler. */
+	private final RRMScheduler scheduler;
+
 	/** The Gson instance. */
 	private final Gson gson = new Gson();
 
@@ -117,7 +120,8 @@ public class ApiServer implements Runnable {
 		DeviceDataManager deviceDataManager,
 		ConfigManager configManager,
 		Modeler modeler,
-		UCentralClient client
+		UCentralClient client,
+		RRMScheduler scheduler
 	) {
 		this.params = params;
 		this.serviceKey = serviceKey;
@@ -125,6 +129,7 @@ public class ApiServer implements Runnable {
 		this.configManager = configManager;
 		this.modeler = modeler;
 		this.client = client;
+		this.scheduler = scheduler;
 	}
 
 	@Override
@@ -472,6 +477,9 @@ public class ApiServer implements Runnable {
 
 				// Revalidate data model
 				modeler.revalidate();
+
+				// Update scheduler
+				scheduler.syncTriggers();
 			} catch (Exception e) {
 				response.status(400);
 				return e.getMessage();
@@ -604,6 +612,9 @@ public class ApiServer implements Runnable {
 
 				// Revalidate data model
 				modeler.revalidate();
+
+				// Update scheduler
+				scheduler.syncTriggers();
 			} catch (Exception e) {
 				response.status(400);
 				return e.getMessage();
@@ -670,6 +681,9 @@ public class ApiServer implements Runnable {
 
 				// Revalidate data model
 				modeler.revalidate();
+
+				// Update scheduler
+				scheduler.syncTriggers();
 			} catch (Exception e) {
 				response.status(400);
 				return e.getMessage();

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import com.facebook.openwifirrm.DeviceConfig;
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.RRMConfig.ModuleConfig.ModelerParams;
+import com.facebook.openwifirrm.Utils;
 import com.facebook.openwifirrm.ucentral.UCentralApConfiguration;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
@@ -390,9 +391,9 @@ public class Modeler implements Runnable {
 		return dataModel;
 	}
 
-	/** Return the current data model (deep clone via gson). */
+	/** Return the current data model (deep copy). */
 	public DataModel getDataModelCopy() {
-		return gson.fromJson(gson.toJson(dataModel), DataModel.class);
+		return Utils.deepCopy(dataModel, DataModel.class);
 	}
 
 	/** Revalidate the data model to remove any non-RRM-enabled devices. */

--- a/src/main/java/com/facebook/openwifirrm/modules/RRMScheduler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/RRMScheduler.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.modules;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.quartz.CronScheduleBuilder;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerContext;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.impl.StdSchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.facebook.openwifirrm.DeviceConfig;
+import com.facebook.openwifirrm.DeviceDataManager;
+import com.facebook.openwifirrm.RRMConfig.ModuleConfig.RRMSchedulerParams;
+import com.facebook.openwifirrm.RRMSchedule.RRMAlgorithm;
+import com.facebook.openwifirrm.optimizers.ChannelOptimizer;
+import com.facebook.openwifirrm.optimizers.LeastUsedChannelOptimizer;
+import com.facebook.openwifirrm.optimizers.LocationBasedOptimalTPC;
+import com.facebook.openwifirrm.optimizers.MeasurementBasedApApTPC;
+import com.facebook.openwifirrm.optimizers.MeasurementBasedApClientTPC;
+import com.facebook.openwifirrm.optimizers.RandomChannelInitializer;
+import com.facebook.openwifirrm.optimizers.RandomTxPowerInitializer;
+import com.facebook.openwifirrm.optimizers.TPC;
+import com.facebook.openwifirrm.optimizers.UnmanagedApAwareChannelOptimizer;
+
+/**
+ * RRM scheduler, implemented using Quartz.
+ */
+public class RRMScheduler {
+	private static final Logger logger = LoggerFactory.getLogger(RRMScheduler.class);
+
+	/** SchedulerContext key holding the RRMScheduler instance. */
+	private static final String SCHEDULER_CONTEXT_RRMSCHEDULER = "RRMScheduler";
+
+	/** The single Quartz job instance. */
+	private final JobDetail job = JobBuilder.newJob(RRMJob.class)
+		.withIdentity("RRM")
+		.storeDurably()
+		.build();
+
+	/** The module parameters. */
+	private final RRMSchedulerParams params;
+
+	/** The device data manager. */
+	private final DeviceDataManager deviceDataManager;
+
+	/** The ConfigManager module instance. */
+	private ConfigManager configManager;
+
+	/** The Modeler module instance. */
+	private Modeler modeler;
+
+	/** The scheduler instance. */
+	private Scheduler scheduler;
+
+	/** The zones with active triggers scheduled. */
+	private Set<String> scheduledZones;
+
+	/** RRM job. */
+	public static class RRMJob implements Job {
+		@Override
+		public void execute(JobExecutionContext context) throws JobExecutionException {
+			String zone = context.getTrigger().getKey().getName();
+			logger.debug("Executing job for zone: {}", zone);
+			try {
+				SchedulerContext schedulerContext = context.getScheduler().getContext();
+				RRMScheduler instance =
+					(RRMScheduler) schedulerContext.get(SCHEDULER_CONTEXT_RRMSCHEDULER);
+				instance.performRRM(zone);
+			} catch (SchedulerException e) {
+				throw new JobExecutionException(e);
+			}
+		}
+	}
+
+	/** Constructor. */
+	public RRMScheduler(
+		RRMSchedulerParams params, DeviceDataManager deviceDataManager
+	) {
+		this.params = params;
+		this.deviceDataManager = deviceDataManager;
+	}
+
+	/** Build the Properties to pass to StdSchedulerFactory. */
+	private Properties getSchedulerProperties() {
+		Properties props = new Properties();
+		props.setProperty("org.quartz.scheduler.skipUpdateCheck", "true");
+		props.setProperty(
+			"org.quartz.threadPool.threadCount",
+			Integer.toString(params.threadCount)
+		);
+		return props;
+	}
+
+	/** Start the scheduler, returning true if newly started. */
+	public boolean start(ConfigManager configManager, Modeler modeler) {
+		this.configManager = configManager;
+		this.modeler = modeler;
+
+		try {
+			if (scheduler != null && scheduler.isStarted()) {
+				return false;
+			}
+
+			// Create scheduler
+			StdSchedulerFactory factory =
+				new StdSchedulerFactory(getSchedulerProperties());
+			this.scheduler = factory.getScheduler();
+			scheduler.getContext().put(SCHEDULER_CONTEXT_RRMSCHEDULER, this);
+
+			// Schedule job and triggers
+			scheduler.addJob(job, false);
+			syncTriggers();
+			logger.info("Scheduled {} RRM trigger(s)", scheduledZones.size());
+
+			// Start scheduler
+			scheduler.start();
+			return true;
+		} catch (SchedulerException e) {
+			logger.error("Failed to start scheduler", e);
+			return false;
+		}
+	}
+
+	/** Shut down the scheduler. */
+	public void shutdown() {
+		try {
+			if (scheduler != null && !scheduler.isShutdown()) {
+				scheduler.shutdown();
+			}
+		} catch (SchedulerException e) {
+			logger.error("Failed to shutdown scheduler", e);
+		}
+	}
+
+	/**
+	 * Synchronize triggers to the current topology, adding/updating/deleting
+	 * them as necessary. This updates {@link #scheduledZones}.
+	 */
+	public void syncTriggers() {
+		Set<String> scheduled = ConcurrentHashMap.newKeySet();
+		Set<String> prevScheduled = new HashSet<>();
+		if (scheduledZones != null) {
+			prevScheduled.addAll(scheduledZones);
+		}
+
+		// Add new triggers
+		for (String zone : deviceDataManager.getZones()) {
+			DeviceConfig config = deviceDataManager.getZoneConfig(zone);
+			if (
+				config.schedule == null ||
+				config.schedule.cron == null ||
+				config.schedule.cron.isEmpty()
+			) {
+				continue;  // RRM not scheduled
+			}
+
+			// Create trigger
+			Trigger trigger = TriggerBuilder.newTrigger()
+				.withIdentity(zone)
+				.forJob(job)
+				.withSchedule(
+					CronScheduleBuilder.cronSchedule(config.schedule.cron)
+				).build();
+			try {
+				if (!prevScheduled.contains(zone)) {
+					scheduler.scheduleJob(trigger);
+				} else {
+					scheduler.rescheduleJob(trigger.getKey(), trigger);
+				}
+			} catch (SchedulerException e) {
+				logger.error(
+					"Failed to schedule RRM trigger for zone: " + zone, e
+				);
+				continue;
+			}
+			scheduled.add(zone);
+			logger.debug(
+				"Scheduled/updated RRM for zone '{}' at: < {} >",
+				zone, config.schedule.cron
+			);
+		}
+
+		// Remove old triggers
+		prevScheduled.removeAll(scheduled);
+		for (String zone : prevScheduled) {
+			try {
+				scheduler.unscheduleJob(TriggerKey.triggerKey(zone));
+			} catch (SchedulerException e) {
+				logger.error(
+					"Failed to remove RRM trigger for zone: " + zone, e
+				);
+				continue;
+			}
+			logger.debug("Removed RRM trigger for zone '{}'", zone);
+		}
+
+		this.scheduledZones = scheduled;
+	}
+
+	/** Run RRM algorithms for the given zone. */
+	protected void performRRM(String zone) {
+		logger.info("Starting scheduled RRM for zone '{}'", zone);
+
+		// TODO better place for these definitions
+		final String RRM_ALGORITHM_CHANNEL = "optimizeChannel";
+		final String RRM_ALGORITHM_TPC = "optimizeTxPower";
+
+		// Get algorithms from zone config
+		DeviceConfig config = deviceDataManager.getZoneConfig(zone);
+		if (config.schedule == null) {
+			logger.error("RRM schedule missing for zone '{}', aborting!", zone);
+			return;
+		}
+		if (
+			config.schedule.algorithms == null ||
+			config.schedule.algorithms.isEmpty()
+		) {
+			logger.debug("Using default RRM algorithms for zone '{}'", zone);
+			config.schedule.algorithms = Arrays.asList(
+				new RRMAlgorithm(RRM_ALGORITHM_CHANNEL, null),
+				new RRMAlgorithm(RRM_ALGORITHM_TPC, null)
+			);
+		}
+
+		// Execute algorithms
+		for (RRMAlgorithm algo : config.schedule.algorithms) {
+			if (algo.name == null) {
+				continue;
+			}
+
+			String mode = (algo.args != null)
+				? algo.args.getOrDefault("mode", "")
+				: "";
+
+			// TODO de-dupe with ApiServer code
+			switch (algo.name) {
+				case RRM_ALGORITHM_CHANNEL: {
+					logger.info(
+						"> Zone '{}': Running channel optimizer...", zone
+					);
+					ChannelOptimizer optimizer;
+					switch (mode) {
+					case "random":
+						optimizer = new RandomChannelInitializer(
+							modeler.getDataModelCopy(), zone, deviceDataManager
+						);
+						break;
+					case "least_used":
+						optimizer = new LeastUsedChannelOptimizer(
+							modeler.getDataModelCopy(), zone, deviceDataManager
+						);
+						break;
+					case "unmanaged_aware":
+					default:
+						optimizer = new UnmanagedApAwareChannelOptimizer(
+							modeler.getDataModelCopy(), zone, deviceDataManager
+						);
+						break;
+					}
+					Map<String, Map<String, Integer>> channelMap =
+						optimizer.computeChannelMap();
+					optimizer.applyConfig(
+						deviceDataManager, configManager, channelMap
+					);
+					break;
+				}
+
+				case RRM_ALGORITHM_TPC: {
+					logger.info(
+						"> Zone '{}': Running tx power optimizer...", zone
+					);
+					TPC optimizer;
+					switch (mode) {
+					case "random":
+						optimizer = new RandomTxPowerInitializer(
+							modeler.getDataModelCopy(), zone, deviceDataManager
+						);
+						break;
+					case "measure_ap_client":
+						optimizer = new MeasurementBasedApClientTPC(
+							modeler.getDataModelCopy(), zone, deviceDataManager
+						);
+						break;
+					case "measure_ap_ap":
+					default:
+						optimizer = new MeasurementBasedApApTPC(
+							modeler.getDataModelCopy(), zone, deviceDataManager
+						);
+						break;
+					case "location_optimal":
+						optimizer = new LocationBasedOptimalTPC(
+							modeler.getDataModelCopy(), zone, deviceDataManager
+						);
+						break;
+					}
+					Map<String, Map<String, Integer>> txPowerMap =
+						optimizer.computeTxPowerMap();
+					optimizer.applyConfig(
+						deviceDataManager, configManager, txPowerMap
+					);
+					break;
+				}
+			}
+		}
+	}
+}

--- a/src/test/java/com/facebook/openwifirrm/DeviceDataManagerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/DeviceDataManagerTest.java
@@ -63,6 +63,7 @@ public class DeviceDataManagerTest {
 		assertTrue(deviceDataManager.isZoneInTopology(zoneA));
 		assertTrue(deviceDataManager.isZoneInTopology(zoneB));
 		assertFalse(deviceDataManager.isZoneInTopology(zoneUnknown));
+		assertEquals(Arrays.asList(zoneA, zoneB), deviceDataManager.getZones());
 
 		// Minimal JSON sanity check
 		assertFalse(deviceDataManager.getTopologyJson().isEmpty());
@@ -171,6 +172,9 @@ public class DeviceDataManagerTest {
 		assertFalse(actualApCfgB.enableRRM);
 		assertEquals(2, actualApCfgA.allowedChannels.get("2G").size());
 		assertEquals(3, actualApCfgB.allowedChannels.get("2G").size());
+		DeviceConfig actualZoneCfgA = deviceDataManager.getZoneConfig(zoneA);
+		assertNotNull(actualZoneCfgA);
+		assertTrue(actualZoneCfgA.enableRRM);
 
 		// Minimal JSON sanity check
 		assertFalse(deviceDataManager.getDeviceLayeredConfigJson().isEmpty());

--- a/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
@@ -85,6 +85,11 @@ public class ApiServerTest {
 		UCentralKafkaConsumer consumer = null;
 		DatabaseManager dbManager = null;
 
+		// Create scheduler
+		RRMScheduler scheduler = new RRMScheduler(
+			rrmConfig.moduleConfig.schedulerParams, deviceDataManager
+		);
+
 		// Instantiate dependent instances
 		ConfigManager configManager = new ConfigManager(
 			rrmConfig.moduleConfig.configManagerParams,
@@ -115,7 +120,8 @@ public class ApiServerTest {
 			deviceDataManager,
 			configManager,
 			modeler,
-			client
+			client,
+			scheduler
 		);
 		try {
 			server.run();

--- a/src/test/java/com/facebook/openwifirrm/modules/ProvMonitorTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ProvMonitorTest.java
@@ -15,9 +15,7 @@ import org.junit.jupiter.api.TestInfo;
 
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.RRMConfig;
-import com.facebook.openwifirrm.mysql.DatabaseManager;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
-import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
 
 public class ProvMonitorTest {
 	/** Test device data manager. */
@@ -35,38 +33,12 @@ public class ProvMonitorTest {
 
 		// Create clients (null for now)
 		UCentralClient client = null;
-		UCentralKafkaConsumer consumer = null;
-		DatabaseManager dbManager = null;
-
-		// Instantiate dependent instances
-		ConfigManager configManager = new ConfigManager(
-			rrmConfig.moduleConfig.configManagerParams,
-			deviceDataManager,
-			client
-		);
-		DataCollector dataCollector = new DataCollector(
-			rrmConfig.moduleConfig.dataCollectorParams,
-			deviceDataManager,
-			client,
-			consumer,
-			configManager,
-			dbManager
-		);
-		Modeler modeler = new Modeler(
-			rrmConfig.moduleConfig.modelerParams,
-			deviceDataManager,
-			consumer,
-			client,
-			dataCollector,
-			configManager
-		);
 
 		// Instantiate ProvMonitor
 		this.provMonitor = new ProvMonitor(
 			rrmConfig.moduleConfig.provMonitorParams,
-			configManager,
 			deviceDataManager,
-			modeler,
+			client,
 			null
 		);
 	}


### PR DESCRIPTION
Signed-off-by: Jeffrey Han <39203126+elludraon@users.noreply.github.com>

Allow scheduling RRM algorithms to be run per zone. This implementation uses the Quartz Job Scheduler library.
- Add "schedule" (`RRMSchedule`) field to `DeviceConfig`, which is only read at the network/zone layer (i.e. ignored at AP layer). This allows scheduling specified algorithms at a given interval in Quartz's cron-like format.
- Add `RRMScheduler` module encapsulating all Quartz implementation details and RRM execution.
- Add `RRMScheduler.syncTriggers()` calls throughout codebase as needed to ensure triggers remain in sync with topology and device config.
- Add "schedulerParams" (`RRMSchedulerParams`) structure to `RRMConfig`, which currently only allows specifying thread pool size.

**The config field names and values are TBD.** For now, this reuses the names from `ApiServer`.

Example `device_config.json` snippet which runs channel optimization with default settings every 5 minutes:
```json
{
  "zoneConfig": {
    "some-venue": {
      "schedule": {
        "cron": "0 0/5 * * * ?",
        "algorithms": [
          {
            "name": "optimizeChannel"
          }
        ]
      }
    }
  }
}
```

Unrelated:
- Delete commented optimizer code from `ProvMonitor` because it won't be invoked from there.
- Fix leakage of `DeviceConfig` references in `DeviceDataManager.computeDeviceConfig()` by returning a deep clone.
- Change RRM config field "configOnEventOnly" default from `false` to `true`.
