### PR TITLE
Handle empty topology file

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
@@ -114,7 +114,6 @@ public class DeviceDataManager {
 			} else {
 				topo = gson.fromJson(contents, DeviceTopology.class);
 			}
-
 		}
 		validateTopology(topo);
 		return topo;

--- a/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
@@ -106,7 +106,15 @@ public class DeviceDataManager {
 			// Read file
 			logger.info("Reading topology file '{}'", topologyFile.getPath());
 			String contents = Utils.readFile(topologyFile);
-			topo = gson.fromJson(contents, DeviceTopology.class);
+			if (contents == null || contents.isBlank()) {
+				// Blank file, write defaults to disk
+				logger.info("Topology file '{}' is blank, writing to it...", topologyFile.getPath());
+				topo = new DeviceTopology();
+				Utils.writeJsonFile(topologyFile, topo);
+			} else {
+				topo = gson.fromJson(contents, DeviceTopology.class);
+			}
+
 		}
 		validateTopology(topo);
 		return topo;

--- a/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
@@ -129,7 +129,7 @@ public class DeviceDataManager {
 		}
 		if (cfg == null) {
 			// Missing/empty file, write defaults to disk
-			logger.info("Creating default config file '{}'", deviceConfigFile.getPath());
+			logger.info("Creating default device config file '{}'", deviceConfigFile.getPath());
 			cfg = new DeviceLayeredConfig();
 			Utils.writeJsonFile(deviceConfigFile, cfg);
 		} else {

--- a/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
@@ -108,7 +108,7 @@ public class DeviceDataManager {
 			String contents = Utils.readFile(topologyFile);
 			if (contents == null || contents.isBlank()) {
 				// Blank file, write defaults to disk
-				logger.info("Topology file '{}' is blank, writing to it...", topologyFile.getPath());
+				logger.info("Topology file '{}' is blank, writing defaults to it...", topologyFile.getPath());
 				topo = new DeviceTopology();
 				Utils.writeJsonFile(topologyFile, topo);
 			} else {
@@ -132,7 +132,7 @@ public class DeviceDataManager {
 		if (!deviceConfigFile.isFile()) {
 			// No file, write defaults to disk
 			logger.info(
-				"Device config file '{}' does not exist, creating it...",
+					"Device config file '{}' does not exist, creating it...",
 				deviceConfigFile.getPath()
 			);
 			cfg = new DeviceLayeredConfig();
@@ -143,7 +143,13 @@ public class DeviceDataManager {
 				"Reading device config file '{}'", deviceConfigFile.getPath()
 			);
 			String contents = Utils.readFile(deviceConfigFile);
-			cfg = gson.fromJson(contents, DeviceLayeredConfig.class);
+			if (contents == null || contents.isBlank()) {
+				cfg = new DeviceLayeredConfig();
+				Utils.writeJsonFile(deviceConfigFile, cfg);
+			} else {
+				logger.info("Device config file '{}' is blank, writing defaults to it...", deviceConfigFile.getPath());
+				cfg = gson.fromJson(contents, DeviceLayeredConfig.class);
+			}
 
 			// Sanitize config (NOTE: topology must be initialized!)
 			boolean modified = sanitizeDeviceLayeredConfig(cfg);

--- a/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
@@ -93,26 +93,19 @@ public class DeviceDataManager {
 	 * @throws IOException
 	 */
 	private DeviceTopology readTopology(File topologyFile) throws IOException {
-		DeviceTopology topo;
-		if (!topologyFile.isFile()) {
-			// No file, write defaults to disk
-			logger.info(
-				"Topology file '{}' does not exist, creating it...",
-				topologyFile.getPath()
-			);
-			topo = new DeviceTopology();
-			Utils.writeJsonFile(topologyFile, topo);
-		} else {
+		DeviceTopology topo = null;
+
+		if (topologyFile.isFile()) {
 			// Read file
 			logger.info("Reading topology file '{}'", topologyFile.getPath());
 			String contents = Utils.readFile(topologyFile);
-			if (contents == null || contents.isBlank()) {
-				logger.info("Topology file '{}' is blank, writing defaults to it...", topologyFile.getPath());
-				topo = new DeviceTopology();
-				Utils.writeJsonFile(topologyFile, topo);
-			} else {
-				topo = gson.fromJson(contents, DeviceTopology.class);
-			}
+			topo = gson.fromJson(contents, DeviceTopology.class);
+		}
+		if (topo == null) {
+			// Missing/empty file, write defaults to disk
+			logger.info("Creating default topology file '{}'", topologyFile.getPath());
+			topo = new DeviceTopology();
+			Utils.writeJsonFile(topologyFile, topo);
 		}
 		validateTopology(topo);
 		return topo;
@@ -127,29 +120,19 @@ public class DeviceDataManager {
 	 */
 	private DeviceLayeredConfig readDeviceLayeredConfig(File deviceConfigFile)
 		throws IOException {
-		DeviceLayeredConfig cfg;
-		if (!deviceConfigFile.isFile()) {
-			// No file, write defaults to disk
-			logger.info(
-				"Device config file '{}' does not exist, creating it...",
-				deviceConfigFile.getPath()
-			);
+		DeviceLayeredConfig cfg = null;
+		if (deviceConfigFile.isFile()) {
+			// Read file
+			logger.info("Reading device config file '{}'", deviceConfigFile.getPath());
+			String contents = Utils.readFile(deviceConfigFile);
+			cfg = gson.fromJson(contents, DeviceLayeredConfig.class);
+		}
+		if (cfg == null) {
+			// Missing/empty file, write defaults to disk
+			logger.info("Creating default config file '{}'", deviceConfigFile.getPath());
 			cfg = new DeviceLayeredConfig();
 			Utils.writeJsonFile(deviceConfigFile, cfg);
 		} else {
-			// Read file
-			logger.info(
-				"Reading device config file '{}'", deviceConfigFile.getPath()
-			);
-			String contents = Utils.readFile(deviceConfigFile);
-			if (contents == null || contents.isBlank()) {
-				cfg = new DeviceLayeredConfig();
-				Utils.writeJsonFile(deviceConfigFile, cfg);
-			} else {
-				logger.info("Device config file '{}' is blank, writing defaults to it...", deviceConfigFile.getPath());
-				cfg = gson.fromJson(contents, DeviceLayeredConfig.class);
-			}
-
 			// Sanitize config (NOTE: topology must be initialized!)
 			boolean modified = sanitizeDeviceLayeredConfig(cfg);
 			if (modified) {

--- a/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
@@ -107,7 +107,6 @@ public class DeviceDataManager {
 			logger.info("Reading topology file '{}'", topologyFile.getPath());
 			String contents = Utils.readFile(topologyFile);
 			if (contents == null || contents.isBlank()) {
-				// Blank file, write defaults to disk
 				logger.info("Topology file '{}' is blank, writing defaults to it...", topologyFile.getPath());
 				topo = new DeviceTopology();
 				Utils.writeJsonFile(topologyFile, topo);
@@ -132,7 +131,7 @@ public class DeviceDataManager {
 		if (!deviceConfigFile.isFile()) {
 			// No file, write defaults to disk
 			logger.info(
-					"Device config file '{}' does not exist, creating it...",
+				"Device config file '{}' does not exist, creating it...",
 				deviceConfigFile.getPath()
 			);
 			cfg = new DeviceLayeredConfig();

--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -83,6 +83,7 @@ public class Launcher implements Callable<Integer> {
 			logger.info("Reading config file '{}'", configFile.getPath());
 			String contents = Utils.readFile(configFile);
 			if (contents == null || contents.isBlank()) {
+				logger.info("Config file '{}' does not exist, writing defaults it...", configFile.getPath());
 				config = new RRMConfig();
 				Utils.writeJsonFile(configFile, config);
 			} else {

--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -82,21 +82,23 @@ public class Launcher implements Callable<Integer> {
 			// Read file
 			logger.info("Reading config file '{}'", configFile.getPath());
 			String contents = Utils.readFile(configFile);
-			JSONObject userConfig = new JSONObject(contents);
-
-			// In case of any added/missing values, we want to build off the
-			// defaults in RRMConfig, so this code gets more complex...
-			JSONObject fullConfig =
-				new JSONObject(gson.toJson(new RRMConfig()));
-			Utils.jsonMerge(fullConfig, userConfig);
-			config = gson.fromJson(fullConfig.toString(), RRMConfig.class);
-
-			// Compare merged config with contents as read from disk
-			// If any differences (ex. added fields), overwrite config file
-			if (!fullConfig.toString().equals(userConfig.toString())) {
-				logger.info("Rewriting config file with new changes...");
-				try (Writer writer = new FileWriter(configFile)) {
-					gson.toJson(config, writer);
+			if (contents == null || contents.isBlank()) {
+				config = new RRMConfig();
+				Utils.writeJsonFile(configFile, config);
+			} else {
+				JSONObject userConfig = new JSONObject(contents);
+				// In case of any added/missing values, we want to build off the
+				// defaults in RRMConfig, so this code gets more complex...
+				JSONObject fullConfig = new JSONObject(gson.toJson(new RRMConfig()));
+				Utils.jsonMerge(fullConfig, userConfig);
+				config = gson.fromJson(fullConfig.toString(), RRMConfig.class);
+				// Compare merged config with contents as read from disk
+				// If any differences (ex. added fields), overwrite config file
+				if (!fullConfig.toString().equals(userConfig.toString())) {
+					logger.info("Rewriting config file with new changes...");
+					try (Writer writer = new FileWriter(configFile)) {
+						gson.toJson(config, writer);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Handle blank input files (blank meaning containing no characters or only whitespace), which was not handled before. Only "empty JSONs" (i.e., `{}`) were handled before.

Signed-off-by: Rocky Mandayam <rockymandayam@fb.com>