### PR TITLE
[WIFI-10655] Gracefully abort topology sync with prov in case of bad data

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -142,7 +142,14 @@ public class ProvMonitor implements Runnable {
 				topo.computeIfAbsent(venue, k -> new TreeSet<>());
 			zone.add(tag.serialNumber);
 		}
-		deviceDataManager.setTopology(topo);
+
+		try {
+			deviceDataManager.setTopology(topo);
+		} catch (IllegalArgumentException exc) {
+			logger.info("Failed validating the topology ({}), aborting sync", exc.getMessage());
+			return;
+		}
+
 		logger.info(
 			"Synced topology with owprov: {} zone(s), {} total device(s)",
 			topo.size(),

--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -145,8 +145,8 @@ public class ProvMonitor implements Runnable {
 
 		try {
 			deviceDataManager.setTopology(topo);
-		} catch (IllegalArgumentException exc) {
-			logger.info("Failed validating the topology ({}), aborting sync", exc.getMessage());
+		} catch (IllegalArgumentException e) {
+			logger.error("Invalid topology received from owprov, aborting sync", e);
 			return;
 		}
 


### PR DESCRIPTION
Provisioning service had a bug where it allowed duplicate devices across different venues. RRM has the functionality to check for it but upon receiving this bad data, it will just crash the whole process. Handle it gracefully by handling `IllegalArgumentException`, log the error, and just abort the sync.

Open question:
- How do I test? I thought I'd go about mocking it but looking at the testing framework used (Junit), mocking is not included. Should I bring in Mockito, mock out the client and test?