### PR TITLE
[WIFI-10341] Implement owprov RRM API

### DIFF
--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -5,66 +5,84 @@ This document describes the RRM algorithms implemented by this service.
 `ChannelOptimizer` and its subclasses implement various channel optimization
 algorithms.
 
-* `RandomChannelInitializer`: This algorithm randomly selects a channel, and
-  then assigns all APs to that selected channel. This is only for testing and
-  re-initialization.
+### `RandomChannelInitializer`
+This algorithm randomly selects a channel, and then assigns all APs to that
+selected channel. This is only for testing and re-initialization.
 
-* `LeastUsedChannelOptimizer`: This algorithm assigns the channel of the OWF APs
-  based on the following logic:
-    1. If no other APs are on the same channel as the OWF AP, then the algorithm
-       keeps the OWF AP on the same channel.
-    2. If any other APs are on the same channel as the OWF AP, and the OWF AP
-       scan results indicate unused channels in its RF vicinity, then the
-       algorithm randomly assigns one of those channels to the AP.
-    3. If any other APs are on the same channel as this AP and the OWF AP scan
-       results indicate all available channels are occupied locally, then the
-       algorithm assigns the channel with the least number of APs in its WiFi
-       scan result.
+Parameters:
+* `mode`: "random"
 
-* `UnmanagedApAwareChannelOptimizer`: Building on the least used channel
-  assignment algorithm, this algorithm can additionally (1) prioritize non-OWF
-  ("unmanaged") APs over OWF APs and (2) keep track of the current assignment.
-  This algorithm will try to avoid assigning the OWF APs to a channel with many
-  non-OWF APs and prevent assigning subsequent OWF APs to the same channel as
-  previously-assigned OWF APs. The assignment decisions are based on the
-  following logic:
-    1. If no other APs are on the same channel as the OWF AP, then the algorithm
-       keeps the OWF AP on the same channel.
-    2. If any other APs are on the same channel as the OWF AP, and the OWF AP
-       scan results indicate unused channels in its RF vicinity, then the
-       algorithm randomly assigns one of those channels to the AP.
-    3. If any other APs are on the same channel as this AP and the OWF AP scan
-       results indicate all available channels are occupied locally, then the
-       algorithm assigns the channel with the least channel weight (*W*):
-       $$ W = (D \times N) + (1 \times M) $$
-       where *D > 1* is the default weight, *N* is the number of non-OWF APs,
-       and *M* is the number of OWF APs.
+### `LeastUsedChannelOptimizer`
+This algorithm assigns the channel of the OWF APs based on the following logic:
+1. If no other APs are on the same channel as the OWF AP, then the algorithm
+   keeps the OWF AP on the same channel.
+2. If any other APs are on the same channel as the OWF AP, and the OWF AP scan
+   results indicate unused channels in its RF vicinity, then the algorithm
+   randomly assigns one of those channels to the AP.
+3. If any other APs are on the same channel as this AP and the OWF AP scan
+   results indicate all available channels are occupied locally, then the
+   algorithm assigns the channel with the least number of APs in its WiFi scan
+   result.
+
+Parameters:
+* `mode`: "least_used"
+
+### `UnmanagedApAwareChannelOptimizer`
+Building on the least used channel assignment algorithm, this algorithm can
+additionally (1) prioritize non-OWF ("unmanaged") APs over OWF APs and (2) keep
+track of the current assignment. This algorithm will try to avoid assigning the
+OWF APs to a channel with many non-OWF APs and prevent assigning subsequent OWF
+APs to the same channel as previously-assigned OWF APs. The assignment decisions
+are based on the following logic:
+1. If no other APs are on the same channel as the OWF AP, then the algorithm
+   keeps the OWF AP on the same channel.
+2. If any other APs are on the same channel as the OWF AP, and the OWF AP scan
+   results indicate unused channels in its RF vicinity, then the algorithm
+   randomly assigns one of those channels to the AP.
+3. If any other APs are on the same channel as this AP and the OWF AP scan
+   results indicate all available channels are occupied locally, then the
+   algorithm assigns the channel with the least channel weight (*W*):
+   $$ W = (D \times N) + (1 \times M) $$
+   where *D > 1* is the default weight, *N* is the number of non-OWF APs, and
+   *M* is the number of OWF APs.
+
+Parameters:
+* `mode`: "unmanaged_aware"
 
 ## Transmit Power Control
 `TPC` and its subclasses implement various transmit power control algorithms.
 
