### PR TITLE
Configure javadoc, fix errors, deploy to gh-pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: mvn javadoc:javadoc
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/site/apidocs
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OpenWiFi RRM Service
-OpenWiFi uCentral-based radio resource management service.
+OpenWiFi uCentral-based radio resource management (RRM) service.
 
 ## Requirements
 * **Running:** JRE 11.

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,16 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.4.1</version>
+        <configuration>
+          <doclint>all,-missing</doclint>
+          <notimestamp>true</notimestamp>
+          <bottom>Copyright &#169; Meta Platforms, Inc. and affiliates.</bottom>
+        </configuration>
+      </plugin>
+      <plugin>
         <!-- Generate "openapi.yaml" in project root, NOT packaged -->
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-maven-plugin</artifactId>

--- a/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceDataManager.java
@@ -72,7 +72,7 @@ public class DeviceDataManager {
 	 * Initialize from the given files.
 	 * @param topologyFile the {@link DeviceTopology} file
 	 * @param deviceLayeredConfigFile the {@link DeviceLayeredConfig} file
-	 * @throws IOException
+	 * @throws IOException if file I/O fails
 	 */
 	public DeviceDataManager(File topologyFile, File deviceLayeredConfigFile)
 		throws IOException {
@@ -90,7 +90,7 @@ public class DeviceDataManager {
 	 *
 	 * If the file does not exist, try to create it.
 	 *
-	 * @throws IOException
+	 * @throws IOException if file I/O fails
 	 */
 	private DeviceTopology readTopology(File topologyFile) throws IOException {
 		DeviceTopology topo;
@@ -117,7 +117,7 @@ public class DeviceDataManager {
 	 *
 	 * If the file does not exist, try to create it.
 	 *
-	 * @throws IOException
+	 * @throws IOException if file I/O fails
 	 */
 	private DeviceLayeredConfig readDeviceLayeredConfig(File deviceConfigFile)
 		throws IOException {

--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -64,7 +64,7 @@ public class Launcher implements Callable<Integer> {
 	 * If the file is missing any default fields in {@link RRMConfig}, try to
 	 * rewrite it.
 	 *
-	 * @throws IOException
+	 * @throws IOException if file I/O fails
 	 */
 	private RRMConfig readRRMConfig(File configFile) throws IOException {
 		RRMConfig config;

--- a/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
@@ -62,13 +62,13 @@ public class RRMAlgorithm {
 
 		/**
 		 * Computed channel assignments.
-		 * @see {@link ChannelOptimizer#computeChannelMap()}
+		 * @see ChannelOptimizer#computeChannelMap()
 		 */
 		public Map<String, Map<String, Integer>> channelMap;
 
 		/**
 		 * Computed tx power assignments.
-		 * @see {@link TPC#computeTxPowerMap()}
+		 * @see TPC#computeTxPowerMap()
 		 */
 		public Map<String, Map<String, Integer>> txPowerMap;
 	}
@@ -98,7 +98,7 @@ public class RRMAlgorithm {
 	 *
 	 * @param name the algorithm name, which must exist in {@link AlgorithmType}
 	 * @param argsRaw the arguments as a comma-separated list of key=value
-	 *                pairs, e.g. <tt> key1=val1,key2=val2,key3=val3</tt>
+	 *                pairs, e.g. <code> key1=val1,key2=val2,key3=val3</code>
 	 *
 	 * @return the parsed object, or null if parsing failed
 	 */

--- a/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
@@ -98,7 +98,7 @@ public class RRMAlgorithm {
 	 *
 	 * @param name the algorithm name, which must exist in {@link AlgorithmType}
 	 * @param argsRaw the arguments as a comma-separated list of key=value
-	 *                pairs, e.g. <code> key1=val1,key2=val2,key3=val3</code>
+	 *                pairs, e.g. {@code key1=val1,key2=val2,key3=val3}
 	 *
 	 * @return the parsed object, or null if parsing failed
 	 */

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -20,43 +20,43 @@ public class RRMConfig {
 	public class ServiceConfig {
 		/**
 		 * RRM service name/type
-		 * (<tt>SERVICECONFIG_NAME</tt>)
+		 * (<code>SERVICECONFIG_NAME</code>)
 		 */
 		public String name = "owrrm";
 
 		/**
 		 * RRM service ID (random persistent number)
-		 * (<tt>SERVICECONFIG_NAME</tt>)
+		 * (<code>SERVICECONFIG_NAME</code>)
 		 */
 		public long id = (long) (Math.random() * Long.MAX_VALUE);
 
 		/**
 		 * Private endpoint for the RRM service
-		 * (<tt>SERVICECONFIG_PRIVATEENDPOINT</tt>)
+		 * (<code>SERVICECONFIG_PRIVATEENDPOINT</code>)
 		 */
 		public String privateEndpoint = "http://owrrm.wlan.local:16789";  // see ApiServerParams.httpPort
 
 		/**
 		 * Public endpoint for the RRM service
-		 * (<tt>SERVICECONFIG_PUBLICENDPOINT</tt>)
+		 * (<code>SERVICECONFIG_PUBLICENDPOINT</code>)
 		 */
 		public String publicEndpoint = "";
 
 		/**
 		 * RRM vendor name
-		 * (<tt>SERVICECONFIG_VENDOR</tt>)
+		 * (<code>SERVICECONFIG_VENDOR</code>)
 		 */
 		public String vendor = "Meta";
 
 		/**
 		 * RRM vendor URL
-		 * (<tt>SERVICECONFIG_VENDORURL</tt>)
+		 * (<code>SERVICECONFIG_VENDORURL</code>)
 		 */
 		public String vendorUrl = "https://github.com/Telecominfraproject/wlan-cloud-rrm";
 
 		/**
 		 * RRM reference URL
-		 * (<tt>SERVICECONFIG_VENDORREFERENCEURL</tt>)
+		 * (<code>SERVICECONFIG_VENDORREFERENCEURL</code>)
 		 */
 		public String vendorReferenceUrl = "https://github.com/Telecominfraproject/wlan-cloud-rrm/blob/main/ALGORITHMS.md";
 	}
@@ -70,25 +70,25 @@ public class RRMConfig {
 	public class UCentralConfig {
 		/**
 		 * If set, use public service endpoints instead of private ones
-		 * (<tt>UCENTRALCONFIG_USEPUBLICENDPOINTS</tt>)
+		 * (<code>UCENTRALCONFIG_USEPUBLICENDPOINTS</code>)
 		 */
 		public boolean usePublicEndpoints = false;
 
 		/**
 		 * uCentralSec public endpoint
-		 * (<tt>UCENTRALCONFIG_UCENTRALSECPUBLICENDPOINT</tt>)
+		 * (<code>UCENTRALCONFIG_UCENTRALSECPUBLICENDPOINT</code>)
 		 */
 		public String uCentralSecPublicEndpoint = "";
 
 		/**
 		 * uCentral username (for public endpoints only)
-		 * (<tt>UCENTRALCONFIG_USERNAME</tt>)
+		 * (<code>UCENTRALCONFIG_USERNAME</code>)
 		 */
 		public String username = "tip@ucentral.com";
 
 		/**
 		 * uCentral password (for public endpoints only)
-		 * (<tt>UCENTRALCONFIG_PASSWORD</tt>)
+		 * (<code>UCENTRALCONFIG_PASSWORD</code>)
 		 */
 		public String password = "";
 
@@ -98,19 +98,19 @@ public class RRMConfig {
 		public class UCentralSocketParams {
 			/**
 			 * Connection timeout for all requests, in ms
-			 * (<tt>UCENTRALSOCKETPARAMS_CONNECTTIMEOUTMS</tt>)
+			 * (<code>UCENTRALSOCKETPARAMS_CONNECTTIMEOUTMS</code>)
 			 */
 			public int connectTimeoutMs = 2000;
 
 			/**
 			 * Socket timeout for all requests, in ms
-			 * (<tt>UCENTRALSOCKETPARAMS_SOCKETTIMEOUTMS</tt>)
+			 * (<code>UCENTRALSOCKETPARAMS_SOCKETTIMEOUTMS</code>)
 			 */
 			public int socketTimeoutMs = 15000;
 
 			/**
 			 * Socket timeout for wifi scan requests, in ms
-			 * (<tt>UCENTRALSOCKETPARAMS_WIFISCANTIMEOUTMS</tt>)
+			 * (<code>UCENTRALSOCKETPARAMS_WIFISCANTIMEOUTMS</code>)
 			 */
 			public int wifiScanTimeoutMs = 45000;
 		}
@@ -129,38 +129,38 @@ public class RRMConfig {
 	public class KafkaConfig {
 		/**
 		 * Kafka bootstrap host:port, or empty to disable
-		 * (<tt>KAFKACONFIG_BOOTSTRAPSERVER</tt>)
+		 * (<code>KAFKACONFIG_BOOTSTRAPSERVER</code>)
 		 */
 		public String bootstrapServer = "127.0.0.1:9093";
 
 		/**
 		 * Kafka topic holding uCentral state
-		 * (<tt>KAFKACONFIG_STATETOPIC</tt>)
+		 * (<code>KAFKACONFIG_STATETOPIC</code>)
 		 */
 		public String stateTopic = "state";
 
 		/**
 		 * Kafka topic holding uCentral wifi scan results
-		 * (<tt>KAFKACONFIG_WIFISCANTOPIC</tt>)
+		 * (<code>KAFKACONFIG_WIFISCANTOPIC</code>)
 		 */
 		public String wifiScanTopic = "wifiscan";
 
 		/**
 		 * Kafka topic holding uCentral microservice events.
 		 * Used for detecting API keys and internal endpoints.
-		 * (<tt>KAFKACONFIG_SERVICEEVENTSTOPIC</tt>)
+		 * (<code>KAFKACONFIG_SERVICEEVENTSTOPIC</code>)
 		 */
 		public String serviceEventsTopic = "service_events";
 
 		/**
 		 * Kafka consumer group ID
-		 * (<tt>KAFKACONFIG_GROUPID</tt>)
+		 * (<code>KAFKACONFIG_GROUPID</code>)
 		 */
 		public String groupId = "rrm-service";
 
 		/**
 		 * Kafka "auto.offset.reset" config ["earliest", "latest"]
-		 * (<tt>KAFKACONFIG_AUTOOFFSETRESET</tt>)
+		 * (<code>KAFKACONFIG_AUTOOFFSETRESET</code>)
 		 */
 		public String autoOffsetReset = "latest";
 	}
@@ -174,31 +174,31 @@ public class RRMConfig {
 	public class DatabaseConfig {
 		/**
 		 * MySQL database host:port, or empty to disable
-		 * (<tt>DATABASECONFIG_SERVER</tt>)
+		 * (<code>DATABASECONFIG_SERVER</code>)
 		 */
 		public String server = "127.0.0.1:3306";
 
 		/**
 		 * MySQL database user
-		 * (<tt>DATABASECONFIG_USER</tt>)
+		 * (<code>DATABASECONFIG_USER</code>)
 		 */
 		public String user = "root";
 
 		/**
 		 * MySQL database password
-		 * (<tt>DATABASECONFIG_PASSWORD</tt>)
+		 * (<code>DATABASECONFIG_PASSWORD</code>)
 		 */
 		public String password = "openwifi";
 
 		/**
 		 * MySQL database name
-		 * (<tt>DATABASECONFIG_DBNAME</tt>)
+		 * (<code>DATABASECONFIG_DBNAME</code>)
 		 */
 		public String dbName = "rrm";
 
 		/**
 		 * Data retention interval in days (0 to disable)
-		 * (<tt>DATABASECONFIG_DATARETENTIONINTERVALDAYS</tt>)
+		 * (<code>DATABASECONFIG_DATARETENTIONINTERVALDAYS</code>)
 		 */
 		public int dataRetentionIntervalDays = 14;
 	}
@@ -216,33 +216,33 @@ public class RRMConfig {
 		public class DataCollectorParams {
 			/**
 			 * The main logic loop interval (i.e. sleep time), in ms
-			 * (<tt>DATACOLLECTORPARAMS_UPDATEINTERVALMS</tt>)
+			 * (<code>DATACOLLECTORPARAMS_UPDATEINTERVALMS</code>)
 			 */
 			public int updateIntervalMs = 5000;
 
 			/**
 			 * The expected device statistics interval, in seconds (or -1 to
 			 * disable managing this value)
-			 * (<tt>DATACOLLECTORPARAMS_DEVICESTATSINTERVALSEC</tt>)
+			 * (<code>DATACOLLECTORPARAMS_DEVICESTATSINTERVALSEC</code>)
 			 */
 			public int deviceStatsIntervalSec = 60;
 
 			/**
 			 * The wifi scan interval (per device), in seconds (or -1 to disable
 			 * automatic scans)
-			 * (<tt>DATACOLLECTORPARAMS_WIFISCANINTERVALSEC</tt>)
+			 * (<code>DATACOLLECTORPARAMS_WIFISCANINTERVALSEC</code>)
 			 */
 			public int wifiScanIntervalSec = 60;
 
 			/**
 			 * The capabilities request interval (per device), in seconds
-			 * (<tt>DATACOLLECTORPARAMS_CAPABILITIESINTERVALSEC</tt>)
+			 * (<code>DATACOLLECTORPARAMS_CAPABILITIESINTERVALSEC</code>)
 			 */
 			public int capabilitiesIntervalSec = 3600;
 
 			/**
 			 * Number of executor threads for async tasks (ex. wifi scans)
-			 * (<tt>DATACOLLECTORPARAMS_EXECUTORTHREADCOUNT</tt>)
+			 * (<code>DATACOLLECTORPARAMS_EXECUTORTHREADCOUNT</code>)
 			 */
 			public int executorThreadCount = 3;
 		}
@@ -257,27 +257,27 @@ public class RRMConfig {
 		public class ConfigManagerParams {
 			/**
 			 * The main logic loop interval (i.e. sleep time), in ms
-			 * (<tt>CONFIGMANAGERPARAMS_UPDATEINTERVALMS</tt>)
+			 * (<code>CONFIGMANAGERPARAMS_UPDATEINTERVALMS</code>)
 			 */
 			public int updateIntervalMs = 60000;
 
 			/**
 			 * Enable pushing device config changes?
-			 * (<tt>CONFIGMANAGERPARAMS_CONFIGENABLED</tt>)
+			 * (<code>CONFIGMANAGERPARAMS_CONFIGENABLED</code>)
 			 */
 			public boolean configEnabled = true;
 
 			/**
 			 * If set, device config changes will only be pushed on events
 			 * (e.g. RRM algorithm execution, config API calls)
-			 * (<tt>CONFIGMANAGERPARAMS_CONFIGONEVENTONLY</tt>)
+			 * (<code>CONFIGMANAGERPARAMS_CONFIGONEVENTONLY</code>)
 			 */
 			public boolean configOnEventOnly = true;
 
 			/**
 			 * The debounce interval for reconfiguring the same device, in
 			 * seconds (or -1 to disable)
-			 * (<tt>CONFIGMANAGERPARAMS_CONFIGDEBOUNCEINTERVALSEC</tt>)
+			 * (<code>CONFIGMANAGERPARAMS_CONFIGDEBOUNCEINTERVALSEC</code>)
 			 */
 			public int configDebounceIntervalSec = 30;
 		}
@@ -292,7 +292,7 @@ public class RRMConfig {
 		public class ModelerParams {
 			/**
 			 * Maximum rounds of wifi scan results to store per device
-			 * (<tt>MODELERPARAMS_WIFISCANBUFFERSIZE</tt>)
+			 * (<code>MODELERPARAMS_WIFISCANBUFFERSIZE</code>)
 			 */
 			public int wifiScanBufferSize = 10;
 		}
@@ -306,38 +306,38 @@ public class RRMConfig {
 		public class ApiServerParams {
 			/**
 			 * The HTTP port to listen on, or -1 to disable
-			 * (<tt>APISERVERPARAMS_HTTPPORT</tt>)
+			 * (<code>APISERVERPARAMS_HTTPPORT</code>)
 			 */
 			public int httpPort = 16789;
 
 			/**
 			 * Enable HTTP basic auth?
-			 * (<tt>APISERVERPARAMS_USEBASICAUTH</tt>)
+			 * (<code>APISERVERPARAMS_USEBASICAUTH</code>)
 			 */
 			public boolean useBasicAuth = false;
 
 			/**
 			 * The HTTP basic auth username (if enabled)
-			 * (<tt>APISERVERPARAMS_BASICAUTHUSER</tt>)
+			 * (<code>APISERVERPARAMS_BASICAUTHUSER</code>)
 			 */
 			public String basicAuthUser = "admin";
 
 			/**
 			 * The HTTP basic auth password (if enabled)
-			 * (<tt>APISERVERPARAMS_BASICAUTHPASSWORD</tt>)
+			 * (<code>APISERVERPARAMS_BASICAUTHPASSWORD</code>)
 			 */
 			public String basicAuthPassword = "openwifi";
 
 			/**
 			 * Enable OpenWiFi authentication via tokens (external) and API keys
 			 * (internal)
-			 * (<tt>APISERVERPARAMS_USEOPENWIFIAUTH</tt>)
+			 * (<code>APISERVERPARAMS_USEOPENWIFIAUTH</code>)
 			 */
 			public boolean useOpenWifiAuth = false;
 
 			/**
 			 * The maximum cache size for OpenWiFi tokens
-			 * (<tt>APISERVERPARAMS_OPENWIFIAUTHCACHESIZE</tt>)
+			 * (<code>APISERVERPARAMS_OPENWIFIAUTHCACHESIZE</code>)
 			 */
 			public int openWifiAuthCacheSize = 100;
 		}
@@ -351,13 +351,13 @@ public class RRMConfig {
 		public class ProvMonitorParams {
 			/**
 			 * Enable use of venue information for topology
-			 * (<tt>PROVMONITORPARAMS_USEVENUES</tt>)
+			 * (<code>PROVMONITORPARAMS_USEVENUES</code>)
 			 */
 			public boolean useVenues = true;
 
 			/**
 			 * Sync interval, in ms, for owprov venue information etc.
-			 * (<tt>PROVMONITORPARAMS_SYNCINTERVALMS</tt>)
+			 * (<code>PROVMONITORPARAMS_SYNCINTERVALMS</code>)
 			 */
 			public int syncIntervalMs = 300000;
 		}
@@ -371,13 +371,13 @@ public class RRMConfig {
 		public class RRMSchedulerParams {
 			/**
 			 * Thread pool size for executing jobs
-			 * (<tt>SCHEDULERPARAMS_THREADCOUNT</tt>)
+			 * (<code>SCHEDULERPARAMS_THREADCOUNT</code>)
 			 */
 			public int threadCount = 2;
 
 			/**
 			 * If set, do not apply any changes from scheduled algorithms
-			 * (<tt>SCHEDULERPARAMS_DRYRUN</tt>)
+			 * (<code>SCHEDULERPARAMS_DRYRUN</code>)
 			 */
 			public boolean dryRun = false;
 		}

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -20,43 +20,43 @@ public class RRMConfig {
 	public class ServiceConfig {
 		/**
 		 * RRM service name/type
-		 * (<code>SERVICECONFIG_NAME</code>)
+		 * ({@code SERVICECONFIG_NAME})
 		 */
 		public String name = "owrrm";
 
 		/**
 		 * RRM service ID (random persistent number)
-		 * (<code>SERVICECONFIG_NAME</code>)
+		 * ({@code SERVICECONFIG_NAME})
 		 */
 		public long id = (long) (Math.random() * Long.MAX_VALUE);
 
 		/**
 		 * Private endpoint for the RRM service
-		 * (<code>SERVICECONFIG_PRIVATEENDPOINT</code>)
+		 * ({@code SERVICECONFIG_PRIVATEENDPOINT})
 		 */
 		public String privateEndpoint = "http://owrrm.wlan.local:16789";  // see ApiServerParams.httpPort
 
 		/**
 		 * Public endpoint for the RRM service
-		 * (<code>SERVICECONFIG_PUBLICENDPOINT</code>)
+		 * ({@code SERVICECONFIG_PUBLICENDPOINT})
 		 */
 		public String publicEndpoint = "";
 
 		/**
 		 * RRM vendor name
-		 * (<code>SERVICECONFIG_VENDOR</code>)
+		 * ({@code SERVICECONFIG_VENDOR})
 		 */
 		public String vendor = "Meta";
 
 		/**
 		 * RRM vendor URL
-		 * (<code>SERVICECONFIG_VENDORURL</code>)
+		 * ({@code SERVICECONFIG_VENDORURL})
 		 */
 		public String vendorUrl = "https://github.com/Telecominfraproject/wlan-cloud-rrm";
 
 		/**
 		 * RRM reference URL
-		 * (<code>SERVICECONFIG_VENDORREFERENCEURL</code>)
+		 * ({@code SERVICECONFIG_VENDORREFERENCEURL})
 		 */
 		public String vendorReferenceUrl = "https://github.com/Telecominfraproject/wlan-cloud-rrm/blob/main/ALGORITHMS.md";
 	}
@@ -70,25 +70,25 @@ public class RRMConfig {
 	public class UCentralConfig {
 		/**
 		 * If set, use public service endpoints instead of private ones
-		 * (<code>UCENTRALCONFIG_USEPUBLICENDPOINTS</code>)
+		 * ({@code UCENTRALCONFIG_USEPUBLICENDPOINTS})
 		 */
 		public boolean usePublicEndpoints = false;
 
 		/**
 		 * uCentralSec public endpoint
-		 * (<code>UCENTRALCONFIG_UCENTRALSECPUBLICENDPOINT</code>)
+		 * ({@code UCENTRALCONFIG_UCENTRALSECPUBLICENDPOINT})
 		 */
 		public String uCentralSecPublicEndpoint = "";
 
 		/**
 		 * uCentral username (for public endpoints only)
-		 * (<code>UCENTRALCONFIG_USERNAME</code>)
+		 * ({@code UCENTRALCONFIG_USERNAME})
 		 */
 		public String username = "tip@ucentral.com";
 
 		/**
 		 * uCentral password (for public endpoints only)
-		 * (<code>UCENTRALCONFIG_PASSWORD</code>)
+		 * ({@code UCENTRALCONFIG_PASSWORD})
 		 */
 		public String password = "";
 
@@ -98,19 +98,19 @@ public class RRMConfig {
 		public class UCentralSocketParams {
 			/**
 			 * Connection timeout for all requests, in ms
-			 * (<code>UCENTRALSOCKETPARAMS_CONNECTTIMEOUTMS</code>)
+			 * ({@code UCENTRALSOCKETPARAMS_CONNECTTIMEOUTMS})
 			 */
 			public int connectTimeoutMs = 2000;
 
 			/**
 			 * Socket timeout for all requests, in ms
-			 * (<code>UCENTRALSOCKETPARAMS_SOCKETTIMEOUTMS</code>)
+			 * ({@code UCENTRALSOCKETPARAMS_SOCKETTIMEOUTMS})
 			 */
 			public int socketTimeoutMs = 15000;
 
 			/**
 			 * Socket timeout for wifi scan requests, in ms
-			 * (<code>UCENTRALSOCKETPARAMS_WIFISCANTIMEOUTMS</code>)
+			 * ({@code UCENTRALSOCKETPARAMS_WIFISCANTIMEOUTMS})
 			 */
 			public int wifiScanTimeoutMs = 45000;
 		}
@@ -129,38 +129,38 @@ public class RRMConfig {
 	public class KafkaConfig {
 		/**
 		 * Kafka bootstrap host:port, or empty to disable
-		 * (<code>KAFKACONFIG_BOOTSTRAPSERVER</code>)
+		 * ({@code KAFKACONFIG_BOOTSTRAPSERVER})
 		 */
 		public String bootstrapServer = "127.0.0.1:9093";
 
 		/**
 		 * Kafka topic holding uCentral state
-		 * (<code>KAFKACONFIG_STATETOPIC</code>)
+		 * ({@code KAFKACONFIG_STATETOPIC})
 		 */
 		public String stateTopic = "state";
 
 		/**
 		 * Kafka topic holding uCentral wifi scan results
-		 * (<code>KAFKACONFIG_WIFISCANTOPIC</code>)
+		 * ({@code KAFKACONFIG_WIFISCANTOPIC})
 		 */
 		public String wifiScanTopic = "wifiscan";
 
 		/**
 		 * Kafka topic holding uCentral microservice events.
 		 * Used for detecting API keys and internal endpoints.
-		 * (<code>KAFKACONFIG_SERVICEEVENTSTOPIC</code>)
+		 * ({@code KAFKACONFIG_SERVICEEVENTSTOPIC})
 		 */
 		public String serviceEventsTopic = "service_events";
 
 		/**
 		 * Kafka consumer group ID
-		 * (<code>KAFKACONFIG_GROUPID</code>)
+		 * ({@code KAFKACONFIG_GROUPID})
 		 */
 		public String groupId = "rrm-service";
 
 		/**
 		 * Kafka "auto.offset.reset" config ["earliest", "latest"]
-		 * (<code>KAFKACONFIG_AUTOOFFSETRESET</code>)
+		 * ({@code KAFKACONFIG_AUTOOFFSETRESET})
 		 */
 		public String autoOffsetReset = "latest";
 	}
@@ -174,31 +174,31 @@ public class RRMConfig {
 	public class DatabaseConfig {
 		/**
 		 * MySQL database host:port, or empty to disable
-		 * (<code>DATABASECONFIG_SERVER</code>)
+		 * ({@code DATABASECONFIG_SERVER})
 		 */
 		public String server = "127.0.0.1:3306";
 
 		/**
 		 * MySQL database user
-		 * (<code>DATABASECONFIG_USER</code>)
+		 * ({@code DATABASECONFIG_USER})
 		 */
 		public String user = "root";
 
 		/**
 		 * MySQL database password
-		 * (<code>DATABASECONFIG_PASSWORD</code>)
+		 * ({@code DATABASECONFIG_PASSWORD})
 		 */
 		public String password = "openwifi";
 
 		/**
 		 * MySQL database name
-		 * (<code>DATABASECONFIG_DBNAME</code>)
+		 * ({@code DATABASECONFIG_DBNAME})
 		 */
 		public String dbName = "rrm";
 
 		/**
 		 * Data retention interval in days (0 to disable)
-		 * (<code>DATABASECONFIG_DATARETENTIONINTERVALDAYS</code>)
+		 * ({@code DATABASECONFIG_DATARETENTIONINTERVALDAYS})
 		 */
 		public int dataRetentionIntervalDays = 14;
 	}
@@ -216,33 +216,33 @@ public class RRMConfig {
 		public class DataCollectorParams {
 			/**
 			 * The main logic loop interval (i.e. sleep time), in ms
-			 * (<code>DATACOLLECTORPARAMS_UPDATEINTERVALMS</code>)
+			 * ({@code DATACOLLECTORPARAMS_UPDATEINTERVALMS})
 			 */
 			public int updateIntervalMs = 5000;
 
 			/**
 			 * The expected device statistics interval, in seconds (or -1 to
 			 * disable managing this value)
-			 * (<code>DATACOLLECTORPARAMS_DEVICESTATSINTERVALSEC</code>)
+			 * ({@code DATACOLLECTORPARAMS_DEVICESTATSINTERVALSEC})
 			 */
 			public int deviceStatsIntervalSec = 60;
 
 			/**
 			 * The wifi scan interval (per device), in seconds (or -1 to disable
 			 * automatic scans)
-			 * (<code>DATACOLLECTORPARAMS_WIFISCANINTERVALSEC</code>)
+			 * ({@code DATACOLLECTORPARAMS_WIFISCANINTERVALSEC})
 			 */
 			public int wifiScanIntervalSec = 60;
 
 			/**
 			 * The capabilities request interval (per device), in seconds
-			 * (<code>DATACOLLECTORPARAMS_CAPABILITIESINTERVALSEC</code>)
+			 * ({@code DATACOLLECTORPARAMS_CAPABILITIESINTERVALSEC})
 			 */
 			public int capabilitiesIntervalSec = 3600;
 
 			/**
 			 * Number of executor threads for async tasks (ex. wifi scans)
-			 * (<code>DATACOLLECTORPARAMS_EXECUTORTHREADCOUNT</code>)
+			 * ({@code DATACOLLECTORPARAMS_EXECUTORTHREADCOUNT})
 			 */
 			public int executorThreadCount = 3;
 		}
@@ -257,27 +257,27 @@ public class RRMConfig {
 		public class ConfigManagerParams {
 			/**
 			 * The main logic loop interval (i.e. sleep time), in ms
-			 * (<code>CONFIGMANAGERPARAMS_UPDATEINTERVALMS</code>)
+			 * ({@code CONFIGMANAGERPARAMS_UPDATEINTERVALMS})
 			 */
 			public int updateIntervalMs = 60000;
 
 			/**
 			 * Enable pushing device config changes?
-			 * (<code>CONFIGMANAGERPARAMS_CONFIGENABLED</code>)
+			 * ({@code CONFIGMANAGERPARAMS_CONFIGENABLED})
 			 */
 			public boolean configEnabled = true;
 
 			/**
 			 * If set, device config changes will only be pushed on events
 			 * (e.g. RRM algorithm execution, config API calls)
-			 * (<code>CONFIGMANAGERPARAMS_CONFIGONEVENTONLY</code>)
+			 * ({@code CONFIGMANAGERPARAMS_CONFIGONEVENTONLY})
 			 */
 			public boolean configOnEventOnly = true;
 
 			/**
 			 * The debounce interval for reconfiguring the same device, in
 			 * seconds (or -1 to disable)
-			 * (<code>CONFIGMANAGERPARAMS_CONFIGDEBOUNCEINTERVALSEC</code>)
+			 * ({@code CONFIGMANAGERPARAMS_CONFIGDEBOUNCEINTERVALSEC})
 			 */
 			public int configDebounceIntervalSec = 30;
 		}
@@ -292,7 +292,7 @@ public class RRMConfig {
 		public class ModelerParams {
 			/**
 			 * Maximum rounds of wifi scan results to store per device
-			 * (<code>MODELERPARAMS_WIFISCANBUFFERSIZE</code>)
+			 * ({@code MODELERPARAMS_WIFISCANBUFFERSIZE})
 			 */
 			public int wifiScanBufferSize = 10;
 		}
@@ -306,38 +306,38 @@ public class RRMConfig {
 		public class ApiServerParams {
 			/**
 			 * The HTTP port to listen on, or -1 to disable
-			 * (<code>APISERVERPARAMS_HTTPPORT</code>)
+			 * ({@code APISERVERPARAMS_HTTPPORT})
 			 */
 			public int httpPort = 16789;
 
 			/**
 			 * Enable HTTP basic auth?
-			 * (<code>APISERVERPARAMS_USEBASICAUTH</code>)
+			 * ({@code APISERVERPARAMS_USEBASICAUTH})
 			 */
 			public boolean useBasicAuth = false;
 
 			/**
 			 * The HTTP basic auth username (if enabled)
-			 * (<code>APISERVERPARAMS_BASICAUTHUSER</code>)
+			 * ({@code APISERVERPARAMS_BASICAUTHUSER})
 			 */
 			public String basicAuthUser = "admin";
 
 			/**
 			 * The HTTP basic auth password (if enabled)
-			 * (<code>APISERVERPARAMS_BASICAUTHPASSWORD</code>)
+			 * ({@code APISERVERPARAMS_BASICAUTHPASSWORD})
 			 */
 			public String basicAuthPassword = "openwifi";
 
 			/**
 			 * Enable OpenWiFi authentication via tokens (external) and API keys
 			 * (internal)
-			 * (<code>APISERVERPARAMS_USEOPENWIFIAUTH</code>)
+			 * ({@code APISERVERPARAMS_USEOPENWIFIAUTH})
 			 */
 			public boolean useOpenWifiAuth = false;
 
 			/**
 			 * The maximum cache size for OpenWiFi tokens
-			 * (<code>APISERVERPARAMS_OPENWIFIAUTHCACHESIZE</code>)
+			 * ({@code APISERVERPARAMS_OPENWIFIAUTHCACHESIZE})
 			 */
 			public int openWifiAuthCacheSize = 100;
 		}
@@ -351,13 +351,13 @@ public class RRMConfig {
 		public class ProvMonitorParams {
 			/**
 			 * Enable use of venue information for topology
-			 * (<code>PROVMONITORPARAMS_USEVENUES</code>)
+			 * ({@code PROVMONITORPARAMS_USEVENUES})
 			 */
 			public boolean useVenues = true;
 
 			/**
 			 * Sync interval, in ms, for owprov venue information etc.
-			 * (<code>PROVMONITORPARAMS_SYNCINTERVALMS</code>)
+			 * ({@code PROVMONITORPARAMS_SYNCINTERVALMS})
 			 */
 			public int syncIntervalMs = 300000;
 		}
@@ -371,13 +371,13 @@ public class RRMConfig {
 		public class RRMSchedulerParams {
 			/**
 			 * Thread pool size for executing jobs
-			 * (<code>SCHEDULERPARAMS_THREADCOUNT</code>)
+			 * ({@code SCHEDULERPARAMS_THREADCOUNT})
 			 */
 			public int threadCount = 2;
 
 			/**
 			 * If set, do not apply any changes from scheduled algorithms
-			 * (<code>SCHEDULERPARAMS_DRYRUN</code>)
+			 * ({@code SCHEDULERPARAMS_DRYRUN})
 			 */
 			public boolean dryRun = false;
 		}

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -132,7 +132,7 @@ public class ApiServer implements Runnable {
 	 * The auth token cache (map from token to expiration time, in UNIX seconds)
 	 * for incoming requests.
 	 *
-	 * @see {@link #performOpenWifiAuth(Request, Response)}
+	 * @see #performOpenWifiAuth(Request, Response)
 	 */
 	private final Map<String, Long> tokenCache;
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/TPC.java
@@ -71,7 +71,7 @@ public abstract class TPC {
 	 *
 	 * @param deviceDataManager the DeviceDataManager instance
 	 * @param configManager the ConfigManager instance
-	 * @param channelMap the map of devices (by serial number) to radio to tx power
+	 * @param txPowerMap the map of devices (by serial number) to radio to tx power
 	 */
 	public void applyConfig(
 		DeviceDataManager deviceDataManager,

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  <body>
+    <p>
+      OpenWiFi uCentral-based radio resource management service. Sources are available
+      <a href="https://github.com/Telecominfraproject/wlan-cloud-rrm" target="_blank">here</a>.
+    </p>
+  </body>
+</html>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <body>
     <p>
-      OpenWiFi uCentral-based radio resource management service. Sources are available
+      OpenWiFi uCentral-based radio resource management (RRM) service. Sources are available
       <a href="https://github.com/Telecominfraproject/wlan-cloud-rrm" target="_blank">here</a>.
     </p>
   </body>


### PR DESCRIPTION
- Add Javadoc config section to `pom.xml`
- Fix Javadoc errors in sources
- Add minimal `overview.html` to be placed on generated index page
- Add GitHub workflow to build Javadoc on push and deploy to gh-pages branch