### PR TITLE
[WIFI-10593] Allow different values per AP for `RandomChannelInitializer` and `RandomTxPowerInitializer`

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -38,28 +38,29 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 	public static final String ALGORITHM_ID = "random";
 
 	/** The PRNG instance. */
-	private Random rng = new Random();
+	private final Random rng;
 
 	/** Whether to set a different value per AP or use a single value for all APs */
-	private boolean setDifferentChannelsPerAp = false;
+	private final boolean setDifferentChannelsPerAp;
 
 	/** Constructor. */
 	public RandomChannelInitializer(
 		DataModel model, String zone, DeviceDataManager deviceDataManager
 	) {
-		super(model, zone, deviceDataManager);
+		this(model, zone, deviceDataManager, false, new Random());
 	}
 
 	/** Constructor (allows setting different channel per AP) */
 	public RandomChannelInitializer(
 		DataModel model, String zone, DeviceDataManager deviceDataManager, boolean setDifferentChannelsPerAp
 	) {
-		this(model, zone, deviceDataManager);
-		this.setDifferentChannelsPerAp = setDifferentChannelsPerAp;
+		this(model, zone, deviceDataManager, setDifferentChannelsPerAp, new Random());
 	}
 
-	/** Constructor (allows setting different channel per AP and passing
-	 * in a custom Random class to allow seeding) */
+	/**
+	 * Constructor (allows setting different channel per AP and passing
+	 * in a custom Random class to allow seeding)
+	 */
 	public RandomChannelInitializer(
 		DataModel model,
 		String zone,
@@ -67,7 +68,8 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 		boolean setDifferentChannelsPerAp,
 		Random rng
 	) {
-		this(model, zone, deviceDataManager, setDifferentChannelsPerAp);
+		super(model, zone, deviceDataManager);
+		this.setDifferentChannelsPerAp = setDifferentChannelsPerAp;
 		this.rng = rng;
 	}
 
@@ -119,7 +121,9 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 				);
 			}
 
