### PR TITLE
Move Kafka consumer poll timeout to RRMConfig

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/Launcher.java
+++ b/src/main/java/com/facebook/openwifirrm/Launcher.java
@@ -179,6 +179,7 @@ public class Launcher implements Callable<Integer> {
 				config.kafkaConfig.bootstrapServer,
 				config.kafkaConfig.groupId,
 				config.kafkaConfig.autoOffsetReset,
+				config.kafkaConfig.pollTimeoutMs,
 				config.kafkaConfig.stateTopic,
 				config.kafkaConfig.wifiScanTopic,
 				config.kafkaConfig.serviceEventsTopic

--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -169,6 +169,12 @@ public class RRMConfig {
 		 * ({@code KAFKACONFIG_AUTOOFFSETRESET})
 		 */
 		public String autoOffsetReset = "latest";
+
+		/**
+		 * Kafka consumer poll timeout duration, in ms
+		 * ({@code KAFKACONFIG_POLLTIMEOUTMS})
+		 */
+		public long pollTimeoutMs = 10000;
 	}
 
 	/** uCentral Kafka configuration. */
@@ -480,6 +486,9 @@ public class RRMConfig {
 		}
 		if ((v = env.get("KAFKACONFIG_AUTOOFFSETRESET")) != null) {
 			kafkaConfig.autoOffsetReset = v;
+		}
+		if ((v = env.get("KAFKACONFIG_POLLTIMEOUTMS")) != null) {
+			kafkaConfig.pollTimeoutMs = Long.parseLong(v);
 		}
 
 		/* DatabaseConfig */


### PR DESCRIPTION
Move hardcoded Kafka consumer poll timeout (used when fetching topics and records) into `RRMConfig` as `KAFKACONFIG_POLLTIMEOUTMS`, keeping the same default of 10 seconds.