### PR TITLE
Misc fixes

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/RRM.java
+++ b/src/main/java/com/facebook/openwifirrm/RRM.java
@@ -126,6 +126,7 @@ public class RRM {
 				? new ProvMonitor(
 					config.moduleConfig.provMonitorParams,
 					deviceDataManager,
+					modeler,
 					client,
 					scheduler
 				) : null;

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -350,6 +350,12 @@ public class RRMConfig {
 			 * (<tt>SCHEDULERPARAMS_THREADCOUNT</tt>)
 			 */
 			public int threadCount = 2;
+
+			/**
+			 * If set, do not apply any changes from scheduled algorithms
+			 * (<tt>SCHEDULERPARAMS_DRYRUN</tt>)
+			 */
+			public boolean dryRun = false;
 		}
 
 		/** RRMScheduler parameters. */
@@ -510,6 +516,9 @@ public class RRMConfig {
 			config.moduleConfig.schedulerParams;
 		if ((v = env.get("SCHEDULERPARAMS_THREADCOUNT")) != null) {
 			schedulerParams.threadCount = Integer.parseInt(v);
+		}
+		if ((v = env.get("SCHEDULERPARAMS_DRYRUN")) != null) {
+			schedulerParams.dryRun = Boolean.parseBoolean(v);
 		}
 
 		return config;

--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -45,6 +45,9 @@ public class ProvMonitor implements Runnable {
 	/** The device data manager. */
 	private final DeviceDataManager deviceDataManager;
 
+	/** The Modeler module instance. */
+	private final Modeler modeler;
+
 	/** The uCentral client. */
 	private final UCentralClient client;
 
@@ -55,11 +58,13 @@ public class ProvMonitor implements Runnable {
 	public ProvMonitor(
 		ProvMonitorParams params,
 		DeviceDataManager deviceDataManager,
+		Modeler modeler,
 		UCentralClient client,
 		RRMScheduler scheduler
 	) {
 		this.params = params;
 		this.deviceDataManager = deviceDataManager;
+		this.modeler = modeler;
 		this.client = client;
 		this.scheduler = scheduler;
 	}
@@ -167,6 +172,9 @@ public class ProvMonitor implements Runnable {
 			inventoryForRRM.serialNumbers.size(),
 			inventory.taglist.size()
 		);
+
+		// Revalidate data model
+		modeler.revalidate();
 
 		// Update scheduler
 		scheduler.syncTriggers();

--- a/src/main/java/com/facebook/openwifirrm/modules/RRMScheduler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/RRMScheduler.java
@@ -282,9 +282,11 @@ public class RRMScheduler {
 					}
 					Map<String, Map<String, Integer>> channelMap =
 						optimizer.computeChannelMap();
-					optimizer.applyConfig(
-						deviceDataManager, configManager, channelMap
-					);
+					if (!params.dryRun) {
+						optimizer.applyConfig(
+							deviceDataManager, configManager, channelMap
+						);
+					}
 					break;
 				}
 
@@ -318,9 +320,11 @@ public class RRMScheduler {
 					}
 					Map<String, Map<String, Integer>> txPowerMap =
 						optimizer.computeTxPowerMap();
-					optimizer.applyConfig(
-						deviceDataManager, configManager, txPowerMap
-					);
+					if (!params.dryRun) {
+						optimizer.applyConfig(
+							deviceDataManager, configManager, txPowerMap
+						);
+					}
 					break;
 				}
 			}

--- a/src/main/java/com/facebook/openwifirrm/optimizers/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/MeasurementBasedApApTPC.java
@@ -52,7 +52,6 @@ public class MeasurementBasedApApTPC extends TPC {
 	 */
 	public static final int DEFAULT_NTH_SMALLEST_RSSI = 0;
 
-
 	/** coverage threshold between APs, in dB */
 	private final int coverageThreshold;
 
@@ -84,7 +83,7 @@ public class MeasurementBasedApApTPC extends TPC {
 	}
 
 	/**
-	 * Retrieve BSSIDs of APs we are managing
+	 * Retrieve BSSIDs of APs we are managing.
 	 */
 	protected static Set<String> getManagedBSSIDs(DataModel model) {
 		Set<String> managedBSSIDs = new HashSet<>();
@@ -109,25 +108,27 @@ public class MeasurementBasedApApTPC extends TPC {
 	}
 
 	/**
-	 * Get the current 5G tx power for an AP using the latest device status
+	 * Get the current 5GHz radio tx power (the first one found) for an AP using
+	 * the latest device status.
+	 *
 	 * @param latestDeviceStatus JsonArray containing radio config for the AP
+	 * @return the tx power, or 0 if none found
 	 */
 	protected static int getCurrentTxPower(JsonArray latestDeviceStatus) {
-		for (int radioIndex = 0; radioIndex < latestDeviceStatus.size(); radioIndex++) {
-			JsonElement e = latestDeviceStatus.get(radioIndex);
+		for (JsonElement e : latestDeviceStatus) {
 			if (!e.isJsonObject()) {
-				return 0;
+				continue;
 			}
 			JsonObject radioObject = e.getAsJsonObject();
 			String band = radioObject.get("band").getAsString();
-			if (band.equals("5G")) {
+			if (band.equals("5G") && radioObject.has("tx-power")) {
 				return radioObject.get("tx-power").getAsInt();
 			}
 		}
-
 		return 0;
 	}
 
+	/** Return true if the given channel is a 5GHz channel. */
 	protected static boolean isChannel5G(int channel) {
 		return (36 <= channel && channel <= 165);
 	}
@@ -190,17 +191,17 @@ public class MeasurementBasedApApTPC extends TPC {
 		// Bound tx_power by [MIN_TX_POWER, MAX_TX_POWER]
 		if (newTxPower > MAX_TX_POWER) {
 			logger.info(
-					"Device {}: computed tx power > maximum {}, using maximum",
-					serialNumber,
-					MAX_TX_POWER
-				);
+				"Device {}: computed tx power > maximum {}, using maximum",
+				serialNumber,
+				MAX_TX_POWER
+			);
 			newTxPower = MAX_TX_POWER;
 		} else if (newTxPower < MIN_TX_POWER) {
 			logger.info(
-					"Device {}: computed tx power < minimum {}, using minimum",
-					serialNumber,
-					MIN_TX_POWER
-				);
+				"Device {}: computed tx power < minimum {}, using minimum",
+				serialNumber,
+				MIN_TX_POWER
+			);
 			newTxPower = MIN_TX_POWER;
 		}
 		return newTxPower;

--- a/src/test/java/com/facebook/openwifirrm/modules/ProvMonitorTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ProvMonitorTest.java
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.TestInfo;
 
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.RRMConfig;
+import com.facebook.openwifirrm.mysql.DatabaseManager;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
+import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
 
 public class ProvMonitorTest {
 	/** Test device data manager. */
@@ -33,11 +35,37 @@ public class ProvMonitorTest {
 
 		// Create clients (null for now)
 		UCentralClient client = null;
+		UCentralKafkaConsumer consumer = null;
+		DatabaseManager dbManager = null;
+
+		// Instantiate dependent instances
+		ConfigManager configManager = new ConfigManager(
+			rrmConfig.moduleConfig.configManagerParams,
+			deviceDataManager,
+			client
+		);
+		DataCollector dataCollector = new DataCollector(
+			rrmConfig.moduleConfig.dataCollectorParams,
+			deviceDataManager,
+			client,
+			consumer,
+			configManager,
+			dbManager
+		);
+		Modeler modeler = new Modeler(
+			rrmConfig.moduleConfig.modelerParams,
+			deviceDataManager,
+			consumer,
+			client,
+			dataCollector,
+			configManager
+		);
 
 		// Instantiate ProvMonitor
 		this.provMonitor = new ProvMonitor(
 			rrmConfig.moduleConfig.provMonitorParams,
 			deviceDataManager,
+			modeler,
 			client,
 			null
 		);


### PR DESCRIPTION
- Fix crash in `MeasurementBasedApApTPC.getCurrentTxPower()` if "tx-power" field is missing
- Add missing `Modeler.revalidate()` call to `ProvMonitor` after sync
- Add RRM config `SCHEDULERPARAMS_DRYRUN` (default false) for debugging the scheduler