-* `RandomTxPowerinitializer`: This algorithm randomly selects a Tx power value,
-  and then assigns all APs to the value. This is only for testing and
-  re-initialization.
+### `RandomTxPowerinitializer`
+This algorithm randomly selects a Tx power value, and then assigns all APs to
+the value. This is only for testing and re-initialization.
 
-* `MeasurementBasedApClientTPC`: This algorithm tries to assign the Tx power of
-  the OWF APs based on the associated clients of each AP. The strategy is
-  described in the steps below (for each AP):
-    1. Determine the operating SNR & MCS on the client side.
-    2. If this SNR is greater than the minimum required SNR to achieve this MCS,
-       reduce the Tx power. Otherwise, no change is made.
-    3. If there are multiple clients, the above decision is made based on the
-       client with lowest SNR.
+Parameters:
+* `mode`: "random"
 
-* `MeasurementBasedApApTPC`: This algorithm tries to assign the Tx power of the
-  OWF APs by getting a set of APs to transmit at a power level to minimize
-  overlapping coverage. The power levels of these APs will be determined by the
-  following steps:
-    1. Through WiFi scans, collect the list of RSSIs (from *N-1* APs) reported
-       by every AP.
-    2. For each AP, find the lowest RSSI in its list. If this is higher than
-       `RSSI_threshold`, decrease the Tx power of this AP by
-       `(RSSI_lowest - RSSI_threshold)`.
-    3. If this is lower than `RSSI_threshold`, increase the Tx power of this AP
-       by `(RSSI_threshold - RSSI_lowest)`.
+### `MeasurementBasedApClientTPC`
+This algorithm tries to assign the Tx power of the OWF APs based on the
+associated clients of each AP. The strategy is described in the steps below (for
+each AP):
+1. Determine the operating SNR & MCS on the client side.
+2. If this SNR is greater than the minimum required SNR to achieve this MCS,
+   reduce the Tx power. Otherwise, no change is made.
+3. If there are multiple clients, the above decision is made based on the client
+   with lowest SNR.
 
+Parameters:
+* `mode`: "measure_ap_client"
+
+### `MeasurementBasedApApTPC`
+This algorithm tries to assign the Tx power of the OWF APs by getting a set of
+APs to transmit at a power level to minimize overlapping coverage. The power
+levels of these APs will be determined by the following steps:
+1. Through WiFi scans, collect the list of RSSIs (from *N-1* APs) reported by
+   every AP.
+2. For each AP, find the lowest RSSI in its list. If this is higher than
+   `RSSI_threshold`, decrease the Tx power of this AP by
+   `(RSSI_lowest - RSSI_threshold)`.
+3. If this is lower than `RSSI_threshold`, increase the Tx power of this AP by
+   `(RSSI_threshold - RSSI_lowest)`.
+
+Parameters:
+* `mode`: "measure_ap_ap"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,6 +10,22 @@ tags:
 - name: Config
 - name: Optimization
 paths:
+  /api/v1/algorithms:
+    get:
+      tags:
+      - SDK
+      summary: Get RRM algorithms
+      description: Returns the RRM algorithm list.
+      operationId: algorithms
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Algorithm'
   /api/v1/currentModel:
     get:
       tags:
@@ -150,7 +166,7 @@ paths:
       - name: mode
         in: query
         description: "The assignment algorithm to use:\n- random: random tx power\
-          \ initialier\n- measure_ap_client: measurement-based AP-client TPC algorithm\n\
+          \ initializer\n- measure_ap_client: measurement-based AP-client TPC algorithm\n\
           - measure_ap_ap: measurement-based AP-AP TPC algorithm\n- location_optimal:\
           \ location-based optimal TPC algorithm\n"
         required: true
@@ -179,6 +195,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TxPowerAllocation'
+  /api/v1/provider:
+    get:
+      tags:
+      - SDK
+      summary: Get RRM provider info
+      description: Returns the RRM provider info.
+      operationId: provider
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Provider'
+  /api/v1/runRRM:
+    put:
+      tags:
+      - SDK
+      summary: Run RRM algorithm
+      description: Run a specific RRM algorithm now.
+      operationId: runRRM
+      parameters:
+      - name: algorithm
+        in: query
+        description: The algorithm name
+        required: true
+        schema:
+          type: string
+      - name: args
+        in: query
+        description: The algorithm arguments
+        schema:
+          type: string
+      - name: venue
+        in: query
+        description: The RF zone
+        required: true
+        schema:
+          type: string
+      - name: mock
+        in: query
+        description: Do not apply changes
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlgorithmResult'
   /api/v1/setDeviceApConfig:
     post:
       tags:
