### PR TITLE
Implement a POST/system command required by OpenWIFI SDK

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -325,6 +325,29 @@ paths:
           description: Success
         "400":
           description: Bad Request
+  /api/v1/setSystem:
+    post:
+      tags:
+      - SDK
+      summary: System commands details
+      description: Perform some system wide commands.
+      operationId: systemCommand
+      requestBody:
+        description: Command details
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JSONObject'
+        required: true
+      responses:
+        "200":
+          description: Successful command execution
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Bad Request
   /api/v1/setTopology:
     post:
       tags:
@@ -527,6 +550,11 @@ components:
             additionalProperties:
               type: integer
               format: int32
+    JSONObject:
+      type: object
+      properties:
+        empty:
+          type: boolean
     Certificate:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -325,19 +325,43 @@ paths:
           description: Success
         "400":
           description: Bad Request
-  /api/v1/setSystem:
+  /api/v1/system:
+    get:
+      tags:
+      - SDK
+      summary: Get system info
+      description: Returns the system info from the running service.
+      operationId: system
+      parameters:
+      - name: command
+        in: query
+        description: Get a value
+        required: true
+        schema:
+          type: string
+          enum:
+          - info
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemInfoResults'
+        "400":
+          description: Bad Request
     post:
       tags:
       - SDK
-      summary: System commands details
-      description: Perform some system wide commands.
-      operationId: systemCommand
+      summary: Run system commands
+      description: Perform some system-wide commands.
+      operationId: setSystem
       requestBody:
         description: Command details
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JSONObject'
+              type: object
         required: true
       responses:
         "200":
@@ -365,31 +389,6 @@ paths:
       responses:
         "200":
           description: Success
-        "400":
-          description: Bad Request
-  /api/v1/system:
-    get:
-      tags:
-      - SDK
-      summary: Get system info
-      description: Returns the system info from the running service.
-      operationId: system
-      parameters:
-      - name: command
-        in: query
-        description: Get a value
-        required: true
-        schema:
-          type: string
-          enum:
-          - info
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SystemInfoResults'
         "400":
           description: Bad Request
 components:
@@ -550,11 +549,6 @@ components:
             additionalProperties:
               type: integer
               format: int32
-    JSONObject:
-      type: object
-      properties:
-        empty:
-          type: boolean
     Certificate:
       type: object
       properties:

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -30,6 +30,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.json.JSONObject;
 import org.reflections.Reflections;
 import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
