### PR TITLE
Fix javadoc warnings

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -144,12 +144,13 @@ public class MeasurementBasedApApTPC extends TPC {
 	 */
 
 	/**
-	 * Build a map from BSSID to a sorted (ascending) list of RSSIs from neighboring
-	 * APs. Every managed BSSID is a key in the returned map; if that BSSID does not
-	 * have an RSSI for that AP, the BSSID is mapped to an empty list.
+	 * Build a map from BSSID to a sorted (ascending) list of RSSIs from
+	 * neighboring APs. Every managed BSSID is a key in the returned map; if
+	 * that BSSID does not have an RSSI for that AP, the BSSID is mapped to an
+	 * empty list.
 	 *
 	 * @param managedBSSIDs   set of all BSSIDs of APs we are managing
-	 * @param latestWifiScans @see Modeler.DataModel#latestWifiScans for data
+	 * @param latestWifiScans {@link DataModel#latestWifiScans} for data
 	 *                        structure
 	 * @param band            "2G" or "5G"
 	 * @return a map from BSSID to a sorted (ascending) list of RSSIs from

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/WifiScanEntryResult.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/WifiScanEntryResult.java
@@ -37,15 +37,15 @@ public class WifiScanEntryResult {
 	public String ht_oper;
 	/**
 	 * vht_oper is short for "very high throughput operation element". Note that
-	 * this field, when non-null, contains some information already present in other
-	 * fields. This field may be null, however, since pre-802.11ac BSSs do not
-	 * support HT. For BSSs that do support VHT, VHT is supported on the 5G band.
-	 * VHT operation is controlled by both the HT operation element and the VHT
-	 * operation element.
+	 * this field, when non-null, contains some information already present in
+	 * other fields. This field may be null, however, since pre-802.11ac BSSs do
+	 * not support HT. For BSSs that do support VHT, VHT is supported on the 5G
+	 * band. VHT operation is controlled by both the HT operation element and
+	 * the VHT operation element.
 	 *
-	 * For information about about the contents of this field, its encoding, etc.,
-	 * please see the javadoc for {@link ht_oper} first. The vht_oper likely
-	 * operates similarly.
+	 * For information about about the contents of this field, its encoding,
+	 * etc., please see the javadoc for {@link #ht_oper} first. The vht_oper
+	 * likely operates similarly.
 	 */
 	public String vht_oper;
 	public int capability;


### PR DESCRIPTION
Fix javadoc warnings (`mvn javadoc:javadoc` succeeds now)