### PR TITLE
Fix build version generation in CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         registry: tip-tip-wlan-cloud-ucentral.jfrog.io
         registry_user: ucentral
         registry_password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+        checkout_fetch_depth: 0
 
     - name: Notify on failure via Slack
       if: failure() && github.ref == 'refs/heads/main'

--- a/scripts/get_build_version.sh
+++ b/scripts/get_build_version.sh
@@ -4,5 +4,5 @@
 if [ -d .git ] && [ -x "$(command -v git)" ]; then
   BUILD_NUM="$(git rev-list --count --first-parent HEAD)"
   HASH="$(git rev-parse --short HEAD)"
-  echo "-$HASH($BUILD_NUM)"
+  echo " - $HASH($BUILD_NUM)"
 fi


### PR DESCRIPTION
Build version was not being correctly generated in workflows due to shallow clone. Change this to a full clone with history using the new fetch depth parameter from https://github.com/Telecominfraproject/.github/pull/7 (`checkout_fetch_depth`).