@@ -287,13 +354,30 @@ paths:
           - info
       responses:
         "200":
-          description: Successful command execution
+          description: Success
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SystemInfoResults'
 components:
   schemas:
+    Algorithm:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        shortName:
+          type: string
+        parameterFormat:
+          type: string
+        parameterSamples:
+          type: array
+          items:
+            type: string
+        helper:
+          type: string
     DeviceConfig:
       type: object
       properties:
@@ -359,10 +443,6 @@ components:
       properties:
         name:
           type: string
-        args:
-          type: object
-          additionalProperties:
-            type: string
     RRMSchedule:
       type: object
       properties:
@@ -401,6 +481,36 @@ components:
       type: object
       properties:
         data:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int32
+    Provider:
+      type: object
+      properties:
+        vendor:
+          type: string
+        vendorShortname:
+          type: string
+        version:
+          type: string
+        about:
+          type: string
+    AlgorithmResult:
+      type: object
+      properties:
+        error:
+          type: string
+        channelMap:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int32
+        txPowerMap:
           type: object
           additionalProperties:
             type: object

--- a/src/main/java/com/facebook/openwifirrm/RRM.java
+++ b/src/main/java/com/facebook/openwifirrm/RRM.java
@@ -29,7 +29,6 @@ import com.facebook.openwifirrm.ucentral.KafkaRunner;
 import com.facebook.openwifirrm.ucentral.UCentralClient;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaConsumer;
 import com.facebook.openwifirrm.ucentral.UCentralKafkaProducer;
-import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.gw.models.SystemInfoResults;
 
 /**
@@ -111,7 +110,7 @@ public class RRM {
 		);
 		ApiServer apiServer = new ApiServer(
 			config.moduleConfig.apiServerParams,
-			UCentralUtils.generateServiceKey(config.serviceConfig),
+			config.serviceConfig,
 			deviceDataManager,
 			configManager,
 			modeler,

--- a/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
@@ -60,10 +60,16 @@ public class RRMAlgorithm {
 		/** The error string, only set upon failure to execute the algorithm. */
 		public String error;
 
-		/** Computed channel assignments. */
+		/**
+		 * Computed channel assignments.
+		 * @see {@link ChannelOptimizer#computeChannelMap()}
+		 */
 		public Map<String, Map<String, Integer>> channelMap;
 
-		/** Computed tx power assignments. */
+		/**
+		 * Computed tx power assignments.
+		 * @see {@link TPC#computeTxPowerMap()}
+		 */
 		public Map<String, Map<String, Integer>> txPowerMap;
 	}
 
