### PR TITLE
Add multi-band check for MeasurementBasedApApTPC

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -267,6 +267,10 @@ public class MeasurementBasedApApTPC extends TPC {
 			}
 			JsonArray radioStatuses = allStatuses.get(serialNumber).getAsJsonArray();
 			int currentTxPower = getCurrentTxPower(radioStatuses, band);
+			if (currentTxPower == 0) {
+				// this AP is not on the band of interest
+				continue;
+			}
 			String bssid = state.interfaces[0].ssids[0].bssid;
 			List<Integer> rssiValues = bssidToRssiValues.get(bssid);
 			logger.debug("Device <{}> : BSSID <{}>", serialNumber, bssid);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -112,14 +113,17 @@ public class MeasurementBasedApApTPC extends TPC {
 	}
 
 	/**
-	 * Get the current band radio tx power (the first one found) for an AP using the
-	 * latest device status.
+	 * Get the current band radio tx power (the first one found) for an AP using
+	 * the latest device status.
 	 *
 	 * @param latestDeviceStatus JsonArray containing radio config for the AP
-	 * @param band "2G" or "5G"
-	 * @return the tx power, or -1 if none found
+	 * @param band band (e.g., "2G")
+	 * @return an Optional containing the tx power if one exists, or else an
+	 *         empty Optional
 	 */
