### PR TITLE
Enable Random Tx Power Initializer in 2G

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -33,13 +33,11 @@ public class RandomTxPowerInitializer extends TPC {
 	/** The fixed tx power (dBm). */
 	private final int txPower;
 
-	/** Constructor (uses default tx power). */
+	/** Constructor (uses random tx power). */
 	public RandomTxPowerInitializer(
 		DataModel model, String zone, DeviceDataManager deviceDataManager
 	) {
-		super(model, zone, deviceDataManager);
-		Random rand = new Random();
-		this.txPower = rand.nextInt(TPC.MAX_TX_POWER + 1 - TPC.MIN_TX_POWER) + TPC.MIN_TX_POWER;
+		this(model, zone, deviceDataManager, getRandomTxPower());
 	}
 
 	/** Constructor. */
@@ -51,6 +49,11 @@ public class RandomTxPowerInitializer extends TPC {
 	) {
 		super(model, zone, deviceDataManager);
 		this.txPower = txPower;
+	}
+
+	public static int getRandomTxPower() {
+		Random rand = new Random();
+		return rand.nextInt(TPC.MAX_TX_POWER + 1 - TPC.MIN_TX_POWER) + TPC.MIN_TX_POWER;
 	}
 
 	@Override

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -51,6 +51,7 @@ public class RandomTxPowerInitializer extends TPC {
 		this.txPower = txPower;
 	}
 
+	/** Get a random tx power in [MIN_TX_POWER, MAX_TX_POWER], both inclusive */
 	public static int getRandomTxPower() {
 		Random rand = new Random();
 		return rand.nextInt(TPC.MAX_TX_POWER + 1 - TPC.MIN_TX_POWER) + TPC.MIN_TX_POWER;

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -9,6 +9,7 @@
 package com.facebook.openwifirrm.optimizers.tpc;
 
 import java.util.Map;
+import java.util.Random;
 import java.util.TreeMap;
 
 import org.slf4j.Logger;
@@ -29,9 +30,6 @@ public class RandomTxPowerInitializer extends TPC {
 	/** The RRM algorithm ID. */
 	public static final String ALGORITHM_ID = "random";
 
-	/** Default tx power. */
-	public static final int DEFAULT_TX_POWER = 23;
-
 	/** The fixed tx power (dBm). */
 	private final int txPower;
 
@@ -39,7 +37,9 @@ public class RandomTxPowerInitializer extends TPC {
 	public RandomTxPowerInitializer(
 		DataModel model, String zone, DeviceDataManager deviceDataManager
 	) {
-		this(model, zone, deviceDataManager, DEFAULT_TX_POWER);
+		super(model, zone, deviceDataManager);
+		Random rand = new Random();
+		this.txPower = rand.nextInt(TPC.MAX_TX_POWER + 1 - TPC.MIN_TX_POWER) + TPC.MIN_TX_POWER;
 	}
 
 	/** Constructor. */
@@ -58,7 +58,9 @@ public class RandomTxPowerInitializer extends TPC {
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
 		for (String serialNumber : model.latestState.keySet()) {
 			Map<String, Integer> radioMap = new TreeMap<>();
-			radioMap.put(UCentralConstants.BAND_5G, txPower);
+			for (String band : UCentralConstants.BANDS) {
+				radioMap.put(band, txPower);
+			}
 			txPowerMap.put(serialNumber, radioMap);
 		}
 		if (!txPowerMap.isEmpty()) {

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -35,7 +35,7 @@ import com.google.gson.JsonArray;
 public class MeasurementBasedApApTPCTest {
 	/** Test zone name. */
 	private static final String TEST_ZONE = "test-zone";
-	private static final int MAX_TX_POWER = 30;
+	private static final int MAX_TX_POWER = TPC.MAX_TX_POWER;
 	/** Default channel width (MHz). */
 	private static final int DEFAULT_CHANNEL_WIDTH = 20;
 

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -33,7 +33,7 @@ public class RandomTxPowerInitializerTest {
 	/** Test zone name. */
 	private static final String TEST_ZONE = "test-zone";
 
-	/** Serial numbers */
+	// Serial numbers
 	private static final String DEVICE_A = "aaaaaaaaaaaa";
 	private static final String DEVICE_B = "bbbbbbbbbbbb";
 

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -8,10 +8,9 @@
 
 package com.facebook.openwifirrm.optimizers.tpc;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.*;
 
-import java.util.Map;
-
+import com.facebook.openwifirrm.DeviceConfig;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -23,39 +22,76 @@ import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.models.State;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 @TestMethodOrder(OrderAnnotation.class)
 public class RandomTxPowerInitializerTest {
 	/** Test zone name. */
 	private static final String TEST_ZONE = "test-zone";
 
+	/** Serial numbers */
+	private static final String DEVICE_A = "aaaaaaaaaaaa";
+	private static final String DEVICE_B = "bbbbbbbbbbbb";
+
 	/** Create an empty device state object. */
-	private State createState() {
+	private static State createState() {
 		return new State();
+	}
+
+	/**
+	 * Creates a manager with 2 devices.
+	 */
+	private static DeviceDataManager createDeviceDataManager() {
+		DeviceDataManager deviceDataManager = new DeviceDataManager();
+		deviceDataManager.setTopology(
+			TestUtils.createTopology(TEST_ZONE, DEVICE_A, DEVICE_B)
+		);
+		return deviceDataManager;
+	}
+
+	/**
+	 * Creates a data model with 2 devices.
+	 */
+	private static DataModel createModel() {
+		DataModel dataModel = new DataModel();
+		dataModel.latestState.put(DEVICE_A, createState());
+		dataModel.latestState.put(DEVICE_B, createState());
+		return dataModel;
 	}
 
 	@Test
 	@Order(1)
-	void test1() throws Exception {
-		final String deviceA = "aaaaaaaaaaaa";
-		final String deviceB = "bbbbbbbbbbbb";
+	void testProvidedTxPower() throws Exception {
+		for (int txPower : Arrays.asList(-1, 16, 27)) {
+			TPC optimizer = new RandomTxPowerInitializer(
+				createModel(), TEST_ZONE, createDeviceDataManager(), txPower
+			);
+			Map<String, Map<String, Integer>> txPowerMap =
+				optimizer.computeTxPowerMap();
 
-		DeviceDataManager deviceDataManager = new DeviceDataManager();
-		deviceDataManager.setTopology(
-			TestUtils.createTopology(TEST_ZONE, deviceA, deviceB)
-		);
+			for (String band : UCentralConstants.BANDS) {
+				assertEquals(txPower, txPowerMap.get(DEVICE_A).get(band));
+				assertEquals(txPower, txPowerMap.get(DEVICE_B).get(band));
+			}
+		}
+	}
 
-		DataModel dataModel = new DataModel();
-		dataModel.latestState.put(deviceA, createState());
-		dataModel.latestState.put(deviceB, createState());
-
-		final int txPower = 16;
+	@Test
+	@Order(2)
+	void testRandomTxPower() throws Exception {
 		TPC optimizer = new RandomTxPowerInitializer(
-			dataModel, TEST_ZONE, deviceDataManager, txPower
+			createModel(), TEST_ZONE, createDeviceDataManager()
 		);
 		Map<String, Map<String, Integer>> txPowerMap =
 			optimizer.computeTxPowerMap();
-
-		assertEquals(txPower, txPowerMap.get(deviceA).get(UCentralConstants.BAND_5G));
-		assertEquals(txPower, txPowerMap.get(deviceB).get(UCentralConstants.BAND_5G));
+		Set<Integer> txPowerSet = new TreeSet<>();
+		for (String serialNumber : txPowerMap.keySet()) {
+			txPowerSet.addAll(txPowerMap.get(serialNumber).values());
+		}
+		// One unique tx power for all devices and bands
+		assertEquals(1, txPowerSet.size());
+		for (int txPower : txPowerSet) {
+			assertTrue(txPower >= TPC.MIN_TX_POWER && txPower <= TPC.MAX_TX_POWER);
+		}
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -8,9 +8,6 @@
 
 package com.facebook.openwifirrm.optimizers.tpc;
 
-import java.util.*;
-
-import com.facebook.openwifirrm.DeviceConfig;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -22,7 +19,14 @@ import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.models.State;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 @TestMethodOrder(OrderAnnotation.class)
 public class RandomTxPowerInitializerTest {


### PR DESCRIPTION
1. Enable Random tx Power Initializer in 2G.
2. Add unit test to cover all bands and default tx power.