### PR TITLE
Update package version to 2.7.0, append git info during docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3-jdk-11 as build
 WORKDIR /usr/src/java
 COPY . .
-RUN mvn clean package
+RUN mvn clean package -DappendVersionString="$(./scripts/get_build_version.sh)"
 
 FROM openjdk:11
 RUN apt-get update && apt-get install -y gettext-base

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: OpenWiFi 2.0 RRM OpenAPI
   description: This document describes the API for the Radio Resource Management service.
-  version: 1.0.0
+  version: 2.7.0
 security:
 - bearerAuth: []
 tags:

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.facebook</groupId>
   <artifactId>openwifi-rrm</artifactId>
-  <version>1.0.0</version>
+  <version>2.7.0</version>
   <properties>
     <java.version>11</java.version>
     <slf4j.version>1.7.32</slf4j.version>
     <junit.version>5.7.2</junit.version>
     <swagger.version>2.1.10</swagger.version>
     <mainClassName>com.facebook.openwifirrm.Launcher</mainClassName>
+    <appendVersionString></appendVersionString>
   </properties>
   <build>
     <finalName>openwifi-rrm</finalName>

--- a/scripts/get_build_version.sh
+++ b/scripts/get_build_version.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Print the "build version" to be appended to the package version
+
+if [ -d .git ] && [ -x "$(command -v git)" ]; then
+  BUILD_NUM="$(git rev-list --count --first-parent HEAD)"
+  HASH="$(git rev-parse --short HEAD)"
+  echo "-$HASH($BUILD_NUM)"
+fi

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -89,7 +89,7 @@ import spark.Spark;
 @OpenAPIDefinition(
 	info = @Info(
 		title = "OpenWiFi 2.0 RRM OpenAPI",
-		version = "1.0.0",  // TODO
+		version = "2.7.0",  // NOTE: needs manual update!
 		description = "This document describes the API for the Radio Resource Management service."
 	),
 	tags = {

--- a/src/main/resources-filtered/version.txt
+++ b/src/main/resources-filtered/version.txt
@@ -1,1 +1,1 @@
-${project.version}
+${project.version}${appendVersionString}


### PR DESCRIPTION
Update package version from 1.0.0 to 2.7.0, both in `pom.xml` and `ApiServer.java`.

Define a new `appendVersionString` property in Maven which gets added to the generated (filtered) `version.txt` resource (used to source the version string at runtime). In the `Dockerfile`, set this property to a combination of Git hash and build number when available (via new script `scripts/get_build_version.sh`).

Example output:
```
$ docker build -f Dockerfile .
Successfully built 0c3cabe843d1

$ docker run --rm -it 0c3cabe843d1 /bin/bash

# java -jar /usr/local/bin/openwifi-rrm.jar -V
2.7.0-ebed9b5(32)
```