### PR TITLE
[WIFI-9987] Improve OpenWiFi auth

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,6 +3,8 @@ info:
   title: OpenWiFi 2.0 RRM OpenAPI
   description: This document describes the API for the Radio Resource Management service.
   version: 1.0.0
+security:
+- bearerAuth: []
 tags:
 - name: SDK
 - name: Config
@@ -435,3 +437,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Certificate'
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -316,6 +316,12 @@ public class RRMConfig {
 			 * (<tt>APISERVERPARAMS_USEOPENWIFIAUTH</tt>)
 			 */
 			public boolean useOpenWifiAuth = false;
+
+			/**
+			 * The maximum cache size for OpenWiFi tokens
+			 * (<tt>APISERVERPARAMS_OPENWIFIAUTHCACHESIZE</tt>)
+			 */
+			public int openWifiAuthCacheSize = 100;
 		}
 
 		/** ApiServer parameters. */
@@ -497,6 +503,9 @@ public class RRMConfig {
 		}
 		if ((v = env.get("APISERVERPARAMS_USEOPENWIFIAUTH")) != null) {
 			apiServerParams.useOpenWifiAuth = Boolean.parseBoolean(v);
+		}
+		if ((v = env.get("APISERVERPARAMS_OPENWIFIAUTHCACHESIZE")) != null) {
+			apiServerParams.openWifiAuthCacheSize = Integer.parseInt(v);
 		}
 		ModuleConfig.ProvMonitorParams provManagerParams =
 			config.moduleConfig.provMonitorParams;

--- a/src/main/java/com/facebook/openwifirrm/Utils.java
+++ b/src/main/java/com/facebook/openwifirrm/Utils.java
@@ -15,6 +15,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.json.JSONObject;
 
@@ -33,6 +35,25 @@ public class Utils {
 
 	// This class should not be instantiated.
 	private Utils() {}
+
+	/** Simple LRU cache, adapted from: https://stackoverflow.com/a/1953516 */
+	public static class LruCache<K, V> extends LinkedHashMap<K, V> {
+		private static final long serialVersionUID = 4884066392195453453L;
+
+		/** The cache size. */
+		private final int maxEntries;
+
+		/** Constructor. */
+		public LruCache(int maxEntries) {
+			super(maxEntries + 1, 1.0f, true);
+			this.maxEntries = maxEntries;
+		}
+
+		@Override
+		protected boolean removeEldestEntry(final Map.Entry<K, V> eldest) {
+			return super.size() > maxEntries;
+		}
+	}
 
 	/** Read a file to a UTF-8 string. */
 	public static String readFile(File f) throws IOException {


### PR DESCRIPTION
Clean up some of the OpenWiFi auth code.
- Only block RRM API paths ("/api/...") behind auth validators.
- Add bearer authentication scheme to OpenAPI document via annotations. This also enables the security forms in Swagger UI.
- Move uCentralSec token cache out of `UCentralClient` and into `ApiServer` as this will probably be the only user of it, and makes the HTTP client class cleaner.
- Add simple synchronized LRU cache implementation for uCentralSec token lookups. This only stores *successful* lookups and not *failed* lookups. Cache size can be configured via `APISERVERPARAMS_OPENWIFIAUTHCACHESIZE`.
