### PR TITLE
[WIFI-9985] Generate openapi.yaml during mvn compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Docker builds can be launched using the provided [Dockerfile](Dockerfile).
 ## OpenAPI
 This service provides an OpenAPI HTTP interface on the port specified in the
 service configuration (`moduleConfig.apiServerParams`). An auto-generated
-OpenAPI 3.0 document is hosted at the endpoints `/openapi.{yaml,json}`.
+OpenAPI 3.0 document is hosted at the endpoints `/openapi.{yaml,json}` and is
+written to `openapi.yaml` in the project root during the Maven "compile" phase.
 
 ## Implementation
 See [IMPLEMENTATION.md](IMPLEMENTATION.md) for service architecture details and

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,437 @@
+openapi: 3.0.1
+info:
+  title: OpenWiFi 2.0 RRM OpenAPI
+  description: This document describes the API for the Radio Resource Management service.
+  version: 1.0.0
+tags:
+- name: SDK
+- name: Config
+- name: Optimization
+paths:
+  /api/v1/currentModel:
+    get:
+      tags:
+      - Optimization
+      summary: Get current RRM model
+      description: Returns the current RRM data model.
+      operationId: getCurrentModel
+      responses:
+        "200":
+          description: Data model
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/getDeviceConfig:
+    get:
+      tags:
+      - Config
+      summary: Get device configuration
+      description: Returns the device configuration by applying all configuration
+        layers.
+      operationId: getDeviceConfig
+      parameters:
+      - name: serial
+        in: query
+        description: The device serial number
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Device configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceConfig'
+  /api/v1/getDeviceLayeredConfig:
+    get:
+      tags:
+      - Config
+      summary: Get device layered configuration
+      description: Returns the device layered configuration.
+      operationId: getDeviceLayeredConfig
+      responses:
+        "200":
+          description: Device layered configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceLayeredConfig'
+  /api/v1/getTopology:
+    get:
+      tags:
+      - Config
+      summary: Get device topology
+      description: Returns the device topology.
+      operationId: getTopology
+      responses:
+        "200":
+          description: Device topology
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceTopology'
+  /api/v1/modifyDeviceApConfig:
+    post:
+      tags:
+      - Config
+      summary: Modify device AP configuration
+      description: Modify the AP layer of the network configuration for the given
+        AP. Any existing fields absent from the request body will be preserved.
+      operationId: modifyDeviceApConfig
+      parameters:
+      - name: serial
+        in: query
+        description: The device serial number
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The device AP configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceConfig'
+        required: true
+      responses:
+        "200":
+          description: Success
+        "400":
+          description: Bad request
+  /api/v1/optimizeChannel:
+    get:
+      tags:
+      - Optimization
+      summary: Optimize channel configuration
+      description: Run channel optimizer and return the new channel allocation.
+      operationId: optimizeChannel
+      parameters:
+      - name: mode
+        in: query
+        description: "The assignment algorithm to use:\n- random: random channel initialization\n\
+          - least_used: least used channel assignment\n- unmanaged_aware: unmanaged\
+          \ AP aware least used channel assignment\n"
+        required: true
+        schema:
+          type: string
+          enum:
+          - random
+          - least_used
+          - unmanaged_aware
+      - name: zone
+        in: query
+        description: The RF zone
+        required: true
+        schema:
+          type: string
+      - name: dry_run
+        in: query
+        description: Do not apply changes
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: Channel allocation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelAllocation'
+  /api/v1/optimizeTxPower:
+    get:
+      tags:
+      - Optimization
+      summary: Optimize tx power configuration
+      description: Run tx power optimizer and return the new tx power allocation.
+      operationId: optimizeTxPower
+      parameters:
+      - name: mode
+        in: query
+        description: "The assignment algorithm to use:\n- random: random tx power\
+          \ initialier\n- measure_ap_client: measurement-based AP-client TPC algorithm\n\
+          - measure_ap_ap: measurement-based AP-AP TPC algorithm\n- location_optimal:\
+          \ location-based optimal TPC algorithm\n"
+        required: true
+        schema:
+          type: string
+          enum:
+          - random
+          - measure_ap_client
+          - measure_ap_ap
+          - location_optimal
+      - name: zone
+        in: query
+        description: The RF zone
+        required: true
+        schema:
+          type: string
+      - name: dry_run
+        in: query
+        description: Do not apply changes
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: Tx power allocation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TxPowerAllocation'
+  /api/v1/setDeviceApConfig:
+    post:
+      tags:
+      - Config
+      summary: Set device AP configuration
+      description: Set the AP layer of the network configuration for the given AP.
+      operationId: setDeviceApConfig
+      parameters:
+      - name: serial
+        in: query
+        description: The device serial number
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The device AP configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceConfig'
+        required: true
+      responses:
+        "200":
+          description: Success
+        "400":
+          description: Bad request
+  /api/v1/setDeviceNetworkConfig:
+    post:
+      tags:
+      - Config
+      summary: Set device network configuration
+      description: Set the network layer of the device configuration.
+      operationId: setDeviceNetworkConfig
+      requestBody:
+        description: The device network configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceConfig'
+        required: true
+      responses:
+        "200":
+          description: Success
+        "400":
+          description: Bad request
+  /api/v1/setDeviceZoneConfig:
+    post:
+      tags:
+      - Config
+      summary: Set device zone configuration
+      description: Set the zone layer of the network configuration for the given zone.
+      operationId: setDeviceZoneConfig
+      parameters:
+      - name: zone
+        in: query
+        description: The RF zone
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: The device zone configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceConfig'
+        required: true
+      responses:
+        "200":
+          description: Success
+        "400":
+          description: Bad request
+  /api/v1/setTopology:
+    post:
+      tags:
+      - Config
+      summary: Set device topology
+      description: Set the device topology.
+      operationId: setTopology
+      requestBody:
+        description: The device topology
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceTopology'
+        required: true
+      responses:
+        "200":
+          description: Success
+        "400":
+          description: Bad request
+  /api/v1/system:
+    get:
+      tags:
+      - SDK
+      summary: Get system info
+      description: Returns the system info from the running service.
+      operationId: system
+      parameters:
+      - name: command
+        in: query
+        description: Get a value
+        required: true
+        schema:
+          type: string
+          enum:
+          - info
+      responses:
+        "200":
+          description: Successful command execution
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemInfoResults'
+components:
+  schemas:
+    DeviceConfig:
+      type: object
+      properties:
+        enableRRM:
+          type: boolean
+        schedule:
+          $ref: '#/components/schemas/RRMSchedule'
+        enableConfig:
+          type: boolean
+        enableWifiScan:
+          type: boolean
+        boundary:
+          type: integer
+          format: int32
+        location:
+          type: array
+          items:
+            type: integer
+            format: int32
+        allowedChannels:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: integer
+              format: int32
+        allowedChannelWidths:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: integer
+              format: int32
+        autoChannels:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+        userChannels:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+        allowedTxPowers:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: integer
+              format: int32
+        autoTxPowers:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+        userTxPowers:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+    RRMAlgorithm:
+      type: object
+      properties:
+        name:
+          type: string
+        args:
+          type: object
+          additionalProperties:
+            type: string
+    RRMSchedule:
+      type: object
+      properties:
+        cron:
+          type: string
+        algorithms:
+          type: array
+          items:
+            $ref: '#/components/schemas/RRMAlgorithm'
+    DeviceLayeredConfig:
+      type: object
+      properties:
+        apConfig:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/DeviceConfig'
+        zoneConfig:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/DeviceConfig'
+        networkConfig:
+          $ref: '#/components/schemas/DeviceConfig'
+    DeviceTopology:
+      type: object
+    ChannelAllocation:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int32
+    TxPowerAllocation:
+      type: object
+      properties:
+        data:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int32
+    Certificate:
+      type: object
+      properties:
+        filename:
+          type: string
+        expires:
+          type: integer
+          format: int64
+    SystemInfoResults:
+      type: object
+      properties:
+        version:
+          type: string
+        uptime:
+          type: integer
+          format: int64
+        start:
+          type: integer
+          format: int64
+        os:
+          type: string
+        processors:
+          type: integer
+          format: int32
+        hostname:
+          type: string
+        certificates:
+          type: array
+          items:
+            $ref: '#/components/schemas/Certificate'

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <java.version>11</java.version>
     <slf4j.version>1.7.32</slf4j.version>
     <junit.version>5.7.2</junit.version>
+    <swagger.version>2.1.10</swagger.version>
     <mainClassName>com.facebook.openwifirrm.Launcher</mainClassName>
   </properties>
   <build>
@@ -71,6 +72,26 @@
             <phase>package</phase>
             <goals>
               <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- Generate "openapi.yaml" in project root, NOT packaged -->
+        <groupId>io.swagger.core.v3</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <version>${swagger.version}</version>
+        <configuration>
+          <outputFileName>openapi</outputFileName>
+          <outputPath>${project.basedir}</outputPath>
+          <outputFormat>YAML</outputFormat>
+          <prettyPrint>TRUE</prettyPrint>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>resolve</goal>
             </goals>
           </execution>
         </executions>
@@ -143,7 +164,7 @@
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-jaxrs2</artifactId>
-      <version>2.1.10</version>
+      <version>${swagger.version}</version>
       </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
Signed-off-by: Jeffrey Han <39203126+elludraon@users.noreply.github.com>

Use "swagger-maven-plugin" to generate `openapi.yaml` during the "mvn compile" phase and check it into the repo. This file is not used for anything else.