### PR TITLE
Use current time for aggregation

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -334,7 +334,12 @@ public class ModelerUtils {
 				}
 				if (agg.getCount() > 0) {
 					aggregatedWifiScans.get(serialNumber).get(bssid).signal = (int) Math.round(agg.getAggregate());
+				} else {
+					aggregatedWifiScans
+						.computeIfAbsent(serialNumber, k -> new HashMap<>())
+						.put(bssid, mostRecentEntry);
 				}
+
 			}
 		}
 		return aggregatedWifiScans;

--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -237,28 +237,34 @@ public class ModelerUtils {
 	}
 
 	/**
-	 * For each AP, for each other AP that sent a wifiscan entry to that AP, this
-	 * method calculates an aggregate wifiscan entry with an aggregated RSSI.
+	 * For each AP, for each other AP that sent a wifiscan entry to that AP,
+	 * this method calculates an aggregate wifiscan entry with an aggregated
+	 * RSSI. If no non-obsolete entry exists, the latest wifiscan entry is used
+	 * instead.
 	 *
-	 * @param dataModel          the data model which includes the latest wifiscan
-	 *                           entries
-	 * @param obsoletionPeriodMs for each (scanning AP, responding AP) tuple, the
-	 *                           maximum amount of time (in milliseconds) it is
-	 *                           worth aggregating over, starting from the most
-	 *                           recent scan entry for that tuple, and working
-	 *                           backwards in time. An entry exactly
-	 *                           {@code obsoletionPeriodMs} ms earlier than the most
-	 *                           recent entry is considered non-obsolete (i.e., the
-	 *                           "non-obsolete" window is inclusive). Must be
-	 *                           non-negative.
+	 * @param dataModel          the data model which includes the latest
+	 *                           wifiscan entries
+	 * @param obsoletionPeriodMs for each (scanning AP, responding AP) tuple,
+	 *                           the maximum amount of time (in milliseconds) it
+	 *                           is worth aggregating over, starting from the
+	 *                           most recent scan entry for that tuple, and
+	 *                           working backwards in time. An entry exactly
+	 *                           {@code obsoletionPeriodMs} ms earlier than the
+	 *                           most recent entry is considered non-obsolete
+	 *                           (i.e., the "non-obsolete" window is inclusive).
+	 *                           Must be non-negative.
 	 * @param agg                an aggregator to calculate the aggregated RSSI
 	 *                           given recent wifiscan entries' RSSIs.
-	 * @return a map from AP serial number to a map from BSSID to an "aggregated
-	 *         wifiscan entry". This aggregated entry is the most recent entry with
-	 *         its {@code signal} attribute modified to be the aggregated signal
-	 *         value instead of the value in just the most recent entry for that (AP
-	 *         serial number, BSSID) tuple. The returned map will only contain APs
-	 *         which received at least one non-obsolete wifiscan entry from a BSS.
+	 * @return a map from AP serial number to a map from BSSID to a
+	 *         {@WifiScanEntry} object. This object is an "aggregated wifiscan
+	 *         entry" unless there is no non-obsolete wifiscan entry, in which
+	 *         case the latest wifiscan entry is used. An aggregated entry is
+	 *         just the latest entry with its {@code signal} attribute modified
+	 *         to be the aggregated signal value instead of the value in just
+	 *         the most recent entry for that (AP serial number, BSSID) tuple.
+	 *         The returned map will only map an (AP, BSSID) to an entry if an
+	 *         least one entry from that BSSID to that AP exists in
+	 *         {@link Modeler.DataModel#latestWifiScans}
 	 */
 	public static Map<String, Map<String, WifiScanEntry>> getAggregatedWifiScans(
 		Modeler.DataModel dataModel,

--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifirrm.aggregators.Aggregator;
+import com.facebook.openwifirrm.aggregators.MeanAggregator;
 import com.facebook.openwifirrm.ucentral.UCentralUtils.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.operationelement.HTOperationElement;
 import com.facebook.openwifirrm.ucentral.operationelement.VHTOperationElement;
@@ -259,9 +260,30 @@ public class ModelerUtils {
 	 *         serial number, BSSID) tuple. The returned map will only contain APs
 	 *         which received at least one non-obsolete wifiscan entry from a BSS.
 	 */
-	public static Map<String, Map<String, WifiScanEntry>> getAggregatedWifiScans(Modeler.DataModel dataModel,
-			long obsoletionPeriodMs,
-			Aggregator<Double> agg) {
+	public static Map<String, Map<String, WifiScanEntry>> getAggregatedWifiScans(
+		Modeler.DataModel dataModel,
+		long obsoletionPeriodMs,
+		Aggregator<Double> agg
+	) {
+		return getAggregatedWifiScans(
+			dataModel,
+			obsoletionPeriodMs,
+			new MeanAggregator(),
+			System.currentTimeMillis()
+		);
+	}
+
+	/**
+	 * @see #getAggregatedWifiScans(com.facebook.openwifirrm.modules.Modeler.DataModel, long, Aggregator)
+	 * <p>
+	 * These two methods were separated to make testing easier, since it relies on current time.
+	 */
+	public static Map<String, Map<String, WifiScanEntry>> getAggregatedWifiScans(
+		Modeler.DataModel dataModel,
+		long obsoletionPeriodMs,
+		Aggregator<Double> agg,
+		long currentUnixTimeMs
+	) {
 		if (obsoletionPeriodMs < 0) {
 			throw new IllegalArgumentException("obsoletionPeriodMs must be non-negative.");
 		}
@@ -299,7 +321,7 @@ public class ModelerUtils {
 				WifiScanEntry mostRecentEntry = entries.get(0);
 				agg.reset();
 				for (WifiScanEntry entry : entries) {
-					if (mostRecentEntry.unixTimeMs - entry.unixTimeMs > obsoletionPeriodMs) {
+					if (currentUnixTimeMs - entry.unixTimeMs > obsoletionPeriodMs) {
 						// discard obsolete entries
 						break;
 					}

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -156,7 +156,7 @@ public class ModelerUtilsTest {
 			dataModel, obsoletionPeriodMs, new MeanAggregator(), currentUnixTimeMs
 		);
 		expectedAggregatedEntryAToB = new WifiScanEntry(entryAToB3);
-		expectedAggregatedEntryAToB.signal = -62; // average of -60, -62, and -64 3;
+		expectedAggregatedEntryAToB.signal = -62; // average of -60, -62, and -64;
 		assertEquals(expectedAggregatedEntryAToB, aggregateMap.get(apB).get(bssidA));
 		// test moving the boundary by 1 ms and excluding the earliest entry
 		aggregateMap = ModelerUtils.getAggregatedWifiScans(
@@ -183,7 +183,7 @@ public class ModelerUtilsTest {
 		);
 		WifiScanEntry expectedAggregatedEntryCToB = new WifiScanEntry(entryCToB1);
 		assertEquals(expectedAggregatedEntryCToB, aggregateMap.get(apB).get(bssidC));
-		assertFalse(aggregateMap.containsKey(apA));
+		assertFalse(aggregateMap.get(apB).containsKey(bssidA));
 
 		// test multiple entries in one scan and scans from multiple APs
 		WifiScanEntry entryAToB4 = TestUtils.createWifiScanEntryWithBssid(1, bssidA);

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -183,7 +183,7 @@ public class ModelerUtilsTest {
 		);
 		WifiScanEntry expectedAggregatedEntryCToB = new WifiScanEntry(entryCToB1);
 		assertEquals(expectedAggregatedEntryCToB, aggregateMap.get(apB).get(bssidC));
-		assertFalse(aggregateMap.get(apB).containsKey(bssidA));
+		assertEquals(entryAToB3, aggregateMap.get(apB).get(bssidA));
 
 		// test multiple entries in one scan and scans from multiple APs
 		WifiScanEntry entryAToB4 = TestUtils.createWifiScanEntryWithBssid(1, bssidA);


### PR DESCRIPTION
This PR is based on a discussion I had with Po-Han and Haleema. Basically, we actually should be using the current time to determine obsoletion in wifiscan entry aggregation. However, if we do not have a recent entry (so there is nothing to aggregate over), we just return the most recent entry (without any aggregation). This PR updates the aggregation logic as well as the tests.