### PR TITLE
Enable MeasurementBasedApClientTPC in 2G

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -108,7 +108,7 @@ public class MeasurementBasedApClientTPC extends TPC {
 		return SNR_min + currentTxPower - clientRssi + NP + NF - M;
 	}
 
-	/** Compute adjusted tx power (dBm) for the given radio. */
+	/** Compute new tx power (dBm) for the given radio. */
 	private int computeTxPowerForRadio(
 		String serialNumber, State state, JsonObject radio
 	) {

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -249,6 +249,8 @@ public class MeasurementBasedApClientTPC extends TPC {
 				if (currentChannel == null) {
 					continue;
 				}
+
+				// TODO: check if band can be directly got from config rather than mapped from channel
 				String band = UCentralUtils.getBandFromChannel(currentChannel);
 				if (band == null) {
 					continue;

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -250,7 +250,6 @@ public class MeasurementBasedApClientTPC extends TPC {
 					continue;
 				}
 
-				// TODO: check if band can be directly got from config rather than mapped from channel
 				String band = UCentralUtils.getBandFromChannel(currentChannel);
 				if (band == null) {
 					continue;

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,12 +108,11 @@ public class MeasurementBasedApClientTPC extends TPC {
 		return SNR_min + currentTxPower - clientRssi + NP + NF - M;
 	}
 
-	/** Compute adjusted tx power (dBm) for the given device. */
-	private int computeTxPowerForDevice(
-		String serialNumber, State state, int radioIndex
+	/** Compute adjusted tx power (dBm) for the given radio. */
+	private int computeTxPowerForRadio(
+		String serialNumber, State state, JsonObject radio
 	) {
 		// Find current tx power and bandwidth
-		JsonObject radio = state.radios[radioIndex];
 		int currentTxPower =
 			radio.has("tx_power") && !radio.get("tx_power").isJsonNull()
 				? radio.get("tx_power").getAsInt()
@@ -239,13 +239,25 @@ public class MeasurementBasedApClientTPC extends TPC {
 				);
 				continue;
 			}
-			// TODO: only using first radio
-			final int radioIndex = 0;
-
-			int newTxPower =
-				computeTxPowerForDevice(serialNumber, state, radioIndex);
 			Map<String, Integer> radioMap = new TreeMap<>();
-			radioMap.put(UCentralConstants.BAND_5G, newTxPower);
+
+			for (JsonObject radio: state.radios) {
+				Integer currentChannel =
+					radio.has("channel") && !radio.get("channel").isJsonNull()
+						? radio.get("channel").getAsInt()
+						: null;
+				if (currentChannel == null) {
+					continue;
+				}
+				String band = UCentralUtils.getBandFromChannel(currentChannel);
+				if (band == null) {
+					continue;
+				}
+				int newTxPower =
+					computeTxPowerForRadio(serialNumber, state, radio);
+
+				radioMap.put(band, newTxPower);
+			}
 			txPowerMap.put(serialNumber, radioMap);
 		}
 

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -391,7 +391,6 @@ public class UCentralUtils {
 				&& channel <= UPPER_CHANNEL_LIMIT.get(band);
 	}
 
-	// TODO: Remove this method if band can be directly got from config
 	/**
 	 * Given the channel, gets the band by checking lower bound and upper bound
 	 * of each band

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -390,4 +390,13 @@ public class UCentralUtils {
 		return LOWER_CHANNEL_LIMIT.get(band) <= channel
 				&& channel <= UPPER_CHANNEL_LIMIT.get(band);
 	}
+
+	public static String getBandFromChannel(int channel) {
+		for (String band: UCentralConstants.BANDS) {
+			if (isChannelInBand(channel, band)) {
+				return band;
+			}
+		}
+		return null;
+	}
 }

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -391,6 +391,7 @@ public class UCentralUtils {
 				&& channel <= UPPER_CHANNEL_LIMIT.get(band);
 	}
 
+	// TODO: Remove this method if band can be directly got from config
 	/**
 	 * Given the channel, gets the band by checking lower bound and upper bound
 	 * of each band

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -391,6 +391,13 @@ public class UCentralUtils {
 				&& channel <= UPPER_CHANNEL_LIMIT.get(band);
 	}
 
+	/**
+	 * Given the channel, gets the band by checking lower bound and upper bound
+	 * of each band
+	 *
+	 * @param channel channel number
+	 * @return band if the channel can be mapped to a valid band; null otherwise
+	 */
 	public static String getBandFromChannel(int channel) {
 		for (String band: UCentralConstants.BANDS) {
 			if (isChannelInBand(channel, band)) {

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -418,6 +418,8 @@ public class TestUtils {
 			state.interfaces[i].ssids[0].associations =
 				new State.Interface.SSID.Association[clientRssis[i].length];
 			for (int j = 0; j < clientRssis[i].length; j++) {
+				state.interfaces[i].ssids[0].associations[j] =
+					state.interfaces[i].ssids[0].new Association();
 				state.interfaces[i].ssids[0].associations[j].rssi = clientRssis[i][j];
 			}
 		}
@@ -453,11 +455,7 @@ public class TestUtils {
 	}
 
 	/**
-<<<<<<< HEAD
 	 * Create a device state object with one radio.
-=======
-	 * Create a device state object with one radio and client RSSIs.
->>>>>>> 37806df (Resolve comments)
 	 *
 	 * @param channel channel number
 	 * @param channelWidth channel width in MHz
@@ -471,7 +469,7 @@ public class TestUtils {
 		int channelWidth,
 		int txPower,
 		String bssid,
-		int[] clientRssis,
+		int[] clientRssis
 	) {
 		return createState(
 			new int[] { channel },

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -383,10 +383,15 @@ public class TestUtils {
 	 * @param channelWidths array of channel widths (MHz)
 	 * @param txPowers array of tx powers (dBm)
 	 * @param bssids array of BSSIDs
+	 * @param clientRssis 2-D array of client RSSIs
 	 * @return the state of an AP with radios described by the given parameters
 	 */
 	public static State createState(
-		int[] channels, int[] channelWidths, int[] txPowers, String[] bssids
+		int[] channels,
+		int[] channelWidths,
+		int[] txPowers,
+		String[] bssids,
+		int[][] clientRssis
 	) {
 		if (!(channels.length == channelWidths.length
 			&& channelWidths.length == txPowers.length
@@ -410,6 +415,11 @@ public class TestUtils {
 			state.radios[i].addProperty("channel_width", channelWidths[i]);
 			state.radios[i].addProperty("tx_power", txPowers[i]);
 			state.interfaces[i].ssids[0].bssid = bssids[i];
+			state.interfaces[i].ssids[0].associations =
+				new State.Interface.SSID.Association[clientRssis[i].length];
+			for (int j = 0; j < clientRssis[i].length; j++) {
+				state.interfaces[i].ssids[0].associations[j].rssi = clientRssis[i][j];
+			}
 		}
 		state.unit = createStateUnit();
 		return state;
@@ -438,10 +448,33 @@ public class TestUtils {
 	 */
 	public static State createState(int channel, int channelWidth, int txPower, String bssid) {
 		return createState(
+			channel, channelWidth, txPower, bssid, new int[] {}
+		);
+	}
+
+	/**
+	 * Create a device state object with one radio.
+	 *
+	 * @param channel channel number
+	 * @param channelWidth channel width in MHz
+	 * @param txPower tx power in dBm
+	 * @param bssid bssid
+	 * @param clientRssis array of client RSSIs
+	 * @return the state of an AP with one radio
+	 */
+	public static State createState(
+		int channel,
+		int channelWidth,
+		int txPower,
+		String bssid,
+		int[] clientRssis,
+	) {
+		return createState(
 			new int[] { channel },
 			new int[] { channelWidth },
 			new int[] { txPower },
-			new String[] { bssid }
+			new String[] { bssid },
+			new int[][] { clientRssis }
 		);
 	}
 
@@ -469,10 +502,52 @@ public class TestUtils {
 		String bssidB
 	) {
 		return createState(
+			channelA,
+			channelWidthA,
+			txPowerA,
+			bssidA,
+			new int[] {},
+			channelB,
+			channelWidthB,
+			txPowerB,
+			bssidB,
+			new int[] {}
+		);
+	}
+
+	/**
+	 * Create a device state object with two radios.
+	 *
+	 * @param channelA channel number
+	 * @param channelWidthA channel width (MHz) of channelA
+	 * @param txPowerA tx power for channelA
+	 * @param bssidA bssid for radio on channelA
+	 * @param clientRssisA array of client RSSIs for channelA
+	 * @param channelB channel number
+	 * @param channelWidthB channel width (MHz) of channelB
+	 * @param txPowerB tx power for channelB
+	 * @param bssidB bssid for radio on channelB
+	 * @param clientRssisB array of client RSSIs for channelB
+	 * @return the state of an AP with two radios
+	 */
+	public static State createState(
+		int channelA,
+		int channelWidthA,
+		int txPowerA,
+		String bssidA,
+		int[] clientRssisA,
+		int channelB,
+		int channelWidthB,
+		int txPowerB,
+		String bssidB,
+		int[] clientRssisB
+	) {
+		return createState(
 			new int[] { channelA, channelB },
 			new int[] { channelWidthA, channelWidthB },
 			new int[] { txPowerA, txPowerB },
-			new String[] { bssidA, bssidB }
+			new String[] { bssidA, bssidB },
+			new int[][] { clientRssisA, clientRssisB }
 		);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -453,7 +453,11 @@ public class TestUtils {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * Create a device state object with one radio.
+=======
+	 * Create a device state object with one radio and client RSSIs.
+>>>>>>> 37806df (Resolve comments)
 	 *
 	 * @param channel channel number
 	 * @param channelWidth channel width in MHz

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
@@ -23,47 +23,11 @@ import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
-import com.facebook.openwifirrm.ucentral.models.State;
-import com.google.gson.JsonObject;
 
 @TestMethodOrder(OrderAnnotation.class)
 public class MeasurementBasedApClientTPCTest {
 	/** Test zone name. */
 	private static final String TEST_ZONE = "test-zone";
-
-	/** Create a device state object containing the given parameters. */
-	private State createState(
-		String serialNumber, int curTxPower, int bandwidth, int[] channels, int... clientRssi
-	) {
-		State state = new State();
-		state.radios = new JsonObject[channels.length];
-		int curIndex = 0;
-		for (int channel : channels) {
-			JsonObject radio = new JsonObject();
-			radio.addProperty("channel", channel);
-			radio.addProperty(
-				"channel_width", Integer.toString(bandwidth)
-			);
-			radio.addProperty("tx_power", curTxPower);
-			state.radios[curIndex] = radio;
-			curIndex += 1;
-		}
-		state.interfaces = new State.Interface[] { state.new Interface() };
-		state.interfaces[0].ssids = new State.Interface.SSID[] {
-			state.interfaces[0].new SSID()
-		};
-		state.interfaces[0].ssids[0].ssid = "test-ssid-" + serialNumber;
-		state.interfaces[0].ssids[0].associations =
-			new State.Interface.SSID.Association[clientRssi.length];
-		for (int i = 0; i < clientRssi.length; i++) {
-			State.Interface.SSID.Association client =
-				state.interfaces[0].ssids[0].new Association();
-			client.bssid = client.station = "test-client-" + i;
-			client.rssi = clientRssi[i];
-			state.interfaces[0].ssids[0].associations[i] = client;
-		}
-		return state;
-	}
 
 	@Test
 	@Order(1)
@@ -84,23 +48,23 @@ public class MeasurementBasedApClientTPCTest {
 		DataModel dataModel = new DataModel();
 		dataModel.latestState.put(
 			deviceA,
-			createState(deviceA, 20 /*txPower*/, 20 /*bandwidth*/, new int[] {36} /*channel*/)
+			TestUtils.createState(36, 20, 20, null, new int[] {})
 		);
 		dataModel.latestState.put(
 			deviceB,
-			createState(deviceB, 20 /*txPower*/, 20 /*bandwidth*/, new int[] {36}, -65)
+			TestUtils.createState(36, 20, 20, "", new int[] {-65})
 		);
 		dataModel.latestState.put(
 			deviceC,
-			createState(deviceC, 21 /*txPower*/, 40 /*bandwidth*/, new int[] {36}, -65, -73, -58)
+			TestUtils.createState(36,40, 21, null, new int[] {-65, -73, -58})
 		);
 		dataModel.latestState.put(
 			deviceD,
-			createState(deviceD, 22 /*txPower*/, 20 /*bandwidth*/, new int[] {36},-80)
+			TestUtils.createState(36, 20, 22, null, new int[] {-80})
 		);
 		dataModel.latestState.put(
 			deviceE,
-			createState(deviceE, 23 /*txPower*/, 20 /*bandwidth*/, new int[] {36}, -45)
+			TestUtils.createState(36, 20, 23, null, new int[] {-45})
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(dataModel, TEST_ZONE, deviceDataManager);
@@ -142,22 +106,22 @@ public class MeasurementBasedApClientTPCTest {
 		// 2G only
 		dataModel.latestState.put(
 			deviceA,
-			createState(deviceA, 20 /*txPower*/, 20 /*bandwidth*/, new int[]{2} /*channel*/)
+			TestUtils.createState(1, 20, 20, null, new int[] {})
 		);
 		// 5G only
 		dataModel.latestState.put(
 			deviceB,
-			createState(deviceB, 20 /*txPower*/, 20 /*bandwidth*/, new int[]{36} /*channel*/)
+			TestUtils.createState(36, 20, 20, null, new int[] {})
 		);
 		// 2G and 5G
 		dataModel.latestState.put(
 			deviceC,
-			createState(deviceC, 20 /*txPower*/, 20 /*bandwidth*/, new int[]{2, 36} /*channel*/)
+			TestUtils.createState(1, 20, 20, null, new int[] {}, 36, 20, 20, null, new int[] {})
 		);
 		// No valid bands in 2G or 5G
 		dataModel.latestState.put(
 			deviceD,
-			createState(deviceA, 20 /*txPower*/, 20 /*bandwidth*/, new int[]{25} /*channel*/)
+			TestUtils.createState(25, 20, 20, null, new int[] {})
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(dataModel, TEST_ZONE, deviceDataManager);


### PR DESCRIPTION
1. Add a new util method to determine the band with the given channel.
2. Instead of only using the first radio, iterate over all the radios for each device when compute Tx power in `MeasurementBasedApClientTPC`.
3. Instead of hardcode the band as `5G`, leverage the new method to determine the band for each radio.
4. Add test cases for the changes.

@pohanhf some questions regarding the radios and channels:
1. Is it possible to have a channel that cannot be mapped to either 2G or 5G?
2. Is it possible to have a device with two channels mapping to the same band? e.g. A device with two radios, whose channels are 36 and 60.