@@ -212,6 +213,7 @@ public class ApiServer implements Runnable {
 		Spark.after(this::afterFilter);
 		Spark.options("/*", this::options);
 		Spark.get("/api/v1/system", new SystemEndpoint());
+		Spark.post("/api/v1/setSystem", new SetSystemEndpoint());
 		Spark.get("/api/v1/provider", new ProviderEndpoint());
 		Spark.get("/api/v1/algorithms", new AlgorithmsEndpoint());
 		Spark.put("/api/v1/runRRM", new RunRRMEndpoint());
@@ -518,6 +520,51 @@ public class ApiServer implements Runnable {
 
 			response.type(MediaType.APPLICATION_JSON);
 			return gson.toJson(result);
+		}
+	}
+	
+	@Path("/api/v1/setSystem")
+	public class SetSystemEndpoint implements Route {
+		@POST
+		@Produces({ MediaType.APPLICATION_JSON })
+		@Operation(
+			summary = "System commands details", 
+			description = "Perform some system wide commands.", 
+			operationId = "systemCommand", 
+			tags = {"SDK" }, 
+			requestBody = @RequestBody(
+				description = "Command details", 
+				content = {
+					@Content(
+						mediaType = "application/json", 
+						schema = @Schema(implementation = JSONObject.class))
+				}, 
+				required = true
+			), 
+			responses = {
+				@ApiResponse(
+					responseCode = "200", 
+					description = "Successful command execution", 
+					content = @Content(
+						// TODO: Provide a specific class as value of Schema.implementation
+						schema = @Schema(implementation = Object.class)
+					)
+				),
+				@ApiResponse(responseCode = "400", description = "Bad Request")
+			}
+		)
+		@Override
+		public String handle(
+				@Parameter(hidden = true) Request request,
+				@Parameter(hidden = true) Response response
+		) {
+			try {
+				JSONObject obj = gson.fromJson(request.body(), JSONObject.class);
+			} catch (Exception e) {
+				response.status(400);
+				return e.getMessage();
+			}
+			return "";
 		}
 	}
 

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -559,17 +559,13 @@ public class ApiServer implements Runnable {
 				@Parameter(hidden = true) Response response
 		) {
 			try {
-				JSONObject json_obj = new JSONObject(request.body());
-				String command = json_obj.get("command").toString();
+				JSONObject jsonObj = new JSONObject(request.body());
+				String command = jsonObj.get("command").toString();
 				switch (command) {
 					case "setloglevel":
-						return "[]";
 					case "reload":
-						return "[]";
 					case "getloglevels":
-						return "[]";
 					case "getloglevelnames":
-						return "[]";
 					case "getsubsystemnames":
 						return "[]";
 					default:

--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -213,7 +213,7 @@ public class ApiServer implements Runnable {
 		Spark.after(this::afterFilter);
 		Spark.options("/*", this::options);
 		Spark.get("/api/v1/system", new SystemEndpoint());
-		Spark.post("/api/v1/setSystem", new SetSystemEndpoint());
+		Spark.post("/api/v1/system", new SetSystemEndpoint());
 		Spark.get("/api/v1/provider", new ProviderEndpoint());
 		Spark.get("/api/v1/algorithms", new AlgorithmsEndpoint());
 		Spark.put("/api/v1/runRRM", new RunRRMEndpoint());
@@ -522,22 +522,22 @@ public class ApiServer implements Runnable {
 			return gson.toJson(result);
 		}
 	}
-	
-	@Path("/api/v1/setSystem")
+	@Path("/api/v1/system")
 	public class SetSystemEndpoint implements Route {
 		@POST
 		@Produces({ MediaType.APPLICATION_JSON })
 		@Operation(
-			summary = "System commands details", 
-			description = "Perform some system wide commands.", 
-			operationId = "systemCommand", 
+			summary = "Run system commands", 
+			description = "Perform some system-wide commands.", 
+			operationId = "setSystem", 
 			tags = {"SDK" }, 
 			requestBody = @RequestBody(
 				description = "Command details", 
 				content = {
 					@Content(
 						mediaType = "application/json", 
-						schema = @Schema(implementation = JSONObject.class))
+						schema = @Schema(implementation = Object.class)
+					)
 				}, 
 				required = true
 			), 
@@ -559,12 +559,27 @@ public class ApiServer implements Runnable {
 				@Parameter(hidden = true) Response response
 		) {
 			try {
-				JSONObject obj = gson.fromJson(request.body(), JSONObject.class);
+				JSONObject json_obj = new JSONObject(request.body());
+				String command = json_obj.get("command").toString();
+				switch (command) {
+					case "setloglevel":
+						return "[]";
+					case "reload":
+						return "[]";
+					case "getloglevels":
+						return "[]";
+					case "getloglevelnames":
+						return "[]";
+					case "getsubsystemnames":
+						return "[]";
+					default:
+						response.status(400);
+						return "Invalid command";
+				}
 			} catch (Exception e) {
 				response.status(400);
 				return e.getMessage();
 			}
-			return "";
 		}
 	}
 

--- a/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
@@ -515,20 +515,19 @@ public class ApiServerTest {
 		// Test on POST api
 		String url = endpoint("/api/v1/system");
 		// Valid command
-		JSONObject json_obj = new JSONObject("{\"command\": \"reload\"}");
 		HttpResponse<String> post_resp = Unirest
 				.post(url)
-				.body(json_obj)
+				.body("{\"command\": \"reload\"}")
 				.asString();
 		assertEquals(200, post_resp.getStatus());
 
 		// Missing/wrong parameters
 		assertEquals(
 			400, 
-			Unirest.post(url).body(new JSONObject("{\"command\": \"xxx\"}")).asString().getStatus());
+			Unirest.post(url).body("{\"command\": \"xxx\"}").asString().getStatus());
 		assertEquals(
 			400,
-			Unirest.post(url).body(new JSONObject("{\"invalid command\": \"xxx\"}")).asString().getStatus()
+			Unirest.post(url).body("{\"invalid command\": \"xxx\"}").asString().getStatus()
 		);
 	}
 

--- a/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
@@ -507,9 +507,29 @@ public class ApiServerTest {
 	@Test
 	@Order(2000)
 	void test_system() throws Exception {
-		HttpResponse<JsonNode> resp = Unirest.get(endpoint("/api/v1/system?command=info")).asJson();
-		assertEquals(200, resp.getStatus());
-		assertEquals(VersionProvider.get(), resp.getBody().getObject().getString("version"));
+		// Test on GET api
+		HttpResponse<JsonNode> get_resp = Unirest.get(endpoint("/api/v1/system?command=info")).asJson();
+		assertEquals(200, get_resp.getStatus());
+		assertEquals(VersionProvider.get(), get_resp.getBody().getObject().getString("version"));
+
+		// Test on POST api
+		String url = endpoint("/api/v1/system");
+		// Valid command
+		JSONObject json_obj = new JSONObject("{\"command\": \"reload\"}");
+		HttpResponse<String> post_resp = Unirest
+				.post(url)
+				.body(json_obj)
+				.asString();
+		assertEquals(200, post_resp.getStatus());
+
+		// Missing/wrong parameters
+		assertEquals(
+			400, 
+			Unirest.post(url).body(new JSONObject("{\"command\": \"xxx\"}")).asString().getStatus());
+		assertEquals(
+			400,
+			Unirest.post(url).body(new JSONObject("{\"invalid command\": \"xxx\"}")).asString().getStatus()
+		);
 	}
 
 	@Test
@@ -558,26 +578,5 @@ public class ApiServerTest {
 		assertEquals(400, Unirest.put(url).asString().getStatus());
 		assertEquals(400, Unirest.put(url + "?mode=test123&venue=" + zone).asString().getStatus());
 		assertEquals(400, Unirest.put(url + "?venue=asdf&algorithm=" + algorithms.get(0)).asString().getStatus());
-	}
-
-
-	@Test
-	@Order(2004)
-	void test_setSystem() throws Exception {
-		String url = endpoint("/api/v1/setSystem");
-
-		// Create JSONObject
-		JSONObject json_obj = new JSONObject();
-		json_obj.put("aa", 'a');
-		json_obj.put("bb", 'b');
-		
-		HttpResponse<String> resp = Unirest
-			.post(url)
-			.body(gson.toJson(json_obj))
-			.asString();
-		assertEquals(200, resp.getStatus());
-
-		// Missing/wrong parameters
-		assertEquals(400, Unirest.post(url).body("not json").asString().getStatus());
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ApiServerTest.java
@@ -559,4 +559,25 @@ public class ApiServerTest {
 		assertEquals(400, Unirest.put(url + "?mode=test123&venue=" + zone).asString().getStatus());
 		assertEquals(400, Unirest.put(url + "?venue=asdf&algorithm=" + algorithms.get(0)).asString().getStatus());
 	}
+
+
+	@Test
+	@Order(2004)
+	void test_setSystem() throws Exception {
+		String url = endpoint("/api/v1/setSystem");
+
+		// Create JSONObject
+		JSONObject json_obj = new JSONObject();
+		json_obj.put("aa", 'a');
+		json_obj.put("bb", 'b');
+		
+		HttpResponse<String> resp = Unirest
+			.post(url)
+			.body(gson.toJson(json_obj))
+			.asString();
+		assertEquals(200, resp.getStatus());
+
+		// Missing/wrong parameters
+		assertEquals(400, Unirest.post(url).body("not json").asString().getStatus());
+	}
 }


### PR DESCRIPTION
This PR implemented a POST command required by OpenWifi SDK. 
- In `ApiServer.java`, add a new EndPoint `SetSystemEndpoint` to implement POST.
 -- requestBody: Parse this as a JSONObject as  the value of Schema.implementation 
--  responses: Content of `Schema` is Object.class and leave a TODO comment in the code. Simply return "[]" for each valid command.

- Add unit test in `ApiServerTest.java` to test the changes.
- openapi.yaml is auto-generated

Test plan:

1. valid command: `{"command": "getloglevelnames"}`

<img width="1424" alt="Screen Shot 2022-08-30 at 2 23 39 PM" src="https://user-images.githubusercontent.com/60716841/187546870-1f344f77-d0c4-41fe-b204-1d9df2273d32.png">

2. invalid command: `{"command": "xx"}`
<img width="1415" alt="Screen Shot 2022-08-30 at 2 23 59 PM" src="https://user-images.githubusercontent.com/60716841/187547101-3ed03185-b7ec-4015-ac0b-47848273124c.png">
3. invalid command: : `{"xx": "xx"}`
<img width="1420" alt="Screen Shot 2022-08-30 at 2 24 15 PM" src="https://user-images.githubusercontent.com/60716841/187547233-5f670d09-e0f5-4da5-9293-7e5fab97ed3b.png">

