### PR TITLE
Generate version.txt via maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
           <include>**/*</include>
         </includes>
       </resource>
+      <resource>
+        <directory>src/main/resources-filtered</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>**/*</include>
+        </includes>
+      </resource>
     </resources>
     <plugins>
       <plugin>

--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -35,7 +35,7 @@ import picocli.CommandLine.Option;
  */
 @Command(
 	name = "",
-	version = RRM.VERSION,
+	versionProvider = VersionProvider.class,
 	descriptionHeading = "%n",
 	description = "OpenWiFi uCentral-based radio resource management service.",
 	optionListHeading = "%nOptions:%n",
@@ -186,7 +186,7 @@ public class Launcher implements Callable<Integer> {
 				config.kafkaConfig.bootstrapServer,
 				config.kafkaConfig.serviceEventsTopic,
 				config.serviceConfig.name,
-				RRM.VERSION,
+				VersionProvider.get(),
 				config.serviceConfig.id,
 				serviceKey,
 				config.serviceConfig.privateEndpoint,

--- a/src/main/java/com/facebook/openwifirrm/RRM.java
+++ b/src/main/java/com/facebook/openwifirrm/RRM.java
@@ -38,9 +38,6 @@ import com.facebook.openwifirrm.ucentral.gw.models.SystemInfoResults;
 public class RRM {
 	private static final Logger logger = LoggerFactory.getLogger(RRM.class);
 
-	/** The RRM service version. */
-	public static final String VERSION = "1.0";  // TODO move elsewhere?
-
 	/** The executor service instance. */
 	private final ExecutorService executor = Executors.newCachedThreadPool();
 

--- a/src/main/java/com/facebook/openwifirrm/Utils.java
+++ b/src/main/java/com/facebook/openwifirrm/Utils.java
@@ -12,11 +12,13 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Scanner;
 
 import org.json.JSONObject;
 
@@ -74,6 +76,14 @@ public class Utils {
 		throws FileNotFoundException {
 		Gson gson = new GsonBuilder().setPrettyPrinting().create();
 		writeFile(f, gson.toJson(o));
+	}
+
+	/** Read a resource to a UTF-8 string. */
+	public static String readResourceToString(String path) {
+		InputStream is = Utils.class.getClassLoader().getResourceAsStream(path);
+		try (Scanner scanner = new Scanner(is, "UTF-8")) {
+			return scanner.useDelimiter("\\A").next();
+		}
 	}
 
 	/** Recursively merge JSONObject 'b' into 'a'. */

--- a/src/main/java/com/facebook/openwifirrm/VersionProvider.java
+++ b/src/main/java/com/facebook/openwifirrm/VersionProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm;
+
+import picocli.CommandLine.IVersionProvider;
+
+/**
+ * Provides version information by reading a hardcoded resource file.
+ */
+public class VersionProvider implements IVersionProvider {
+	/** The version file/resource. */
+	private static final String VERSION_FILE = "version.txt";
+
+	/** The cached version string. */
+	private static String version;
+
+	/** Read the version file, returning an empty string upon error. */
+	public static final String get() {
+		if (version == null) {
+			version = Utils.readResourceToString(VERSION_FILE).strip();
+		}
+		return version == null ? "" : version;
+	}
+
+	@Override
+	public String[] getVersion() throws Exception {
+		String ver = get();
+		if (ver.isEmpty()) {
+			ver = "ERROR: failed to read version file";
+		}
+		return new String[] { ver };
+	}
+}

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -32,9 +32,9 @@ import com.facebook.openwifirrm.DeviceConfig;
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.DeviceLayeredConfig;
 import com.facebook.openwifirrm.DeviceTopology;
-import com.facebook.openwifirrm.RRM;
 import com.facebook.openwifirrm.RRMConfig.ModuleConfig.ApiServerParams;
 import com.facebook.openwifirrm.Utils.LruCache;
+import com.facebook.openwifirrm.VersionProvider;
 import com.facebook.openwifirrm.optimizers.ChannelOptimizer;
 import com.facebook.openwifirrm.optimizers.LeastUsedChannelOptimizer;
 import com.facebook.openwifirrm.optimizers.LocationBasedOptimalTPC;
@@ -78,7 +78,7 @@ import spark.Spark;
 @OpenAPIDefinition(
 	info = @Info(
 		title = "OpenWiFi 2.0 RRM OpenAPI",
-		version = "1.0.0",
+		version = "1.0.0",  // TODO
 		description = "This document describes the API for the Radio Resource Management service."
 	),
 	tags = {
@@ -427,7 +427,7 @@ public class ApiServer implements Runnable {
 			}
 
 			SystemInfoResults result = new SystemInfoResults();
-			result.version = RRM.VERSION;
+			result.version = VersionProvider.get();
 			result.uptime =
 				Math.max(System.currentTimeMillis() - startTimeMs, 0) / 1000L;
 			result.start = startTimeMs / 1000L;

--- a/src/main/resources-filtered/version.txt
+++ b/src/main/resources-filtered/version.txt
@@ -1,0 +1,1 @@
+${project.version}

--- a/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
@@ -30,8 +30,8 @@ import com.facebook.openwifirrm.DeviceConfig;
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.DeviceLayeredConfig;
 import com.facebook.openwifirrm.DeviceTopology;
-import com.facebook.openwifirrm.RRM;
 import com.facebook.openwifirrm.RRMConfig;
+import com.facebook.openwifirrm.VersionProvider;
 import com.facebook.openwifirrm.mysql.DatabaseManager;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
@@ -476,6 +476,6 @@ public class ApiServerTest {
 	void test_system() throws Exception {
 		HttpResponse<JsonNode> resp = Unirest.get(endpoint("/api/v1/system?command=info")).asJson();
 		assertEquals(200, resp.getStatus());
-		assertEquals(RRM.VERSION, resp.getBody().getObject().getString("version"));
+		assertEquals(VersionProvider.get(), resp.getBody().getObject().getString("version"));
 	}
 }


### PR DESCRIPTION
Generate `version.txt` in classpath via Maven `project.version`, and read this in Java code instead of hardcoding it separately. This does not solve the `@OpenAPIDefinition` "version" problem though.

```bash
$ java -jar target/openwifi-rrm.jar -V
1.0.0
```