### PR TITLE
OpenAPI fixes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -62,6 +62,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeviceConfig'
+        "400":
+          description: Bad Request
   /api/v1/getDeviceLayeredConfig:
     get:
       tags:
@@ -116,7 +118,7 @@ paths:
         "200":
           description: Success
         "400":
-          description: Bad request
+          description: Bad Request
   /api/v1/optimizeChannel:
     get:
       tags:
@@ -155,6 +157,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ChannelAllocation'
+        "400":
+          description: Bad Request
   /api/v1/optimizeTxPower:
     get:
       tags:
@@ -195,6 +199,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TxPowerAllocation'
+        "400":
+          description: Bad Request
   /api/v1/provider:
     get:
       tags:
@@ -246,6 +252,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AlgorithmResult'
+        "400":
+          description: Bad Request
   /api/v1/setDeviceApConfig:
     post:
       tags:
@@ -271,7 +279,7 @@ paths:
         "200":
           description: Success
         "400":
-          description: Bad request
+          description: Bad Request
   /api/v1/setDeviceNetworkConfig:
     post:
       tags:
@@ -290,7 +298,7 @@ paths:
         "200":
           description: Success
         "400":
-          description: Bad request
+          description: Bad Request
   /api/v1/setDeviceZoneConfig:
     post:
       tags:
@@ -316,7 +324,7 @@ paths:
         "200":
           description: Success
         "400":
-          description: Bad request
+          description: Bad Request
   /api/v1/setTopology:
     post:
       tags:
@@ -335,7 +343,7 @@ paths:
         "200":
           description: Success
         "400":
-          description: Bad request
+          description: Bad Request
   /api/v1/system:
     get:
       tags:
@@ -359,6 +367,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SystemInfoResults'
+        "400":
+          description: Bad Request
 components:
   schemas:
     Algorithm:

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -427,7 +427,8 @@ public class ApiServer implements Runnable {
 					content = @Content(
 						schema = @Schema(implementation = SystemInfoResults.class)
 					)
-				)
+				),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -587,7 +588,8 @@ public class ApiServer implements Runnable {
 					content = @Content(
 						schema = @Schema(implementation = RRMAlgorithm.AlgorithmResult.class)
 					)
-				)
+				),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -682,14 +684,8 @@ public class ApiServer implements Runnable {
 				required = true
 			),
 			responses = {
-				@ApiResponse(
-					responseCode = "200",
-					description = "Success"
-				),
-				@ApiResponse(
-					responseCode = "400",
-					description = "Bad request"
-				)
+				@ApiResponse(responseCode = "200", description = "Success"),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -770,7 +766,8 @@ public class ApiServer implements Runnable {
 					content = @Content(
 						schema = @Schema(implementation = DeviceConfig.class)
 					)
-				)
+				),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -817,14 +814,8 @@ public class ApiServer implements Runnable {
 				required = true
 			),
 			responses = {
-				@ApiResponse(
-					responseCode = "200",
-					description = "Success"
-				),
-				@ApiResponse(
-					responseCode = "400",
-					description = "Bad request"
-				)
+				@ApiResponse(responseCode = "200", description = "Success"),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -880,14 +871,8 @@ public class ApiServer implements Runnable {
 				required = true
 			),
 			responses = {
-				@ApiResponse(
-					responseCode = "200",
-					description = "Success"
-				),
-				@ApiResponse(
-					responseCode = "400",
-					description = "Bad request"
-				)
+				@ApiResponse(responseCode = "200", description = "Success"),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -949,14 +934,8 @@ public class ApiServer implements Runnable {
 				required = true
 			),
 			responses = {
-				@ApiResponse(
-					responseCode = "200",
-					description = "Success"
-				),
-				@ApiResponse(
-					responseCode = "400",
-					description = "Bad request"
-				)
+				@ApiResponse(responseCode = "200", description = "Success"),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -1017,14 +996,8 @@ public class ApiServer implements Runnable {
 				required = true
 			),
 			responses = {
-				@ApiResponse(
-					responseCode = "200",
-					description = "Success"
-				),
-				@ApiResponse(
-					responseCode = "400",
-					description = "Bad request"
-				)
+				@ApiResponse(responseCode = "200", description = "Success"),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -1158,7 +1131,8 @@ public class ApiServer implements Runnable {
 							implementation = ChannelAllocation.class
 						)
 					)
-				)
+				),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override
@@ -1262,7 +1236,8 @@ public class ApiServer implements Runnable {
 							implementation = TxPowerAllocation.class
 						)
 					)
-				)
+				),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
 			}
 		)
 		@Override

--- a/src/main/resources/public/swagger-initializer.js
+++ b/src/main/resources/public/swagger-initializer.js
@@ -4,6 +4,11 @@ window.onload = function() {
     defaultModelsExpandDepth: 0,
     dom_id: '#swagger-ui',
     deepLinking: true,
+    syntaxHighlight: {
+      /* https://github.com/swagger-api/swagger-ui/issues/3832 */
+      activated: false,
+      theme: "agate"
+    },
     presets: [
       SwaggerUIBundle.presets.apis,
       SwaggerUIStandalonePreset


### PR DESCRIPTION
- Add missing 400 response codes in several endpoint descriptions
- Disable syntax highlighting in Swagger UI because it causes large (~1mb+) response bodies to hang the UI