### PR TITLE
Move SSL validation toggle into RRMConfig

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -158,6 +158,7 @@ public class Launcher implements Callable<Integer> {
 			UCentralUtils.generateServiceKey(config.serviceConfig);
 
 		// Instantiate clients
+		UCentralClient.verifySsl(config.uCentralConfig.verifySsl);
 		UCentralClient client = new UCentralClient(
 			config.serviceConfig.publicEndpoint,
 			config.uCentralConfig.usePublicEndpoints,

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -93,7 +93,13 @@ public class RRMConfig {
 		public String password = "";
 
 		/**
-		 * uCentral socket parameters
+		 * Verify SSL/TLS certificates in HTTPS requests
+		 * ({@code UCENTRALCONFIG_VERIFYSSL})
+		 */
+		public boolean verifySsl = false;
+
+		/**
+		 * uCentral socket parameters.
 		 */
 		public class UCentralSocketParams {
 			/**
@@ -439,6 +445,9 @@ public class RRMConfig {
 		}
 		if ((v = env.get("UCENTRALCONFIG_PASSWORD")) != null) {
 			uCentralConfig.password = v;
+		}
+		if ((v = env.get("UCENTRALCONFIG_VERIFYSSL")) != null) {
+			uCentralConfig.verifySsl = Boolean.parseBoolean(v);
 		}
 		UCentralConfig.UCentralSocketParams uCentralSocketParams =
 			config.uCentralConfig.uCentralSocketParams;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
@@ -81,9 +81,6 @@ public class UCentralClient {
 
 	static {
 		Unirest.config()
-			// TODO currently disabling SSL/TLS cert verification
-			.verifySsl(false)
-
 			// Suppress unchecked exceptions (ex. SocketTimeoutException),
 			// instead sending a (fake) FailedResponse.
 			.interceptor(new Interceptor() {
@@ -103,6 +100,14 @@ public class UCentralClient {
 			        return new FailedResponse(e);
 			    }
 			});
+	}
+
+	/**
+	 * Toggle verifying SSL/TLS certificates. This should be set only during
+	 * initialization, otherwise it may NOT take effect.
+	 */
+	public static void verifySsl(boolean enable) {
+		Unirest.config().verifySsl(enable);
 	}
 
 	/** Gson instance */


### PR DESCRIPTION
Instead of hardcoded disabling of SSL validation (i.e. `Unirest.config().verifySsl(false)`), move this into `RRMConfig` as `UCENTRALCONFIG_VERIFYSSL`, still default off.