-			// Randomly assign all the devices to the same channel
+			// Randomly assign all the devices to the same channel if
+			// setDifferentChannelsPerAp is false otherwise, assigns
+			// each device to a random channel
 			int defaultChannelIndex = rng.nextInt(availableChannelsList.size());
 
 			for (String serialNumber : entry.getValue()) {

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -43,20 +43,6 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 	/** Whether to set a different value per AP or use a single value for all APs */
 	private final boolean setDifferentChannelsPerAp;
 
-	/** Constructor. */
-	public RandomChannelInitializer(
-		DataModel model, String zone, DeviceDataManager deviceDataManager
-	) {
-		this(model, zone, deviceDataManager, false, new Random());
-	}
-
-	/** Constructor (allows setting different channel per AP) */
-	public RandomChannelInitializer(
-		DataModel model, String zone, DeviceDataManager deviceDataManager, boolean setDifferentChannelsPerAp
-	) {
-		this(model, zone, deviceDataManager, setDifferentChannelsPerAp, new Random());
-	}
-
 	/**
 	 * Constructor (allows setting different channel per AP and passing
 	 * in a custom Random class to allow seeding)
@@ -71,6 +57,20 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 		super(model, zone, deviceDataManager);
 		this.setDifferentChannelsPerAp = setDifferentChannelsPerAp;
 		this.rng = rng;
+	}
+
+	/** Constructor (allows setting different channel per AP) */
+	public RandomChannelInitializer(
+		DataModel model, String zone, DeviceDataManager deviceDataManager, boolean setDifferentChannelsPerAp
+	) {
+		this(model, zone, deviceDataManager, setDifferentChannelsPerAp, new Random());
+	}
+
+	/** Constructor. */
+	public RandomChannelInitializer(
+		DataModel model, String zone, DeviceDataManager deviceDataManager
+	) {
+		this(model, zone, deviceDataManager, false);
 	}
 
 	@Override

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -32,7 +32,8 @@ import com.facebook.openwifirrm.ucentral.models.State;
  * If specified, all APs will be assigned a random channel.
  */
 public class RandomChannelInitializer extends ChannelOptimizer {
-	private static final Logger logger = LoggerFactory.getLogger(RandomChannelInitializer.class);
+	private static final Logger logger =
+		LoggerFactory.getLogger(RandomChannelInitializer.class);
 
 	/** The RRM algorithm ID. */
 	public static final String ALGORITHM_ID = "random";
@@ -61,14 +62,25 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 
 	/** Constructor (allows setting different channel per AP) */
 	public RandomChannelInitializer(
-		DataModel model, String zone, DeviceDataManager deviceDataManager, boolean setDifferentChannelsPerAp
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		boolean setDifferentChannelsPerAp
 	) {
-		this(model, zone, deviceDataManager, setDifferentChannelsPerAp, new Random());
+		this(
+			model,
+			zone,
+			deviceDataManager,
+			setDifferentChannelsPerAp,
+			new Random()
+		);
 	}
 
 	/** Constructor. */
 	public RandomChannelInitializer(
-		DataModel model, String zone, DeviceDataManager deviceDataManager
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager
 	) {
 		this(model, zone, deviceDataManager, false);
 	}
@@ -86,7 +98,8 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 				AVAILABLE_CHANNELS_BAND
 			);
 
-		Map<String, String> bssidsMap = UCentralUtils.getBssidsMap(model.latestState);
+		Map<String, String> bssidsMap =
+			UCentralUtils.getBssidsMap(model.latestState);
 
 		for (Map.Entry<String, List<String>> entry : bandsMap.entrySet()) {
 			// Performance metrics
@@ -95,9 +108,12 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 
 			// Use last wifi scan result for the performance metrics calculation
 			String band = entry.getKey();
-			Map<String, List<WifiScanEntry>> deviceToWifiScans = getDeviceToWiFiScans(
-				band, model.latestWifiScans, bandsMap
-			);
+			Map<String, List<WifiScanEntry>> deviceToWifiScans =
+				getDeviceToWiFiScans(
+					band,
+					model.latestWifiScans,
+					bandsMap
+				);
 
 			// Get the common available channels for all the devices
 			// to get the valid result for single channel assignment
@@ -107,17 +123,22 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 			);
 			for (String serialNumber : entry.getValue()) {
 				List<Integer> deviceChannelsList = deviceAvailableChannels
-					.get(band).get(serialNumber);
-				if (deviceChannelsList == null || deviceChannelsList.isEmpty()) {
+					.get(band)
+					.get(serialNumber);
+				if (
+					deviceChannelsList == null || deviceChannelsList.isEmpty()
+				) {
 					deviceChannelsList = AVAILABLE_CHANNELS_BAND.get(band);
 				}
 				availableChannelsList.retainAll(deviceChannelsList);
 			}
-			if (availableChannelsList == null || availableChannelsList.isEmpty()) {
+			if (
+				availableChannelsList == null || availableChannelsList.isEmpty()
+			) {
 				availableChannelsList = AVAILABLE_CHANNELS_BAND.get(band);
 				logger.debug(
 					"The intersection of the device channels lists is empty!!! " +
-					"Fall back to the default channels list"
+						"Fall back to the default channels list"
 				);
 			}
 
@@ -128,8 +149,8 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 
 			for (String serialNumber : entry.getValue()) {
 				int newChannel = availableChannelsList.get(
-					this.setDifferentChannelsPerAp ?
-						rng.nextInt(availableChannelsList.size()) : defaultChannelIndex
+					this.setDifferentChannelsPerAp
+						? rng.nextInt(availableChannelsList.size()) : defaultChannelIndex
 				);
 
 				State state = model.latestState.get(serialNumber);
@@ -147,7 +168,8 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 					);
 					continue;
 				}
-				int[] currentChannelInfo = getCurrentChannel(band, serialNumber, state);
+				int[] currentChannelInfo =
+					getCurrentChannel(band, serialNumber, state);
 				int currentChannel = currentChannelInfo[0];
 				int currentChannelWidth = currentChannelInfo[1];
 				if (currentChannel == 0) {
@@ -162,9 +184,13 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 				}
 
 				// Log the notice when the updated one and the original one are not equal
-				List<Integer> newAvailableChannelsList = updateAvailableChannelsList(
-					band, serialNumber, currentChannelWidth, availableChannelsList
-				);
+				List<Integer> newAvailableChannelsList =
+					updateAvailableChannelsList(
+						band,
+						serialNumber,
+						currentChannelWidth,
+						availableChannelsList
+					);
 				Set<Integer> availableChannelsSet = new TreeSet<>(
 					availableChannelsList
 				);
@@ -174,18 +200,19 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 				if (!availableChannelsSet.equals(newAvailableChannelsSet)) {
 					logger.info(
 						"Device {}: userChannels/allowedChannels are disabled in " +
-						"single channel assignment.",
+							"single channel assignment.",
 						serialNumber
 					);
 				}
 
 				channelMap.computeIfAbsent(
-					serialNumber, k -> new TreeMap<>()
+					serialNumber,
+					k -> new TreeMap<>()
 				)
-				.put(band, newChannel);
+					.put(band, newChannel);
 				logger.info(
 					"Device {}: Assigning to random free channel {} (from " +
-					"available list: {})",
+						"available list: {})",
 					serialNumber,
 					newChannel,
 					availableChannelsList.toString()
@@ -196,7 +223,12 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 				newChannelMap.put(serialNumber, newChannel);
 			}
 			// Get and log the performance metrics
-			logPerfMetrics(oldChannelMap, newChannelMap, deviceToWifiScans, bssidsMap);
+			logPerfMetrics(
+				oldChannelMap,
+				newChannelMap,
+				deviceToWifiScans,
+				bssidsMap
+			);
 		}
 
 		return channelMap;

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -25,7 +25,8 @@ import com.facebook.openwifirrm.ucentral.UCentralConstants;
  * Random picks a single tx power and assigns the value to all APs.
  */
 public class RandomTxPowerInitializer extends TPC {
-	private static final Logger logger = LoggerFactory.getLogger(RandomTxPowerInitializer.class);
+	private static final Logger logger =
+		LoggerFactory.getLogger(RandomTxPowerInitializer.class);
 
 	/** The RRM algorithm ID. */
 	public static final String ALGORITHM_ID = "random";
@@ -54,21 +55,33 @@ public class RandomTxPowerInitializer extends TPC {
 
 	/** Constructor (uses random tx power per AP). */
 	public RandomTxPowerInitializer(
-		DataModel model, String zone, DeviceDataManager deviceDataManager, boolean setDifferentTxPowerPerAp
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		boolean setDifferentTxPowerPerAp
 	) {
-		this(model, zone, deviceDataManager, setDifferentTxPowerPerAp, new Random());
+		this(
+			model,
+			zone,
+			deviceDataManager,
+			setDifferentTxPowerPerAp,
+			new Random()
+		);
 	}
 
 	/** Constructor (uses random tx power). */
 	public RandomTxPowerInitializer(
-		DataModel model, String zone, DeviceDataManager deviceDataManager
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager
 	) {
 		this(model, zone, deviceDataManager, false, new Random());
 	}
 
 	/** Get a random tx power in [MIN_TX_POWER, MAX_TX_POWER], both inclusive */
 	public int getRandomTxPower() {
-		return rng.nextInt(TPC.MAX_TX_POWER + 1 - TPC.MIN_TX_POWER) + TPC.MIN_TX_POWER;
+		return rng.nextInt(TPC.MAX_TX_POWER + 1 - TPC.MIN_TX_POWER) +
+			TPC.MIN_TX_POWER;
 	}
 
 	@Override
@@ -77,14 +90,19 @@ public class RandomTxPowerInitializer extends TPC {
 		logger.info("Default power: {}", defaultTxPower);
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
 		for (String serialNumber : model.latestState.keySet()) {
-			int txPower = setDifferentTxPowerPerAp ? getRandomTxPower() : defaultTxPower;
+			int txPower =
+				setDifferentTxPowerPerAp ? getRandomTxPower() : defaultTxPower;
 			Map<String, Integer> radioMap = new TreeMap<>();
 			for (String band : UCentralConstants.BANDS) {
 				radioMap.put(band, txPower);
 			}
 			txPowerMap.put(serialNumber, radioMap);
 
-			logger.info("Device {}: Assigning tx power = {}", serialNumber, txPower);
+			logger.info(
+				"Device {}: Assigning tx power = {}",
+				serialNumber,
+				txPower
+			);
 		}
 
 		return txPowerMap;

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -11,7 +11,6 @@ package com.facebook.openwifirrm.optimizers.tpc;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
-import java.util.LinkedList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,12 +31,15 @@ public class RandomTxPowerInitializer extends TPC {
 	public static final String ALGORITHM_ID = "random";
 
 	/** The PRNG instance. */
-	private Random rng = new Random();
+	private final Random rng;
 
 	/** Whether to set a different value per AP or use a single value for all APs */
-	private boolean setDifferentTxPowerPerAp = false;
+	private final boolean setDifferentTxPowerPerAp;
 
-	/** Constructor (uses random tx power per AP and allows passing in a custom Random class to allow seeding). */
+	/**
+	 * Constructor (uses random tx power per AP and allows passing in a custom
+	 * Random class to allow seeding).
+	 */
 	public RandomTxPowerInitializer(
 		DataModel model,
 		String zone,
@@ -45,7 +47,8 @@ public class RandomTxPowerInitializer extends TPC {
 		boolean setDifferentTxPowerPerAp,
 		Random rng
 	) {
-		this(model, zone, deviceDataManager, setDifferentTxPowerPerAp);
+		super(model, zone, deviceDataManager);
+		this.setDifferentTxPowerPerAp = setDifferentTxPowerPerAp;
 		this.rng = rng;
 	}
 
@@ -53,15 +56,14 @@ public class RandomTxPowerInitializer extends TPC {
 	public RandomTxPowerInitializer(
 		DataModel model, String zone, DeviceDataManager deviceDataManager, boolean setDifferentTxPowerPerAp
 	) {
-		this(model, zone, deviceDataManager);
-		this.setDifferentTxPowerPerAp = setDifferentTxPowerPerAp;
+		this(model, zone, deviceDataManager, setDifferentTxPowerPerAp, new Random());
 	}
 
 	/** Constructor (uses random tx power). */
 	public RandomTxPowerInitializer(
 		DataModel model, String zone, DeviceDataManager deviceDataManager
 	) {
-		super(model, zone, deviceDataManager);
+		this(model, zone, deviceDataManager, false, new Random());
 	}
 
 	/** Get a random tx power in [MIN_TX_POWER, MAX_TX_POWER], both inclusive */

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
@@ -47,20 +47,26 @@ public class RandomChannelInitializerTest {
 		// A and B will be assigned to the same channel
 		DataModel dataModel = new DataModel();
 		dataModel.latestState.put(
-			deviceA, TestUtils.createState(6, channelWidth, deviceABssid)
+			deviceA,
+			TestUtils.createState(6, channelWidth, deviceABssid)
 		);
 		dataModel.latestState.put(
-			deviceB, TestUtils.createState(11, channelWidth, deviceBBssid)
+			deviceB,
+			TestUtils.createState(11, channelWidth, deviceBBssid)
 		);
 		dataModel.latestDeviceStatus.put(
-			deviceA, TestUtils.createDeviceStatus(band, 7)
+			deviceA,
+			TestUtils.createDeviceStatus(band, 7)
 		);
 		dataModel.latestDeviceStatus.put(
-			deviceB, TestUtils.createDeviceStatus(band, 8)
+			deviceB,
+			TestUtils.createDeviceStatus(band, 8)
 		);
 
 		ChannelOptimizer optimizer = new RandomChannelInitializer(
-			dataModel, TEST_ZONE, deviceDataManager
+			dataModel,
+			TEST_ZONE,
+			deviceDataManager
 		);
 		Map<String, Map<String, Integer>> channelMap =
 			optimizer.computeChannelMap();
@@ -86,20 +92,28 @@ public class RandomChannelInitializerTest {
 		// A and B will be assigned to the same channel
 		DataModel dataModel = new DataModel();
 		dataModel.latestState.put(
-			deviceA, TestUtils.createState(6, channelWidth, deviceABssid)
+			deviceA,
+			TestUtils.createState(6, channelWidth, deviceABssid)
 		);
 		dataModel.latestState.put(
-			deviceB, TestUtils.createState(11, channelWidth, deviceBBssid)
+			deviceB,
+			TestUtils.createState(11, channelWidth, deviceBBssid)
 		);
 		dataModel.latestDeviceStatus.put(
-			deviceA, TestUtils.createDeviceStatus(band, 7)
+			deviceA,
+			TestUtils.createDeviceStatus(band, 7)
 		);
 		dataModel.latestDeviceStatus.put(
-			deviceB, TestUtils.createDeviceStatus(band, 8)
+			deviceB,
+			TestUtils.createDeviceStatus(band, 8)
 		);
 
 		ChannelOptimizer optimizer = new RandomChannelInitializer(
-			dataModel, TEST_ZONE, deviceDataManager, true, new Random(10)
+			dataModel,
+			TEST_ZONE,
+			deviceDataManager,
+			true,
+			new Random(10)
 		);
 		Map<String, Map<String, Integer>> channelMap =
 			optimizer.computeChannelMap();

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
@@ -9,8 +9,10 @@
 package com.facebook.openwifirrm.optimizers.channel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Map;
+import java.util.Random;
 
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -62,5 +64,45 @@ public class RandomChannelInitializerTest {
 			optimizer.computeChannelMap();
 
 		assertEquals(channelMap.get(deviceA), channelMap.get(deviceB));
+	}
+
+	@Test
+	@Order(2)
+	void testSettingDifferentChannelPerAp() throws Exception {
+		final String band = UCentralConstants.BAND_2G;
+		final String deviceA = "aaaaaaaaaaaa";
+		final String deviceB = "bbbbbbbbbbbb";
+		final int channelWidth = 20;
+
+		DeviceDataManager deviceDataManager = new DeviceDataManager();
+		deviceDataManager.setTopology(
+			TestUtils.createTopology(TEST_ZONE, deviceA, deviceB)
+		);
+
+		// A and B will be assigned to the same channel
+		DataModel dataModel = new DataModel();
+		dataModel.latestState.put(
+			deviceA, TestUtils.createState(6, channelWidth, "ddd")
+		);
+		dataModel.latestState.put(
+			deviceB, TestUtils.createState(11, channelWidth, "eee")
+		);
+		dataModel.latestDeviceStatus.put(
+			deviceA, TestUtils.createDeviceStatus(band, 7)
+		);
+		dataModel.latestDeviceStatus.put(
+			deviceB, TestUtils.createDeviceStatus(band, 8)
+		);
+
+		ChannelOptimizer optimizer = new RandomChannelInitializer(
+			dataModel, TEST_ZONE, deviceDataManager, true, new Random(10)
+		);
+		Map<String, Map<String, Integer>> channelMap =
+			optimizer.computeChannelMap();
+
+		Map<String, Integer> deviceAChannel = channelMap.get(deviceA);
+		Map<String, Integer> deviceBChannel = channelMap.get(deviceB);
+
+		assertNotEquals(deviceAChannel, deviceBChannel);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
@@ -35,6 +35,8 @@ public class RandomChannelInitializerTest {
 		final String band = UCentralConstants.BAND_2G;
 		final String deviceA = "aaaaaaaaaaaa";
 		final String deviceB = "bbbbbbbbbbbb";
+		final String deviceABssid = "aa:aa:aa:aa:aa:aa";
+		final String deviceBBssid = "bb:bb:bb:bb:bb:bb";
 		final int channelWidth = 20;
 
 		DeviceDataManager deviceDataManager = new DeviceDataManager();
@@ -45,10 +47,10 @@ public class RandomChannelInitializerTest {
 		// A and B will be assigned to the same channel
 		DataModel dataModel = new DataModel();
 		dataModel.latestState.put(
-			deviceA, TestUtils.createState(6, channelWidth, "ddd")
+			deviceA, TestUtils.createState(6, channelWidth, deviceABssid)
 		);
 		dataModel.latestState.put(
-			deviceB, TestUtils.createState(11, channelWidth, "eee")
+			deviceB, TestUtils.createState(11, channelWidth, deviceBBssid)
 		);
 		dataModel.latestDeviceStatus.put(
 			deviceA, TestUtils.createDeviceStatus(band, 7)
@@ -72,6 +74,8 @@ public class RandomChannelInitializerTest {
 		final String band = UCentralConstants.BAND_2G;
 		final String deviceA = "aaaaaaaaaaaa";
 		final String deviceB = "bbbbbbbbbbbb";
+		final String deviceABssid = "aa:aa:aa:aa:aa:aa";
+		final String deviceBBssid = "bb:bb:bb:bb:bb:bb";
 		final int channelWidth = 20;
 
 		DeviceDataManager deviceDataManager = new DeviceDataManager();
@@ -82,10 +86,10 @@ public class RandomChannelInitializerTest {
 		// A and B will be assigned to the same channel
 		DataModel dataModel = new DataModel();
 		dataModel.latestState.put(
-			deviceA, TestUtils.createState(6, channelWidth, "ddd")
+			deviceA, TestUtils.createState(6, channelWidth, deviceABssid)
 		);
 		dataModel.latestState.put(
-			deviceB, TestUtils.createState(11, channelWidth, "eee")
+			deviceB, TestUtils.createState(11, channelWidth, deviceBBssid)
 		);
 		dataModel.latestDeviceStatus.put(
 			deviceA, TestUtils.createDeviceStatus(band, 7)

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -19,7 +19,6 @@ import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.models.State;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -27,7 +26,6 @@ import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 
 @TestMethodOrder(OrderAnnotation.class)
 public class RandomTxPowerInitializerTest {
@@ -68,7 +66,11 @@ public class RandomTxPowerInitializerTest {
 	@Order(1)
 	void testSeededTxPower() throws Exception {
 		TPC optimizer = new RandomTxPowerInitializer(
-			createModel(), TEST_ZONE, createDeviceDataManager(), false, new Random(0)
+			createModel(),
+			TEST_ZONE,
+			createDeviceDataManager(),
+			false,
+			new Random(0)
 		);
 
 		Map<String, Map<String, Integer>> txPowerMap =
@@ -86,7 +88,9 @@ public class RandomTxPowerInitializerTest {
 	@Order(2)
 	void testRandomTxPower() throws Exception {
 		TPC optimizer = new RandomTxPowerInitializer(
-			createModel(), TEST_ZONE, createDeviceDataManager()
+			createModel(),
+			TEST_ZONE,
+			createDeviceDataManager()
 		);
 		Map<String, Map<String, Integer>> txPowerMap =
 			optimizer.computeTxPowerMap();
@@ -97,7 +101,9 @@ public class RandomTxPowerInitializerTest {
 		// One unique tx power for all devices and bands
 		assertEquals(1, txPowerSet.size());
 		for (int txPower : txPowerSet) {
-			assertTrue(txPower >= TPC.MIN_TX_POWER && txPower <= TPC.MAX_TX_POWER);
+			assertTrue(
+				txPower >= TPC.MIN_TX_POWER && txPower <= TPC.MAX_TX_POWER
+			);
 		}
 	}
 
@@ -105,7 +111,11 @@ public class RandomTxPowerInitializerTest {
 	@Order(3)
 	void testRandomTxPowerPerAp() throws Exception {
 		TPC optimizer = new RandomTxPowerInitializer(
-			createModel(), TEST_ZONE, createDeviceDataManager(), true, new Random(0)
+			createModel(),
+			TEST_ZONE,
+			createDeviceDataManager(),
+			true,
+			new Random(0)
 		);
 		Map<String, Map<String, Integer>> txPowerMap =
 			optimizer.computeTxPowerMap();
@@ -117,7 +127,9 @@ public class RandomTxPowerInitializerTest {
 		// different values per AP
 		assertTrue(txPowerSet.size() > 1);
 		for (int txPower : txPowerSet) {
-			assertTrue(txPower >= TPC.MIN_TX_POWER && txPower <= TPC.MAX_TX_POWER);
+			assertTrue(
+				txPower >= TPC.MIN_TX_POWER && txPower <= TPC.MAX_TX_POWER
+			);
 		}
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -19,7 +19,6 @@ import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.models.State;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -27,7 +26,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -66,36 +64,21 @@ public class RandomTxPowerInitializerTest {
 		return dataModel;
 	}
 
-	/**
-	 * Return the first value provided by Random, for each key seed
-	 */
-	private static Map<Integer, Integer> mapRngSeedToFirstValue() {
-		Map<Integer, Integer> map = new HashMap<>();
-		map.put(0, 2);
-		map.put(10, 9);
-		map.put(100, 10);
-
-		return map;
-	}
-
 	@Test
 	@Order(1)
 	void testSeededTxPower() throws Exception {
-		Map<Integer, Integer> seedMap = mapRngSeedToFirstValue();
+		TPC optimizer = new RandomTxPowerInitializer(
+			createModel(), TEST_ZONE, createDeviceDataManager(), false, new Random(0)
+		);
 
-		for (Map.Entry<Integer, Integer> entry : seedMap.entrySet()) {
-			TPC optimizer = new RandomTxPowerInitializer(
-				createModel(), TEST_ZONE, createDeviceDataManager(), false, new Random(entry.getKey())
-			);
+		Map<String, Map<String, Integer>> txPowerMap =
+			optimizer.computeTxPowerMap();
 
-			Map<String, Map<String, Integer>> txPowerMap =
-				optimizer.computeTxPowerMap();
-
-			int txPower = entry.getValue();
-			for (String band : UCentralConstants.BANDS) {
-				assertEquals(txPower, txPowerMap.get(DEVICE_A).get(band));
-				assertEquals(txPower, txPowerMap.get(DEVICE_B).get(band));
-			}
+		// first generated random number for seed of 0
+		int txPower = 2;
+		for (String band : UCentralConstants.BANDS) {
+			assertEquals(txPower, txPowerMap.get(DEVICE_A).get(band));
+			assertEquals(txPower, txPowerMap.get(DEVICE_B).get(band));
 		}
 	}
 
@@ -132,7 +115,7 @@ public class RandomTxPowerInitializerTest {
 		}
 
 		// different values per AP
-		assertNotEquals(1, txPowerSet.size());
+		assertTrue(txPowerSet.size() > 1);
 		for (int txPower : txPowerSet) {
 			assertTrue(txPower >= TPC.MIN_TX_POWER && txPower <= TPC.MAX_TX_POWER);
 		}


### PR DESCRIPTION
Previously both `RandomChannelInitializer` and `RandomTxPowerInitializer` would initialize a single random value to use across APs. Introduce another constructor to allow setting a different random value PER AP.

In addition:
- Make  `RandomTxPowerInitializer` follow `RandomChannelInitializer`'s lead in terms of how random values are generated. Instead of holding an attribute for the generated value, it'll be generated on the fly since the value isn't used outside of computing the map.
- Add another constructor that also allows passing in a `Random` instance to allow seeding, making testing possible by having the number generation deterministic. I didn't expose a method for setting the seed as that would introduce weird cases where numbers could have been generated but then the seed was changed.

[WIFI-10593](https://telecominfraproject.atlassian.net/browse/WIFI-10593)