@@ -135,7 +141,7 @@ public class RRMAlgorithm {
 	 * @param zone the RF zone
 	 * @param dryRun if set, do not apply changes
 	 * @param allowDefaultMode if false, "mode" argument must be present and
-	 *                         valid (returns false if invalid)
+	 *                         valid (returns error if invalid)
 	 *
 	 * @return the algorithm result, with exactly one field set ("error" upon
 	 *         failure, any others upon success)

--- a/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.facebook.openwifirrm.modules.ConfigManager;
+import com.facebook.openwifirrm.modules.Modeler;
+import com.facebook.openwifirrm.optimizers.ChannelOptimizer;
+import com.facebook.openwifirrm.optimizers.LeastUsedChannelOptimizer;
+import com.facebook.openwifirrm.optimizers.LocationBasedOptimalTPC;
+import com.facebook.openwifirrm.optimizers.MeasurementBasedApApTPC;
+import com.facebook.openwifirrm.optimizers.MeasurementBasedApClientTPC;
+import com.facebook.openwifirrm.optimizers.RandomChannelInitializer;
+import com.facebook.openwifirrm.optimizers.RandomTxPowerInitializer;
+import com.facebook.openwifirrm.optimizers.TPC;
+import com.facebook.openwifirrm.optimizers.UnmanagedApAwareChannelOptimizer;
+
+/**
+ * RRM algorithm model and utility methods.
+ */
+public class RRMAlgorithm {
+	private static final Logger logger = LoggerFactory.getLogger(RRMAlgorithm.class);
+
+	/** RRM algorithm type enum. */
+	public enum AlgorithmType {
+		OptimizeChannel (
+			"Optimize channel configuration",
+			"Run channel optimization algorithm"
+		),
+		OptimizeTxPower (
+			"Optimize tx power configuration",
+			"Run transmit power control algorithm"
+		);
+
+		/** The long name. */
+		public final String longName;
+		/** The description. */
+		public final String description;
+
+		/** Constructor. */
+		AlgorithmType(String longName, String description) {
+			this.longName = longName;
+			this.description = description;
+		}
+	}
+
+	/** RRM algorithm result. */
+	public static class AlgorithmResult {
+		/** The error string, only set upon failure to execute the algorithm. */
+		public String error;
+
+		/** Computed channel assignments. */
+		public Map<String, Map<String, Integer>> channelMap;
+
+		/** Computed tx power assignments. */
+		public Map<String, Map<String, Integer>> txPowerMap;
+	}
+
+	/** The algorithm name (should be AlgorithmType enum string). */
+	private final String name;
+
+	/** The algorithm arguments. */
+	private final Map<String, String> args;
+
+	/** Constructor (with no arguments). */
+	public RRMAlgorithm(String name) {
+		this(name, null);
+	}
+
+	/** Constructor. */
+	public RRMAlgorithm(String name, Map<String, String> args) {
+		if (name == null) {
+			throw new NullPointerException("name is null");
+		}
+		this.name = name;
+		this.args = args != null ? args : new HashMap<>(0);
+	}
+
+	/**
+	 * Construct an RRMAlgorithm with a raw arguments string.
+	 *
+	 * @param name the algorithm name, which must exist in {@link AlgorithmType}
+	 * @param argsRaw the arguments as a comma-separated list of key=value
+	 *                pairs, e.g. <tt> key1=val1,key2=val2,key3=val3</tt>
+	 *
+	 * @return the parsed object, or null if parsing failed
+	 */
+	public static RRMAlgorithm parse(String name, String argsRaw) {
+		try {
+			AlgorithmType.valueOf(name);
+		} catch (IllegalArgumentException e) {
+			logger.error("Parse error, unknown algorithm name: '{}'", name);
+			return null;  // unsupported algorithm
+		}
+
+		Map<String, String> args = new HashMap<>();
+		for (String s : argsRaw.split(",")) {
+			if (s.isEmpty()) {
+				continue;
+			}
+			String[] kv = s.split("=", 2);
+			if (kv.length != 2) {
+				logger.error("Parse error, invalid key=value arg: '{}'", s);
+				return null;  // invalid key-value pair
+			}
+			if (args.putIfAbsent(kv[0], kv[1]) != null) {
+				logger.error("Parse error, duplicate arg: '{}'", kv[0]);
+				return null;  // duplicate key
+			}
+		}
+
+		return new RRMAlgorithm(name, args);
+	}
+
+	/** Return the algorithm name. */
+	public String getName() { return name; }
+
+	/**
+	 * Run the algorithm.
+	 *
+	 * @param deviceDataManager the device data manager
+	 * @param configManager the ConfigManager module instance
+	 * @param modeler the Modeler module instance
+	 * @param zone the RF zone
+	 * @param dryRun if set, do not apply changes
+	 * @param allowDefaultMode if false, "mode" argument must be present and
+	 *                         valid (returns false if invalid)
+	 *
+	 * @return the algorithm result, with exactly one field set ("error" upon
+	 *         failure, any others upon success)
+	 */
+	public AlgorithmResult run(
+		DeviceDataManager deviceDataManager,
+		ConfigManager configManager,
+		Modeler modeler,
+		String zone,
+		boolean dryRun,
+		boolean allowDefaultMode
+	) {
+		AlgorithmResult result = new AlgorithmResult();
+		if (name == null || args == null) {
+			result.error = "Null algorithm name or arguments?";  // shouldn't happen
+			return result;
+		}
+
+		// Get mode (i.e. specific algorithm)
+		String mode = args.getOrDefault("mode", "");
+		String modeErrorStr = String.format(
+			"Unknown mode '%s' provided for algorithm '%s'", mode, name
+		);
+
+		// Find algorithm to run
+		if (name.equals(RRMAlgorithm.AlgorithmType.OptimizeChannel.name())) {
+			logger.info(
+				"Zone '{}': Running channel optimizer (mode='{}')", zone, mode
+			);
+			ChannelOptimizer optimizer;
+			switch (mode) {
+			default:
+				if (!allowDefaultMode || !mode.isEmpty()) {
+					result.error = modeErrorStr;
+					return result;
+				}
+				logger.info("Using default algorithm mode...");
+				// fall through
+			case UnmanagedApAwareChannelOptimizer.ALGORITHM_ID:
+				optimizer = new UnmanagedApAwareChannelOptimizer(
+					modeler.getDataModelCopy(), zone, deviceDataManager
+				);
+				break;
+			case RandomChannelInitializer.ALGORITHM_ID:
+				optimizer = new RandomChannelInitializer(
+					modeler.getDataModelCopy(), zone, deviceDataManager
+				);
+				break;
+			case LeastUsedChannelOptimizer.ALGORITHM_ID:
+				optimizer = new LeastUsedChannelOptimizer(
+					modeler.getDataModelCopy(), zone, deviceDataManager
+				);
+				break;
+			}
+			result.channelMap = optimizer.computeChannelMap();
+			if (!dryRun) {
+				optimizer.applyConfig(
+					deviceDataManager, configManager, result.channelMap
+				);
+			}
+		} else if (name.equals(RRMAlgorithm.AlgorithmType.OptimizeTxPower.name())) {
+			logger.info(
+				"Zone '{}': Running tx power optimizer (mode='{}')", zone, mode
+			);
+			TPC optimizer;
+			switch (mode) {
+			default:
+				if (!allowDefaultMode || !mode.isEmpty()) {
+					result.error = modeErrorStr;
+					return result;
+				}
+				logger.info("Using default algorithm mode...");
+				// fall through
+			case MeasurementBasedApApTPC.ALGORITHM_ID:
+				optimizer = new MeasurementBasedApApTPC(
+					modeler.getDataModelCopy(), zone, deviceDataManager
+				);
+				break;
+			case RandomTxPowerInitializer.ALGORITHM_ID:
+				optimizer = new RandomTxPowerInitializer(
+					modeler.getDataModelCopy(), zone, deviceDataManager
+				);
+				break;
+			case MeasurementBasedApClientTPC.ALGORITHM_ID:
+				optimizer = new MeasurementBasedApClientTPC(
+					modeler.getDataModelCopy(), zone, deviceDataManager
+				);
+				break;
+			case LocationBasedOptimalTPC.ALGORITHM_ID:
+				optimizer = new LocationBasedOptimalTPC(
+					modeler.getDataModelCopy(), zone, deviceDataManager
+				);
+				break;
+			}
+			result.txPowerMap = optimizer.computeTxPowerMap();
+			if (!dryRun) {
+				optimizer.applyConfig(
+					deviceDataManager, configManager, result.txPowerMap
+				);
+			}
+		} else {
+			result.error = String.format("Unknown algorithm: '%s'", name);
+		}
+		return result;
+	}
+}

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -41,6 +41,24 @@ public class RRMConfig {
 		 * (<tt>SERVICECONFIG_PUBLICENDPOINT</tt>)
 		 */
 		public String publicEndpoint = "";
+
+		/**
+		 * RRM vendor name
+		 * (<tt>SERVICECONFIG_VENDOR</tt>)
+		 */
+		public String vendor = "Meta";
+
+		/**
+		 * RRM vendor URL
+		 * (<tt>SERVICECONFIG_VENDORURL</tt>)
+		 */
+		public String vendorUrl = "https://github.com/Telecominfraproject/wlan-cloud-rrm";
+
+		/**
+		 * RRM reference URL
+		 * (<tt>SERVICECONFIG_VENDORREFERENCEURL</tt>)
+		 */
+		public String vendorReferenceUrl = "https://github.com/Telecominfraproject/wlan-cloud-rrm/blob/main/ALGORITHMS.md";
 	}
 
 	/** Service configuration. */
@@ -389,6 +407,15 @@ public class RRMConfig {
 		}
 		if ((v = env.get("SERVICECONFIG_PUBLICENDPOINT")) != null) {
 			serviceConfig.publicEndpoint = v;
+		}
+		if ((v = env.get("SERVICECONFIG_VENDOR")) != null) {
+			serviceConfig.vendor = v;
+		}
+		if ((v = env.get("SERVICECONFIG_VENDORURL")) != null) {
+			serviceConfig.vendorUrl = v;
+		}
+		if ((v = env.get("SERVICECONFIG_VENDORREFERENCEURL")) != null) {
+			serviceConfig.vendorReferenceUrl = v;
 		}
 
 		/* UCentralConfig */

--- a/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
@@ -9,7 +9,6 @@
 package com.facebook.openwifirrm;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * RRM schedule config.
@@ -30,19 +29,4 @@ public class RRMSchedule {
 	 * If empty, all algorithms will be run using default settings.
 	 */
 	public List<RRMAlgorithm> algorithms;
-
-	/** RRM algorithm name and arguments. */
-	public static class RRMAlgorithm {
-		/** The algorithm name. */
-		public String name;
-
-		/** The algorithm arguments. */
-		public Map<String, String> args;
-
-		/** Constructor. */
-		public RRMAlgorithm(String name, Map<String, String> args) {
-			this.name = name;
-			this.args = args;
-		}
-	}
 }

--- a/src/main/java/com/facebook/openwifirrm/optimizers/ChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/ChannelOptimizer.java
@@ -374,7 +374,7 @@ public abstract class ChannelOptimizer {
 			if (scanRespsFiltered.size() == 0) {
 				// 3. Filter out APs with empty scan results (on a particular band)
 				logger.debug(
-					"Device {}: Empty wifi scan results on {} band, skipping..",
+					"Device {}: Empty wifi scan results on {} band, skipping...",
 					serialNumber,
 					band
 				);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/LeastUsedChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/LeastUsedChannelOptimizer.java
@@ -35,6 +35,9 @@ import com.facebook.openwifirrm.ucentral.models.State;
 public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 	private static final Logger logger = LoggerFactory.getLogger(LeastUsedChannelOptimizer.class);
 
+	/** The RRM algorithm ID. */
+	public static final String ALGORITHM_ID = "least_used";
+
 	/** The window size for overlapping channels. */
 	protected static final int OVERLAP_WINDOW = 4;
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/LocationBasedOptimalTPC.java
@@ -22,9 +22,9 @@ import org.slf4j.LoggerFactory;
 import com.facebook.openwifirrm.DeviceConfig;
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
+import com.facebook.openwifirrm.modules.ModelerUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.models.State;
-import com.facebook.openwifirrm.modules.ModelerUtils;
 
 /**
  * Location-based optimal TPC algorithm.
@@ -33,6 +33,9 @@ import com.facebook.openwifirrm.modules.ModelerUtils;
  */
 public class LocationBasedOptimalTPC extends TPC {
 	private static final Logger logger = LoggerFactory.getLogger(LocationBasedOptimalTPC.class);
+
+	/** The RRM algorithm ID. */
+	public static final String ALGORITHM_ID = "location_optimal";
 
 	/** Constructor. */
 	public LocationBasedOptimalTPC(
@@ -165,8 +168,8 @@ public class LocationBasedOptimalTPC extends TPC {
 			// Generate the required location data for the optimization
 			if (
 				deviceCfg.location.size() == 2 &&
-				deviceCfg.location.get(0) >= 0 && 
-				deviceCfg.location.get(1) >= 0 
+				deviceCfg.location.get(0) >= 0 &&
+				deviceCfg.location.get(1) >= 0
 			) {
 				apLocX.add(deviceCfg.location.get(0).doubleValue());
 				apLocY.add(deviceCfg.location.get(1).doubleValue());

--- a/src/main/java/com/facebook/openwifirrm/optimizers/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/MeasurementBasedApApTPC.java
@@ -38,6 +38,9 @@ import com.google.gson.JsonObject;
 public class MeasurementBasedApApTPC extends TPC {
 	private static final Logger logger = LoggerFactory.getLogger(MeasurementBasedApApTPC.class);
 
+	/** The RRM algorithm ID. */
+	public static final String ALGORITHM_ID = "measure_ap_ap";
+
 	/**
 	 * Default coverage threshold between APs, in dBm.
 	 *

--- a/src/main/java/com/facebook/openwifirrm/optimizers/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/MeasurementBasedApClientTPC.java
@@ -32,12 +32,15 @@ import com.google.gson.JsonObject;
 public class MeasurementBasedApClientTPC extends TPC {
 	private static final Logger logger = LoggerFactory.getLogger(MeasurementBasedApClientTPC.class);
 
+	/** The RRM algorithm ID. */
+	public static final String ALGORITHM_ID = "measure_ap_client";
+
 	/** Default target MCS index. */
 	public static final int DEFAULT_TARGET_MCS = 8;
 
 	/** Default tx power. */
 	public static final int DEFAULT_TX_POWER = 10;
-	
+
 	/** Mapping of MCS index to required SNR (dB) in 802.11ac. */
 	private static final List<Double> MCS_TO_SNR = Collections.unmodifiableList(
 		Arrays.asList(

--- a/src/main/java/com/facebook/openwifirrm/optimizers/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/RandomChannelInitializer.java
@@ -33,6 +33,9 @@ import com.facebook.openwifirrm.ucentral.models.State;
 public class RandomChannelInitializer extends ChannelOptimizer {
 	private static final Logger logger = LoggerFactory.getLogger(RandomChannelInitializer.class);
 
+	/** The RRM algorithm ID. */
+	public static final String ALGORITHM_ID = "random";
+
 	/** The PRNG instance. */
 	private final Random rng = new Random();
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/RandomTxPowerInitializer.java
@@ -26,6 +26,9 @@ import com.facebook.openwifirrm.ucentral.UCentralConstants;
 public class RandomTxPowerInitializer extends TPC {
 	private static final Logger logger = LoggerFactory.getLogger(RandomTxPowerInitializer.class);
 
+	/** The RRM algorithm ID. */
+	public static final String ALGORITHM_ID = "random";
+
 	/** Default tx power. */
 	public static final int DEFAULT_TX_POWER = 23;
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/UnmanagedApAwareChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/UnmanagedApAwareChannelOptimizer.java
@@ -25,11 +25,14 @@ import com.facebook.openwifirrm.ucentral.UCentralUtils.WifiScanEntry;
 /**
  * Unmanaged AP aware least used channel optimizer.
  * <p>
- * Randomly assign APs to the channel with the least channel weight, 
+ * Randomly assign APs to the channel with the least channel weight,
  * where channel weight = DEFAULT_WEIGHT * (number of unmanaged APs) + (number of managed APs).
  */
 public class UnmanagedApAwareChannelOptimizer extends LeastUsedChannelOptimizer {
 	private static final Logger logger = LoggerFactory.getLogger(UnmanagedApAwareChannelOptimizer.class);
+
+	/** The RRM algorithm ID. */
+	public static final String ALGORITHM_ID = "unmanaged_aware";
 
 	/** The default weight for nonOWF APs. */
 	private static final int DEFAULT_WEIGHT = 2;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/rrm/models/Algorithm.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/rrm/models/Algorithm.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.prov.rrm.models;
+
+import java.util.List;
+
+public class Algorithm {
+	public String name;
+	public String description;
+	public String shortName;
+	public String parameterFormat;
+	public List<String> parameterSamples;
+	public String helper;
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/prov/rrm/models/Provider.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/prov/rrm/models/Provider.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.prov.rrm.models;
+
+public class Provider {
+	public String vendor;
+	public String vendorShortname;
+	public String version;
+	public String about;
+}


### PR DESCRIPTION
Implement owprov `rrm_provider.yaml` API: https://github.com/Telecominfraproject/wlan-cloud-owprov/blob/efd7ef2a9b5958fc699c3adbbee9923959054338/openapi/rrm_provider.yaml
- `GET /api/v1/provider`
- `GET /api/v1/algorithms`
- `PUT /api/v1/runRRM`

Details:
- Create `RRMAlgorithm` class which consolidates some previously duplicated logic for executing RRM algorithms in `ApiServer` and `RRMScheduler`.
    - `AlgorithmType` enum is now used for owprov APIs as well as scheduler config
    - `AlgorithmResult` encapsulates possible responses and is returned by `PUT /api/v1/runRRM`
    - Algorithm arguments from owprov APIs are parsed as comma-separated key=value pairs
- Add several `ServiceConfig` fields to handle new owprov API getters.
- Move "mode" names into optimizer classes as a static field `ALGORITHM_ID` instead of hardcoding them all over the place.
- Update `ALGORITHMS.md` to list parameters for each algorithm (supporting of other params TODO).