-	protected static int getCurrentTxPower(JsonArray latestDeviceStatus, String band) {
+	protected static Optional<Integer> getCurrentTxPower(
+		JsonArray latestDeviceStatus, String band
+	) {
 		for (JsonElement e : latestDeviceStatus) {
 			if (!e.isJsonObject()) {
 				continue;
@@ -127,10 +131,10 @@ public class MeasurementBasedApApTPC extends TPC {
 			JsonObject radioObject = e.getAsJsonObject();
 			String radioBand = radioObject.get("band").getAsString();
 			if (radioBand.equals(band) && radioObject.has("tx-power")) {
-				return radioObject.get("tx-power").getAsInt();
+				return Optional.of(radioObject.get("tx-power").getAsInt());
 			}
 		}
-		return -1;
+		return Optional.empty();
 	}
 
 	/**
@@ -266,11 +270,14 @@ public class MeasurementBasedApApTPC extends TPC {
 				continue;
 			}
 			JsonArray radioStatuses = allStatuses.get(serialNumber).getAsJsonArray();
-			int currentTxPower = getCurrentTxPower(radioStatuses, band);
-			if (currentTxPower < 0) {
+			Optional<Integer> possibleCurrentTxPower = getCurrentTxPower(
+				radioStatuses, band
+			);
+			if (possibleCurrentTxPower.isEmpty()) {
 				// this AP is not on the band of interest
 				continue;
 			}
+			int currentTxPower = possibleCurrentTxPower.get();
 			String bssid = state.interfaces[0].ssids[0].bssid;
 			List<Integer> rssiValues = bssidToRssiValues.get(bssid);
 			logger.debug("Device <{}> : BSSID <{}>", serialNumber, bssid);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -117,7 +117,7 @@ public class MeasurementBasedApApTPC extends TPC {
 	 *
 	 * @param latestDeviceStatus JsonArray containing radio config for the AP
 	 * @param band "2G" or "5G"
-	 * @return the tx power, or 0 if none found
+	 * @return the tx power, or -1 if none found
 	 */
 	protected static int getCurrentTxPower(JsonArray latestDeviceStatus, String band) {
 		for (JsonElement e : latestDeviceStatus) {
@@ -130,7 +130,7 @@ public class MeasurementBasedApApTPC extends TPC {
 				return radioObject.get("tx-power").getAsInt();
 			}
 		}
-		return 0;
+		return -1;
 	}
 
 	/**
@@ -267,7 +267,7 @@ public class MeasurementBasedApApTPC extends TPC {
 			}
 			JsonArray radioStatuses = allStatuses.get(serialNumber).getAsJsonArray();
 			int currentTxPower = getCurrentTxPower(radioStatuses, band);
-			if (currentTxPower == 0) {
+			if (currentTxPower < 0) {
 				// this AP is not on the band of interest
 				continue;
 			}

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -18,6 +18,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import com.facebook.openwifirrm.DeviceTopology;
+import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.UCentralUtils.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.models.State;
@@ -34,6 +35,8 @@ public class TestUtils {
 
 	/** Default channel width in MHz */
 	public static final int DEFAULT_CHANNEL_WIDTH = 20;
+	/** Default tx power in dBm */
+	public static final int DEFAULT_TX_POWER = 20;
 
 	/** Create a topology from the given devices in a single zone. */
 	public static DeviceTopology createTopology(String zone, String... devices) {
@@ -52,15 +55,16 @@ public class TestUtils {
 	 * @return a radio info object as a {@code JsonObject}
 	 */
 	private static JsonObject createDeviceStatusRadioObject(
-		String band, int channel, int channelWidth
+		String band, int channel, int channelWidth, int txPower
 	) {
 		return gson.fromJson(
 			String.format(
 				"{\"band\": %s,\"channel\": %d,\"channel-mode\":\"HE\","
-					+ "\"channel-width\":%d,\"country\":\"CA\",\"tx-power\":20}",
+					+ "\"channel-width\":%d,\"country\":\"CA\",\"tx-power\":%d}",
 				band,
 				channel,
-				channelWidth
+				channelWidth,
+				txPower
 			),
 			JsonObject.class
 		);
@@ -73,7 +77,26 @@ public class TestUtils {
 	public static JsonArray createDeviceStatus(String band, int channel) {
 		JsonArray jsonList = new JsonArray();
 		jsonList.add(createDeviceStatusRadioObject(
-			band, channel, DEFAULT_CHANNEL_WIDTH
+			band, channel, DEFAULT_CHANNEL_WIDTH, DEFAULT_TX_POWER
+		));
+		return jsonList;
+	}
+
+	/**
+	 * Create the device status array.
+	 *
+	 * @param band band (e.g., "2G")
+	 * @param channel channel number
+	 * @param txPower tx power in dBm
+	 * @return an array with one radio info entry with the given band, channel,
+	 *         and tx power
+	 */
+	public static JsonArray createDeviceStatus(
+		String band, int channel, int txPower
+	) {
+		JsonArray jsonList = new JsonArray();
+		jsonList.add(createDeviceStatusRadioObject(
+			band, channel, DEFAULT_CHANNEL_WIDTH, txPower
 		));
 		return jsonList;
 	}
@@ -87,7 +110,7 @@ public class TestUtils {
 		for (String band : bands) {
 			int channel = UCentralUtils.LOWER_CHANNEL_LIMIT.get(band);
 			jsonList.add(createDeviceStatusRadioObject(
-				band, channel, DEFAULT_CHANNEL_WIDTH
+				band, channel, DEFAULT_CHANNEL_WIDTH, DEFAULT_TX_POWER
 			));
 		}
 		return jsonList;
@@ -98,21 +121,13 @@ public class TestUtils {
 	 * tx powers and channels.
 	 */
 	public static JsonArray createDeviceStatusDualBand(int channel2G, int txPower2G, int channel5G, int txPower5G) {
-		JsonArray jsonList = gson.fromJson(
-			String.format(
-				"[{\"band\": \"2G\",\"channel\": %d,\"channel-mode\":\"HE\"," +
-				"\"channel-width\":%d,\"country\":\"CA\",\"tx-power\":%d}," +
-				"{\"band\": \"5G\",\"channel\": %d,\"channel-mode\":\"HE\"," +
-				"\"channel-width\":%d,\"country\":\"CA\",\"tx-power\":%d}]",
-				channel2G,
-				DEFAULT_CHANNEL_WIDTH,
-				txPower2G,
-				channel5G,
-				DEFAULT_CHANNEL_WIDTH,
-				txPower5G
-			),
-			JsonArray.class
-		);
+		JsonArray jsonList = new JsonArray();
+		jsonList.add(createDeviceStatusRadioObject(
+			UCentralConstants.BAND_2G, channel2G, DEFAULT_CHANNEL_WIDTH, txPower2G
+		));
+		jsonList.add(createDeviceStatusRadioObject(
+			UCentralConstants.BAND_5G, channel5G, DEFAULT_CHANNEL_WIDTH, txPower5G
+		));
 		return jsonList;
 	}
 
@@ -409,10 +424,23 @@ public class TestUtils {
 	 * @return the state of an AP with one radio
 	 */
 	public static State createState(int channel, int channelWidth, String bssid) {
+		return createState(channel, channelWidth, DEFAULT_TX_POWER, bssid);
+	}
+
+	/**
+	 * Create a device state object with one radio.
+	 *
+	 * @param channel channel number
+	 * @param channelWidth channel width in MHz
+	 * @param txPower tx power in dBm
+	 * @param bssid bssid
+	 * @return the state of an AP with one radio
+	 */
+	public static State createState(int channel, int channelWidth, int txPower, String bssid) {
 		return createState(
 			new int[] { channel },
 			new int[] { channelWidth },
-			new int[] { 20 },
+			new int[] { txPower },
 			new String[] { bssid }
 		);
 	}

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -366,12 +366,16 @@ public class TestUtils {
 	 *
 	 * @param channels array of channel numbers
 	 * @param channelWidths array of channel widths (MHz)
+	 * @param txPowers array of tx powers (dBm)
 	 * @param bssids array of BSSIDs
 	 * @return the state of an AP with radios described by the given parameters
 	 */
-	public static State createState(int[] channels, int[] channelWidths, String[] bssids) {
+	public static State createState(
+		int[] channels, int[] channelWidths, int[] txPowers, String[] bssids
+	) {
 		if (!(channels.length == channelWidths.length
-			&& channelWidths.length == bssids.length)
+			&& channelWidths.length == txPowers.length
+			&& txPowers.length == bssids.length)
 		) {
 			throw new IllegalArgumentException(
 				"All arguments must have the same length."
@@ -389,7 +393,7 @@ public class TestUtils {
 			state.radios[i] = createStateRadio();
 			state.radios[i].addProperty("channel", channels[i]);
 			state.radios[i].addProperty("channel_width", channelWidths[i]);
-			state.radios[i].addProperty("tx_power", DEFAULT_CHANNEL_WIDTH);
+			state.radios[i].addProperty("tx_power", txPowers[i]);
 			state.interfaces[i].ssids[0].bssid = bssids[i];
 		}
 		state.unit = createStateUnit();
@@ -406,9 +410,10 @@ public class TestUtils {
 	 */
 	public static State createState(int channel, int channelWidth, String bssid) {
 		return createState(
-			new int[] {channel},
-			new int[] {channelWidth},
-			new String[] {bssid}
+			new int[] { channel },
+			new int[] { channelWidth },
+			new int[] { 20 },
+			new String[] { bssid }
 		);
 	}
 
@@ -436,9 +441,10 @@ public class TestUtils {
 		String bssidB
 	) {
 		return createState(
-			new int[] {channelA, channelB},
-			new int[] {channelWidthA, channelWidthB},
-			new String[] {bssidA, bssidB}
+			new int[] { channelA, channelB },
+			new int[] { channelWidthA, channelWidthB },
+			new int[] { txPowerA, txPowerB },
+			new String[] { bssidA, bssidB }
 		);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -11,6 +11,7 @@ package com.facebook.openwifirrm.optimizers.tpc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,6 +157,28 @@ public class MeasurementBasedApApTPCTest {
 		return latestWifiScans;
 	}
 
+	/**
+	 * Returns latest wifiscan map for a {@code DataModel} without wifiscan
+	 * entries from AP C to the other APs.
+	 *
+	 * @param channel channel number
+	 * @return latest wifiscan map for a {@code DataModel}
+	 */
+	private static Map<String, List<List<WifiScanEntry>>> createLatestWifiScansWithMissingEntries(int channel) {
+		Map<String, Integer> rssiFromA = Map.ofEntries(Map.entry(BSSID_B, -38));
+		List<WifiScanEntry> wifiScanA = TestUtils
+			.createWifiScanListWithBssid(rssiFromA, channel);
+
+		Map<String, Integer> rssiFromB = Map.ofEntries(Map.entry(BSSID_A, -39));
+		List<WifiScanEntry> wifiScanB = TestUtils
+			.createWifiScanListWithBssid(rssiFromB, channel);
+
+		Map<String, List<List<WifiScanEntry>>> latestWifiScans = new HashMap<>();
+		latestWifiScans.put(DEVICE_A, List.of(wifiScanA));
+		latestWifiScans.put(DEVICE_B, List.of(wifiScanB));
+		return latestWifiScans;
+	}
+
 	@Test
 	@Order(1)
 	void test_getManagedBSSIDs() throws Exception {
@@ -258,43 +281,39 @@ public class MeasurementBasedApApTPCTest {
 	}
 
 	/**
-	 * Tests the tx power map calculations in the given band.
+	 * Tests the tx power map calculations in the given band. Taken from
+	 * algorithm design doc from @pohanhf
 	 *
-	 * @param band "2G" or "5G"
+	 * @param band band (e.g., "2G")
 	 */
-	private static void testComputeTxPowerMapInBand(String band) {
+	private static void testComputeTxPowerMapSimpleInOneBand(String band) {
 		int channel = UCentralUtils.LOWER_CHANNEL_LIMIT.get(band);
-		// First example here taken from algorithm design doc from @pohanhf
 		DataModel dataModel = createModel();
 		dataModel.latestWifiScans = createLatestWifiScansB(channel);
 		DeviceDataManager deviceDataManager = createDeviceDataManager();
-		MeasurementBasedApApTPC optimizer = new MeasurementBasedApApTPC(dataModel, TEST_ZONE, deviceDataManager, -80, 0);
 
+		MeasurementBasedApApTPC optimizer = new MeasurementBasedApApTPC(dataModel, TEST_ZONE, deviceDataManager, -80, 0);
 		Map<String, Map<String, Integer>> txPowerMap = optimizer.computeTxPowerMap();
 
 		assertEquals(3, txPowerMap.size());
 		assertEquals(2, txPowerMap.get(DEVICE_A).get(band));
 		assertEquals(15, txPowerMap.get(DEVICE_B).get(band));
 		assertEquals(10, txPowerMap.get(DEVICE_C).get(band));
+	}
 
-		// Tests an example where wifiscans are missing some data
-		Map<String, Integer> rssiFromA = Map.ofEntries(Map.entry(BSSID_B, -38));
-		List<WifiScanEntry> wifiScanA = TestUtils.createWifiScanListWithBssid(rssiFromA, channel);
+	/**
+	 * Tests the tx power map calculations without a wifiscan entry from one AP.
+	 *
+	 * @param band band (e.g., "2G")
+	 */
+	private static void testComputeTxPowerMapMissingDataInOneBand(String band) {
+		int channel = UCentralUtils.LOWER_CHANNEL_LIMIT.get(band);
+		DataModel dataModel = createModel();
+		dataModel.latestWifiScans = createLatestWifiScansWithMissingEntries(channel);
+		DeviceDataManager deviceDataManager = createDeviceDataManager();
 
-		Map<String, Integer> rssiFromB = Map.ofEntries(Map.entry(BSSID_A, -39));
-		List<WifiScanEntry> wifiScanB = TestUtils.createWifiScanListWithBssid(rssiFromB, channel);
-
-		Map<String, List<List<WifiScanEntry>>> latestWifiScans = new HashMap<>();
-		latestWifiScans.put(DEVICE_A, List.of(wifiScanA));
-		latestWifiScans.put(DEVICE_B, List.of(wifiScanB));
-
-		dataModel = createModel();
-		dataModel.latestWifiScans = latestWifiScans;
-
-		deviceDataManager = createDeviceDataManager();
-		optimizer = new MeasurementBasedApApTPC(dataModel, TEST_ZONE, deviceDataManager);
-
-		txPowerMap = optimizer.computeTxPowerMap();
+		MeasurementBasedApApTPC optimizer = new MeasurementBasedApApTPC(dataModel, TEST_ZONE, deviceDataManager, -80, 0);
+		Map<String, Map<String, Integer>> txPowerMap = optimizer.computeTxPowerMap();
 
 		assertEquals(3, txPowerMap.size());
 		assertEquals(0, txPowerMap.get(DEVICE_A).get(band));
@@ -306,7 +325,44 @@ public class MeasurementBasedApApTPCTest {
 	@Test
 	@Order(5)
 	void test_computeTxPowerMap() throws Exception {
-		testComputeTxPowerMapInBand(UCentralConstants.BAND_5G);
-		testComputeTxPowerMapInBand(UCentralConstants.BAND_2G);
+		// test each band separately
+		for (String band : UCentralConstants.BANDS) {
+			testComputeTxPowerMapSimpleInOneBand(band);
+			testComputeTxPowerMapMissingDataInOneBand(band);
+		}
+
+		// test both bands simultaneously with different setups on each band
+		DataModel dataModel = createModel();
+		DeviceDataManager deviceDataManager = createDeviceDataManager();
+		// 2G setup
+		final int channel2G = UCentralUtils.LOWER_CHANNEL_LIMIT.get(UCentralConstants.BAND_2G);
+		dataModel.latestWifiScans = createLatestWifiScansB(channel2G);
+		// 5G setup
+		final int channel5G = UCentralUtils.LOWER_CHANNEL_LIMIT.get(UCentralConstants.BAND_5G);
+		Map<String, List<List<WifiScanEntry>>> toMerge = createLatestWifiScansWithMissingEntries(channel5G);
+		for (Map.Entry<String, List<List<WifiScanEntry>>> mapEntry : toMerge.entrySet()) {
+			String serialNumber = mapEntry.getKey();
+			List<WifiScanEntry> entriesToMerge = mapEntry.getValue().get(0);
+			dataModel.latestWifiScans
+				.computeIfAbsent(serialNumber,
+					k -> new ArrayList<List<WifiScanEntry>>())
+				.get(0).addAll(entriesToMerge);
+		}
+
+		MeasurementBasedApApTPC optimizer = new MeasurementBasedApApTPC(dataModel, TEST_ZONE, deviceDataManager, -80, 0);
+		Map<String, Map<String, Integer>> txPowerMap = optimizer.computeTxPowerMap();
+
+		// test 2G band
+		assertEquals(3, txPowerMap.size());
+		assertEquals(2, txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G));
+		assertEquals(15, txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G));
+		assertEquals(10, txPowerMap.get(DEVICE_C).get(UCentralConstants.BAND_2G));
+
+		// test 5G band
+		assertEquals(3, txPowerMap.size());
+		assertEquals(0, txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G));
+		assertEquals(0, txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G));
+		// Since no other APs see a signal from DEVICE_C, we set the tx_power to max
+		assertEquals(30, txPowerMap.get(DEVICE_C).get(UCentralConstants.BAND_5G));
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -88,9 +88,8 @@ public class MeasurementBasedApApTPCTest {
 			MAX_TX_POWER, BSSID_A, 36, DEFAULT_CHANNEL_WIDTH, MAX_TX_POWER, BSSID_A);
 		State stateB = TestUtils.createState(1, DEFAULT_CHANNEL_WIDTH,
 			MAX_TX_POWER, BSSID_B, 36, DEFAULT_CHANNEL_WIDTH, MAX_TX_POWER, BSSID_B);
-		State stateC = TestUtils.createState(
-			1, DEFAULT_CHANNEL_WIDTH, MAX_TX_POWER, BSSID_C
-		);
+		State stateC = TestUtils.createState(1, DEFAULT_CHANNEL_WIDTH,
+			MAX_TX_POWER, BSSID_C, 36, DEFAULT_CHANNEL_WIDTH, MAX_TX_POWER, BSSID_C);
 
 		model.latestState.put(DEVICE_A, stateA);
 		model.latestState.put(DEVICE_B, stateB);
@@ -330,13 +329,16 @@ public class MeasurementBasedApApTPCTest {
 
 	@Test
 	@Order(5)
-	void test_computeTxPowerMap() throws Exception {
-		// test each band separately
+	void test_computeTxPowerMapOnOneBand() throws Exception {
 		for (String band : UCentralConstants.BANDS) {
 			testComputeTxPowerMapSimpleInOneBand(band);
 			testComputeTxPowerMapMissingDataInOneBand(band);
 		}
+	}
 
+	@Test
+	@Order(6)
+	void test_computeTxPowerMapMultiBand() {
 		// test both bands simultaneously with different setups on each band
 		DataModel dataModel = createModel();
 		// make device C not operate in the 5G band instead of dual band
@@ -375,7 +377,6 @@ public class MeasurementBasedApApTPCTest {
 		assertEquals(10, txPowerMap.get(DEVICE_C).get(UCentralConstants.BAND_2G));
 
 		// test 5G band
-		assertEquals(3, txPowerMap.size());
 		assertEquals(0, txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G));
 		assertEquals(0, txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G));
 		// device C is not in the 5G band

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -102,10 +102,12 @@ public class MeasurementBasedApApTPCTest {
 		model.latestDeviceStatus.put(
 			DEVICE_C,
 			deviceCIn5G
-				? TestUtils.createDeviceStatusDualBand(1, MAX_TX_POWER, 36,
-					MAX_TX_POWER)
-				: TestUtils.createDeviceStatus(UCentralConstants.BAND_2G, 1,
-					MAX_TX_POWER)
+				? TestUtils.createDeviceStatusDualBand(
+					1, MAX_TX_POWER, 36, MAX_TX_POWER
+				)
+				: TestUtils.createDeviceStatus(
+					UCentralConstants.BAND_2G, 1, MAX_TX_POWER
+				)
 		);
 
 		return model;
@@ -178,12 +180,14 @@ public class MeasurementBasedApApTPCTest {
 	 */
 	private static Map<String, List<List<WifiScanEntry>>> createLatestWifiScansWithMissingEntries(int channel) {
 		Map<String, Integer> rssiFromA = Map.ofEntries(Map.entry(BSSID_B, -38));
-		List<WifiScanEntry> wifiScanA = TestUtils
-			.createWifiScanListWithBssid(rssiFromA, channel);
+		List<WifiScanEntry> wifiScanA = TestUtils.createWifiScanListWithBssid(
+			rssiFromA, channel
+		);
 
 		Map<String, Integer> rssiFromB = Map.ofEntries(Map.entry(BSSID_A, -39));
-		List<WifiScanEntry> wifiScanB = TestUtils
-			.createWifiScanListWithBssid(rssiFromB, channel);
+		List<WifiScanEntry> wifiScanB = TestUtils.createWifiScanListWithBssid(
+			rssiFromB, channel
+		);
 
 		Map<String, List<List<WifiScanEntry>>> latestWifiScans = new HashMap<>();
 		latestWifiScans.put(DEVICE_A, List.of(wifiScanA));
@@ -356,9 +360,12 @@ public class MeasurementBasedApApTPCTest {
 			String serialNumber = mapEntry.getKey();
 			List<WifiScanEntry> entriesToMerge = mapEntry.getValue().get(0);
 			dataModel.latestWifiScans
-				.computeIfAbsent(serialNumber,
-					k -> new ArrayList<List<WifiScanEntry>>())
-				.get(0).addAll(entriesToMerge);
+				.computeIfAbsent(
+					serialNumber,
+					k -> new ArrayList<List<WifiScanEntry>>()
+				)
+				.get(0)
+				.addAll(entriesToMerge);
 		}
 
 		MeasurementBasedApApTPC optimizer = new MeasurementBasedApApTPC(dataModel, TEST_ZONE, deviceDataManager, -80, 0);


### PR DESCRIPTION
In `MeasurementBasedApApTPC`, make sure it only sets tx power  for a (device, band) if that device operates in that band. This PR includes:
- A few lines in `MeasurementBasedApApTPC` to implement this behavior
- Many changes in `MeasurementBasedApApTPCTest` to test the behavior
- Changes to `TestUtils` both to support the changes in `MeasurementBasedApApTPCTest` and to fix a minor bug from a previous PR