### PR TITLE
Set thread names

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/RRM.java
+++ b/src/main/java/com/facebook/openwifirrm/RRM.java
@@ -44,11 +44,14 @@ public class RRM {
 	 * Wrap a {@code Runnable} as a {@code Callable<Object>}.
 	 *
 	 * This is similar to {@link Executors#callable(Runnable)} but will log any
-	 * exceptions thrown and then call {@link System#exit(int)}.
+	 * exceptions thrown and then call {@link System#exit(int)}, and will also
+	 * name the threads.
 	 */
 	private static Callable<Object> wrapRunnable(Runnable task) {
 		return () -> {
 			try {
+				Thread.currentThread()
+					.setName("RRM_" + task.getClass().getSimpleName());
 				task.run();
 			} catch (Exception e) {
 				logger.error("Exception raised in task!", e);

--- a/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import com.facebook.openwifirrm.DeviceConfig;
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.RRMConfig.ModuleConfig.DataCollectorParams;
+import com.facebook.openwifirrm.Utils;
 import com.facebook.openwifirrm.mysql.DatabaseManager;
 import com.facebook.openwifirrm.mysql.StateRecord;
 import com.facebook.openwifirrm.ucentral.UCentralApConfiguration;
@@ -115,7 +116,12 @@ public class DataCollector implements Runnable {
 		this.client = client;
 		this.dbManager = dbManager;
 		this.executor =
-			Executors.newFixedThreadPool(params.executorThreadCount);
+			Executors.newFixedThreadPool(
+				params.executorThreadCount,
+				new Utils.NamedThreadFactory(
+					"RRM_" + this.getClass().getSimpleName()
+				)
+			);
 
 		// Register config hooks
 		configManager.addConfigListener(


### PR DESCRIPTION
Set thread names for all program threads (modules and executors). `NamedThreadFactory` is a copy of `Executors.DefaultThreadFactory` which accepts a name prefix.