### PR TITLE
Update Dockerfile to use OpenJ9 JVM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ WORKDIR /usr/src/java
 COPY . .
 RUN mvn clean package -DappendVersionString="$(./scripts/get_build_version.sh)"
 
-FROM openjdk:11
-RUN apt-get update && apt-get install -y gettext-base
+FROM adoptopenjdk/openjdk11-openj9:latest
+RUN apt-get update && apt-get install -y gettext-base wget
 RUN wget https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-ucentral-deploy/main/docker-compose/certs/restapi-ca.pem \
     -O /usr/local/share/ca-certificates/restapi-ca-selfsigned.pem
 RUN mkdir /owrrm-data
@@ -13,7 +13,8 @@ COPY docker-entrypoint.sh /
 COPY --from=build /usr/src/java/target/openwifi-rrm.jar /usr/local/bin/
 EXPOSE 16789
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["java", "-jar", "/usr/local/bin/openwifi-rrm.jar", \
+CMD ["java", "-XX:+IdleTuningGcOnIdle", "-Xtune:virtualized", \
+     "-jar", "/usr/local/bin/openwifi-rrm.jar", \
      "run", "--config-env", \
      "-t", "/owrrm-data/topology.json", \
      "-d", "/owrrm-data/device_config.json"]


### PR DESCRIPTION
"docker-library/openjdk" is deprecated, so switch to another JDK image (AdoptOpenJDK). While here, switch from HotSpot to Eclipse OpenJ9 JVM, and tweak some JVM flags, in an attempt to reduce resource usage.

- Idle memory (RSS): ~200MB before (HotSpot), ~120MB after (OpenJ9)
- CPU: not measured at this time

Tested by restarting containers and fetching OpenAPI document to memory (by loading `/` in a browser).