### PR TITLE
[WIFI-9985] Add CORS support

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -311,6 +311,14 @@ public class RRMConfig {
 			public int httpPort = 16789;
 
 			/**
+			 * Comma-separated list of all allowed CORS domains (exact match
+			 * including subdomain portions, but excluding protocol).
+			 * If empty, enable CORS for all origins.
+			 * ({@code APISERVERPARAMS_CORSDOMAINLIST})
+			 */
+			public String corsDomainList = "";
+
+			/**
 			 * Enable HTTP basic auth?
 			 * ({@code APISERVERPARAMS_USEBASICAUTH})
 			 */
@@ -524,6 +532,9 @@ public class RRMConfig {
 			config.moduleConfig.apiServerParams;
 		if ((v = env.get("APISERVERPARAMS_HTTPPORT")) != null) {
 			apiServerParams.httpPort = Integer.parseInt(v);
+		}
+		if ((v = env.get("APISERVERPARAMS_CORSDOMAINLIST")) != null) {
+			apiServerParams.corsDomainList = v;
 		}
 		if ((v = env.get("APISERVERPARAMS_USEBASICAUTH")) != null) {
 			apiServerParams.useBasicAuth = Boolean.parseBoolean(v);

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -428,7 +428,7 @@ public class ApiServer implements Runnable {
 			response.header("Access-Control-Allow-Methods", acrm);
 		}
 		response.header("Access-Control-Allow-Credentials", "true");
-		response.header("Access-Control-Max-Age", "86400");
+		response.header("Access-Control-Max-Age", "86400" /* 1 day */);
 		return "OK";
 	}
 

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -9,6 +9,8 @@
 package com.facebook.openwifirrm.modules;
 
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.Arrays;
@@ -18,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.GET;
@@ -136,6 +139,9 @@ public class ApiServer implements Runnable {
 	 */
 	private final Map<String, Long> tokenCache;
 
+	/** The list of allowed CORS domains. If null, all domains are allowed. */
+	private final Set<String> corsDomains;
+
 	/** The Gson instance. */
 	private final Gson gson = new Gson();
 
@@ -166,6 +172,23 @@ public class ApiServer implements Runnable {
 		this.tokenCache = Collections.synchronizedMap(
 			new LruCache<>(Math.max(params.openWifiAuthCacheSize, 1))
 		);
+		this.corsDomains = getCorsDomains(params.corsDomainList);
+	}
+
+	/**
+	 * Build the CORS domain set.
+	 *
+	 * @see ApiServerParams#corsDomainList
+	 */
+	private Set<String> getCorsDomains(String corsDomainList) {
+		if (corsDomainList.isEmpty()) {
+			return null;
+		}
+		Set<String> ret = ConcurrentHashMap.newKeySet();
+		for (String domain : corsDomainList.split(",")) {
+			ret.add(domain);
+		}
+		return ret;
 	}
 
 	@Override
@@ -187,6 +210,7 @@ public class ApiServer implements Runnable {
 		// Install routes
 		Spark.before(this::beforeFilter);
 		Spark.after(this::afterFilter);
+		Spark.options("/*", this::options);
 		Spark.get("/api/v1/system", new SystemEndpoint());
 		Spark.get("/api/v1/provider", new ProviderEndpoint());
 		Spark.get("/api/v1/algorithms", new AlgorithmsEndpoint());
@@ -338,6 +362,26 @@ public class ApiServer implements Runnable {
 		// Remove "Server: Jetty" header
 		response.header("Server", "");
 
+		// Set CORS headers
+		String origin = request.headers("Origin");
+		if (origin != null) {
+			boolean allowOrigin = false;
+			if (corsDomains == null) {
+				allowOrigin = true;
+			} else {
+				try {
+					String originHost = new URI(origin).getHost();
+					allowOrigin = corsDomains.contains(originHost);
+				} catch (URISyntaxException e) { /* invalid origin URI */ }
+			}
+			if (allowOrigin) {
+				response.header("Access-Control-Allow-Origin", origin);
+				response.header("Vary", "Origin");
+			} else {
+				logger.debug("CORS checks failed for origin: {}", origin);
+			}
+		}
+
 		// HTTP basic auth (if enabled)
 		if (params.useBasicAuth) {
 			performHttpBasicAuth(
@@ -370,6 +414,22 @@ public class ApiServer implements Runnable {
 				response.header("Content-Encoding", "gzip");
 			}
 		}
+	}
+
+	/** Global OPTIONS handler. */
+	private String options(Request request, Response response) {
+		// Set CORS headers
+		String acrh = request.headers("Access-Control-Request-Headers");
+		if (acrh != null) {
+			response.header("Access-Control-Allow-Headers", acrh);
+		}
+		String acrm = request.headers("Access-Control-Request-Method");
+		if (acrm != null) {
+			response.header("Access-Control-Allow-Methods", acrm);
+		}
+		response.header("Access-Control-Allow-Credentials", "true");
+		response.header("Access-Control-Max-Age", "86400");
+		return "OK";
 	}
 
 	/** Returns the OpenAPI object, generating and caching it if needed. */

--- a/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
@@ -469,9 +469,39 @@ public class ApiServerTest {
 		assertEquals(404, Unirest.post(fakeEndpoint).asString().getStatus());
 		assertEquals(404, Unirest.put(fakeEndpoint).asString().getStatus());
 		assertEquals(404, Unirest.delete(fakeEndpoint).asString().getStatus());
-		assertEquals(404, Unirest.options(fakeEndpoint).asString().getStatus());
 		assertEquals(404, Unirest.head(fakeEndpoint).asString().getStatus());
 		assertEquals(404, Unirest.patch(fakeEndpoint).asString().getStatus());
+	}
+
+	@Test
+	@Order(1002)
+	void testCORS() throws Exception {
+		final String fakeEndpoint = endpoint("/test123");
+		final String HEADERS = "authorization";
+		final String METHOD = "GET";
+		final String ORIGIN = "https://example.com";
+		HttpResponse<String> resp = Unirest.options(fakeEndpoint)
+			.header("Access-Control-Request-Headers", HEADERS)
+			.header("Access-Control-Request-Method", METHOD)
+			.header("Origin", ORIGIN)
+			.asString();
+		assertEquals(200, resp.getStatus());
+		assertEquals(
+			ORIGIN, resp.getHeaders().getFirst("Access-Control-Allow-Origin")
+		);
+		assertEquals("Origin", resp.getHeaders().getFirst("Vary"));
+		assertEquals(
+			HEADERS, resp.getHeaders().getFirst("Access-Control-Allow-Headers")
+		);
+		assertEquals(
+			METHOD, resp.getHeaders().getFirst("Access-Control-Allow-Methods")
+		);
+		assertEquals(
+			"true",
+			resp.getHeaders().getFirst("Access-Control-Allow-Credentials")
+		);
+		String maxAge = resp.getHeaders().getFirst("Access-Control-Max-Age");
+		assertTrue(Integer.parseInt(maxAge) >= 0);
 	}
 
 	@Test


### PR DESCRIPTION
Add proper CORS support to `ApiServer`.
- Add global HTTP `OPTIONS` handler to reflect requested options.
- Add "Access-Control-Allow-Origin" response header (and "Vary") whenever "Origin" request header is present, *if* CORS checks pass based on `APISERVERPARAMS_CORSDOMAINLIST` RRM config:
    - If set, origin must match a domain in this comma-separated list.
    - If empty, always reflect the "Origin" header (i.e. allow all origins).