### PR TITLE
reorder constructor for `RandomChannelInitializer` and `RandomTxPowerInitializer`

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -44,20 +44,13 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 	/** Whether to set a different value per AP or use a single value for all APs */
 	private final boolean setDifferentChannelsPerAp;
 
-	/**
-	 * Constructor (allows setting different channel per AP and passing
-	 * in a custom Random class to allow seeding)
-	 */
+	/** Constructor. */
 	public RandomChannelInitializer(
 		DataModel model,
 		String zone,
-		DeviceDataManager deviceDataManager,
-		boolean setDifferentChannelsPerAp,
-		Random rng
+		DeviceDataManager deviceDataManager
 	) {
-		super(model, zone, deviceDataManager);
-		this.setDifferentChannelsPerAp = setDifferentChannelsPerAp;
-		this.rng = rng;
+		this(model, zone, deviceDataManager, false);
 	}
 
 	/** Constructor (allows setting different channel per AP) */
@@ -76,13 +69,20 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 		);
 	}
 
-	/** Constructor. */
+	/**
+	 * Constructor (allows setting different channel per AP and passing
+	 * in a custom Random class to allow seeding)
+	 */
 	public RandomChannelInitializer(
 		DataModel model,
 		String zone,
-		DeviceDataManager deviceDataManager
+		DeviceDataManager deviceDataManager,
+		boolean setDifferentChannelsPerAp,
+		Random rng
 	) {
-		this(model, zone, deviceDataManager, false);
+		super(model, zone, deviceDataManager);
+		this.setDifferentChannelsPerAp = setDifferentChannelsPerAp;
+		this.rng = rng;
 	}
 
 	@Override

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -37,20 +37,13 @@ public class RandomTxPowerInitializer extends TPC {
 	/** Whether to set a different value per AP or use a single value for all APs */
 	private final boolean setDifferentTxPowerPerAp;
 
-	/**
-	 * Constructor (uses random tx power per AP and allows passing in a custom
-	 * Random class to allow seeding).
-	 */
+	/** Constructor (uses random tx power). */
 	public RandomTxPowerInitializer(
 		DataModel model,
 		String zone,
-		DeviceDataManager deviceDataManager,
-		boolean setDifferentTxPowerPerAp,
-		Random rng
+		DeviceDataManager deviceDataManager
 	) {
-		super(model, zone, deviceDataManager);
-		this.setDifferentTxPowerPerAp = setDifferentTxPowerPerAp;
-		this.rng = rng;
+		this(model, zone, deviceDataManager, false);
 	}
 
 	/** Constructor (uses random tx power per AP). */
@@ -69,13 +62,20 @@ public class RandomTxPowerInitializer extends TPC {
 		);
 	}
 
-	/** Constructor (uses random tx power). */
+	/**
+	 * Constructor (uses random tx power per AP and allows passing in a custom
+	 * Random class to allow seeding).
+	 */
 	public RandomTxPowerInitializer(
 		DataModel model,
 		String zone,
-		DeviceDataManager deviceDataManager
+		DeviceDataManager deviceDataManager,
+		boolean setDifferentTxPowerPerAp,
+		Random rng
 	) {
-		this(model, zone, deviceDataManager, false, new Random());
+		super(model, zone, deviceDataManager);
+		this.setDifferentTxPowerPerAp = setDifferentTxPowerPerAp;
+		this.rng = rng;
 	}
 
 	/** Get a random tx power in [MIN_TX_POWER, MAX_TX_POWER], both inclusive */


### PR DESCRIPTION
I didn't apply this in #47 so fix it in this PR
- reorder constructor
- change `RandomTxPowerInitializer` to cascade constructors properly