### PR TITLE
Pass down RRM algorithm parameters

### DIFF
--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -11,9 +11,8 @@ selected channel. This is only for testing and re-initialization.
 
 Parameters:
 * `mode`: "random"
-* `args`:
-  * `setDifferentChannelPerAp`: If true, will set a different random channel per AP. If false, it will set the same random channel for all APs.
-    * values: true | false (default: false)
+* `setDifferentChannelPerAp`: If true, will set a different random channel per AP. If false, it will set the same random channel for all APs.
+    * values: `true`, `false` (default: `false`)
 
 ### `LeastUsedChannelOptimizer`
 This algorithm assigns the channel of the OWF APs based on the following logic:
@@ -29,7 +28,6 @@ This algorithm assigns the channel of the OWF APs based on the following logic:
 
 Parameters:
 * `mode`: "least_used"
-* `args:`
 
 ### `UnmanagedApAwareChannelOptimizer`
 Building on the least used channel assignment algorithm, this algorithm can
@@ -52,7 +50,6 @@ are based on the following logic:
 
 Parameters:
 * `mode`: "unmanaged_aware"
-* `args:`
 
 ## Transmit Power Control
 `TPC` and its subclasses implement various transmit power control algorithms,
@@ -64,9 +61,8 @@ the value. This is only for testing and re-initialization.
 
 Parameters:
 * `mode`: "random"
-* `args`:
-  * `setDifferentTxPowerPerAp`: If true, will set a different random tx power per AP. If false, it will set the same random tx power for all APs.
-    * values: true | false (default: false)
+* `setDifferentTxPowerPerAp`: If true, will set a different random tx power per AP. If false, it will set the same random tx power for all APs.
+    * values: `true`, `false` (default: `false`)
 
 ### `MeasurementBasedApClientTPC`
 This algorithm tries to assign the Tx power of the OWF APs based on the
@@ -80,8 +76,7 @@ each AP):
 
 Parameters:
 * `mode`: "measure_ap_client"
-* `args`:
-  * `targetMcs`: The target MCS index
+* `targetMcs`: The target MCS index
     * values: 0-9 (default: 8)
 
 ### `MeasurementBasedApApTPC`
@@ -98,8 +93,7 @@ levels of these APs will be determined by the following steps:
 
 Parameters:
 * `mode`: "measure_ap_ap"
-* `args`:
-  * `coverageThreshold`: Coverage threshold between APs in dBm
+* `coverageThreshold`: Coverage threshold between APs in dBm
     * values:  int < 30 (default: -70)
-  * `nthSmallestRssi`: the nth smallest RSSI that is used for tx power calculation
+* `nthSmallestRssi`: the nth smallest RSSI that is used for tx power calculation
     * values: int >= 0 (default: 0)

--- a/ALGORITHMS.md
+++ b/ALGORITHMS.md
@@ -11,6 +11,9 @@ selected channel. This is only for testing and re-initialization.
 
 Parameters:
 * `mode`: "random"
+* `args`:
+  * `setDifferentChannelPerAp`: If true, will set a different random channel per AP. If false, it will set the same random channel for all APs.
+    * values: true | false (default: false)
 
 ### `LeastUsedChannelOptimizer`
 This algorithm assigns the channel of the OWF APs based on the following logic:
@@ -26,6 +29,7 @@ This algorithm assigns the channel of the OWF APs based on the following logic:
 
 Parameters:
 * `mode`: "least_used"
+* `args:`
 
 ### `UnmanagedApAwareChannelOptimizer`
 Building on the least used channel assignment algorithm, this algorithm can
@@ -48,6 +52,7 @@ are based on the following logic:
 
 Parameters:
 * `mode`: "unmanaged_aware"
+* `args:`
 
 ## Transmit Power Control
 `TPC` and its subclasses implement various transmit power control algorithms,
@@ -59,6 +64,9 @@ the value. This is only for testing and re-initialization.
 
 Parameters:
 * `mode`: "random"
+* `args`:
+  * `setDifferentTxPowerPerAp`: If true, will set a different random tx power per AP. If false, it will set the same random tx power for all APs.
+    * values: true | false (default: false)
 
 ### `MeasurementBasedApClientTPC`
 This algorithm tries to assign the Tx power of the OWF APs based on the
@@ -72,6 +80,9 @@ each AP):
 
 Parameters:
 * `mode`: "measure_ap_client"
+* `args`:
+  * `targetMcs`: The target MCS index
+    * values: 0-9 (default: 8)
 
 ### `MeasurementBasedApApTPC`
 This algorithm tries to assign the Tx power of the OWF APs by getting a set of
@@ -87,3 +98,8 @@ levels of these APs will be determined by the following steps:
 
 Parameters:
 * `mode`: "measure_ap_ap"
+* `args`:
+  * `coverageThreshold`: Coverage threshold between APs in dBm
+    * values:  int < 30 (default: -70)
+  * `nthSmallestRssi`: the nth smallest RSSI that is used for tx power calculation
+    * values: int >= 0 (default: 0)

--- a/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMAlgorithm.java
@@ -186,24 +186,27 @@ public class RRMAlgorithm {
 				logger.info("Using default algorithm mode...");
 				// fall through
 			case UnmanagedApAwareChannelOptimizer.ALGORITHM_ID:
-				optimizer = new UnmanagedApAwareChannelOptimizer(
+				optimizer = UnmanagedApAwareChannelOptimizer.makeWithArgs(
 					modeler.getDataModelCopy(),
 					zone,
-					deviceDataManager
+					deviceDataManager,
+					args
 				);
 				break;
 			case RandomChannelInitializer.ALGORITHM_ID:
-				optimizer = new RandomChannelInitializer(
+				optimizer = RandomChannelInitializer.makeWithArgs(
 					modeler.getDataModelCopy(),
 					zone,
-					deviceDataManager
+					deviceDataManager,
+					args
 				);
 				break;
 			case LeastUsedChannelOptimizer.ALGORITHM_ID:
-				optimizer = new LeastUsedChannelOptimizer(
+				optimizer = LeastUsedChannelOptimizer.makeWithArgs(
 					modeler.getDataModelCopy(),
 					zone,
-					deviceDataManager
+					deviceDataManager,
+					args
 				);
 				break;
 			}
@@ -233,31 +236,35 @@ public class RRMAlgorithm {
 				logger.info("Using default algorithm mode...");
 				// fall through
 			case MeasurementBasedApApTPC.ALGORITHM_ID:
-				optimizer = new MeasurementBasedApApTPC(
+				optimizer = MeasurementBasedApApTPC.makeWithArgs(
 					modeler.getDataModelCopy(),
 					zone,
-					deviceDataManager
+					deviceDataManager,
+					args
 				);
 				break;
 			case RandomTxPowerInitializer.ALGORITHM_ID:
-				optimizer = new RandomTxPowerInitializer(
+				optimizer = RandomTxPowerInitializer.makeWithArgs(
 					modeler.getDataModelCopy(),
 					zone,
-					deviceDataManager
+					deviceDataManager,
+					args
 				);
 				break;
 			case MeasurementBasedApClientTPC.ALGORITHM_ID:
-				optimizer = new MeasurementBasedApClientTPC(
+				optimizer = MeasurementBasedApClientTPC.makeWithArgs(
 					modeler.getDataModelCopy(),
 					zone,
-					deviceDataManager
+					deviceDataManager,
+					args
 				);
 				break;
 			case LocationBasedOptimalTPC.ALGORITHM_ID:
-				optimizer = new LocationBasedOptimalTPC(
+				optimizer = LocationBasedOptimalTPC.makeWithArgs(
 					modeler.getDataModelCopy(),
 					zone,
-					deviceDataManager
+					deviceDataManager,
+					args
 				);
 				break;
 			}

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizer.java
@@ -45,6 +45,16 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 	/** The PRNG instance. */
 	protected final Random rng = new Random();
 
+	/** Factory method to parse generic args map into the proper constructor */
+	public static LeastUsedChannelOptimizer makeWithArgs(
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		Map<String, String> args
+	) {
+		return new LeastUsedChannelOptimizer(model, zone, deviceDataManager);
+	}
+
 	/** Constructor. */
 	public LeastUsedChannelOptimizer(
 		DataModel model,

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -57,7 +57,7 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 		boolean setDifferentChannelPerAp = DEFAULT_SET_DIFFERENT_CHANNEL_PER_AP;
 
 		String arg;
-		if ((arg = args.get("rrm-algorithm-params")) != null) {
+		if ((arg = args.get("setDifferentChannelPerAp")) != null) {
 			setDifferentChannelPerAp = Boolean.parseBoolean(arg);
 		}
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -38,11 +38,38 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 	/** The RRM algorithm ID. */
 	public static final String ALGORITHM_ID = "random";
 
+	/**
+	 * Args key for setting different channel per AP
+	 */
+	public static final String ARG_SET_DIFFERENT_CHANNEL_PER_AP =
+		"setDifferentChannelPerAp";
+
 	/** The PRNG instance. */
 	private final Random rng;
 
 	/** Whether to set a different value per AP or use a single value for all APs */
-	private final boolean setDifferentChannelsPerAp;
+	private final boolean setDifferentChannelPerAp;
+
+	/** Factory method to parse generic args map into the proper constructor */
+	public static RandomChannelInitializer makeWithArgs(
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		Map<String, String> args
+	) {
+		if (args.containsKey(ARG_SET_DIFFERENT_CHANNEL_PER_AP)) {
+			boolean setDifferentChannelPerAp =
+				args.get(ARG_SET_DIFFERENT_CHANNEL_PER_AP) == "true";
+			return new RandomChannelInitializer(
+				model,
+				zone,
+				deviceDataManager,
+				setDifferentChannelPerAp
+			);
+		} else {
+			return new RandomChannelInitializer(model, zone, deviceDataManager);
+		}
+	}
 
 	/** Constructor. */
 	public RandomChannelInitializer(
@@ -58,13 +85,13 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 		DataModel model,
 		String zone,
 		DeviceDataManager deviceDataManager,
-		boolean setDifferentChannelsPerAp
+		boolean setDifferentChannelPerAp
 	) {
 		this(
 			model,
 			zone,
 			deviceDataManager,
-			setDifferentChannelsPerAp,
+			setDifferentChannelPerAp,
 			new Random()
 		);
 	}
@@ -77,11 +104,11 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 		DataModel model,
 		String zone,
 		DeviceDataManager deviceDataManager,
-		boolean setDifferentChannelsPerAp,
+		boolean setDifferentChannelPerAp,
 		Random rng
 	) {
 		super(model, zone, deviceDataManager);
-		this.setDifferentChannelsPerAp = setDifferentChannelsPerAp;
+		this.setDifferentChannelPerAp = setDifferentChannelPerAp;
 		this.rng = rng;
 	}
 
@@ -143,13 +170,13 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 			}
 
 			// Randomly assign all the devices to the same channel if
-			// setDifferentChannelsPerAp is false otherwise, assigns
+			// setDifferentChannelPerAp is false otherwise, assigns
 			// each device to a random channel
 			int defaultChannelIndex = rng.nextInt(availableChannelsList.size());
 
 			for (String serialNumber : entry.getValue()) {
 				int newChannel = availableChannelsList.get(
-					this.setDifferentChannelsPerAp
+					this.setDifferentChannelPerAp
 						? rng.nextInt(availableChannelsList.size()) : defaultChannelIndex
 				);
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -38,11 +38,8 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 	/** The RRM algorithm ID. */
 	public static final String ALGORITHM_ID = "random";
 
-	/**
-	 * Args key for setting different channel per AP
-	 */
-	public static final String ARG_SET_DIFFERENT_CHANNEL_PER_AP =
-		"setDifferentChannelPerAp";
+	/** Default value for setDifferentChannelPerAp */
+	public static final boolean DEFAULT_SET_DIFFERENT_CHANNEL_PER_AP = false;
 
 	/** The PRNG instance. */
 	private final Random rng;
@@ -57,18 +54,19 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 		DeviceDataManager deviceDataManager,
 		Map<String, String> args
 	) {
-		if (args.containsKey(ARG_SET_DIFFERENT_CHANNEL_PER_AP)) {
-			boolean setDifferentChannelPerAp =
-				args.get(ARG_SET_DIFFERENT_CHANNEL_PER_AP) == "true";
-			return new RandomChannelInitializer(
-				model,
-				zone,
-				deviceDataManager,
-				setDifferentChannelPerAp
-			);
-		} else {
-			return new RandomChannelInitializer(model, zone, deviceDataManager);
+		boolean setDifferentChannelPerAp = DEFAULT_SET_DIFFERENT_CHANNEL_PER_AP;
+
+		String arg;
+		if ((arg = args.get("rrm-algorithm-params")) != null) {
+			setDifferentChannelPerAp = Boolean.parseBoolean(arg);
 		}
+
+		return new RandomChannelInitializer(
+			model,
+			zone,
+			deviceDataManager,
+			setDifferentChannelPerAp
+		);
 	}
 
 	/** Constructor. */
@@ -77,7 +75,12 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 		String zone,
 		DeviceDataManager deviceDataManager
 	) {
-		this(model, zone, deviceDataManager, false);
+		this(
+			model,
+			zone,
+			deviceDataManager,
+			DEFAULT_SET_DIFFERENT_CHANNEL_PER_AP
+		);
 	}
 
 	/** Constructor (allows setting different channel per AP) */

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/UnmanagedApAwareChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/UnmanagedApAwareChannelOptimizer.java
@@ -39,6 +39,20 @@ public class UnmanagedApAwareChannelOptimizer
 	/** The default weight for nonOWF APs. */
 	private static final int DEFAULT_WEIGHT = 2;
 
+	/** Factory method to parse generic args map into the proper constructor */
+	public static UnmanagedApAwareChannelOptimizer makeWithArgs(
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		Map<String, String> args
+	) {
+		return new UnmanagedApAwareChannelOptimizer(
+			model,
+			zone,
+			deviceDataManager
+		);
+	}
+
 	/** Constructor. */
 	public UnmanagedApAwareChannelOptimizer(
 		DataModel model,

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -38,6 +38,16 @@ public class LocationBasedOptimalTPC extends TPC {
 	/** The RRM algorithm ID. */
 	public static final String ALGORITHM_ID = "location_optimal";
 
+	/** Factory method to parse generic args map into the proper constructor */
+	public static LocationBasedOptimalTPC makeWithArgs(
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		Map<String, String> args
+	) {
+		return new LocationBasedOptimalTPC(model, zone, deviceDataManager);
+	}
+
 	/** Constructor. */
 	public LocationBasedOptimalTPC(
 		DataModel model,

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -58,11 +58,50 @@ public class MeasurementBasedApApTPC extends TPC {
 	 */
 	public static final int DEFAULT_NTH_SMALLEST_RSSI = 0;
 
+	/**
+	 * Args key for coverage threshold
+	 */
+	public static final String ARG_COVERAGE_THRESHOLD = "coverageThreshold";
+
+	/**
+	 * Args key for nth smallest RSSI
+	 */
+	public static final String ARG_NTH_SMALLEST_RSSI = "nthSmallestRssi";
+
 	/** coverage threshold between APs, in dB */
 	private final int coverageThreshold;
 
 	/** Nth smallest RSSI (zero-indexed) is used for Tx power calculation */
 	private final int nthSmallestRssi; // TODO non-zero values untested
+
+	/** Factory method to parse generic args map into the proper constructor */
+	public static MeasurementBasedApApTPC makeWithArgs(
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		Map<String, String> args
+	) {
+
+		if (
+			args.containsKey(ARG_COVERAGE_THRESHOLD) &&
+				args.containsKey(ARG_NTH_SMALLEST_RSSI)
+		) {
+			int coverageThreshold =
+				Integer.parseInt(args.get(ARG_COVERAGE_THRESHOLD));
+			int nthSmallestRssi =
+				Integer.parseInt(args.get(ARG_NTH_SMALLEST_RSSI));
+			return new MeasurementBasedApApTPC(
+				model,
+				zone,
+				deviceDataManager,
+				coverageThreshold,
+				nthSmallestRssi
+			);
+		} else {
+
+			return new MeasurementBasedApApTPC(model, zone, deviceDataManager);
+		}
+	}
 
 	/** Constructor. */
 	public MeasurementBasedApApTPC(

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -77,10 +77,17 @@ public class MeasurementBasedApApTPC extends TPC {
 		String arg;
 		if ((arg = args.get("coverageThreshold")) != null) {
 			try {
-				coverageThreshold = Integer.parseInt(arg);
+				int parsedCoverageThreshold = Integer.parseInt(arg);
+				if (parsedCoverageThreshold > 30) {
+					logger.error(
+						"Invalid value passed for coverageThreshold - must be less than 30. Using default value."
+					);
+				} else {
+					coverageThreshold = parsedCoverageThreshold;
+				}
 			} catch (NumberFormatException e) {
 				logger.error(
-					"Invalid integer passed to parameter coverageThreshold, using default value: ",
+					"Invalid integer passed to parameter coverageThreshold, using default value",
 					e
 				);
 			}
@@ -88,10 +95,17 @@ public class MeasurementBasedApApTPC extends TPC {
 
 		if ((arg = args.get("nthSmallestRssi")) != null) {
 			try {
-				nthSmallestRssi = Integer.parseInt(arg);
+				int parsedNthSmallestRssi = Integer.parseInt(arg);
+				if (parsedNthSmallestRssi < 0) {
+					logger.error(
+						"Invalid value passed for nthSmallestRssi - must be greater than 0. Using default value."
+					);
+				} else {
+					nthSmallestRssi = parsedNthSmallestRssi;
+				}
 			} catch (NumberFormatException e) {
 				logger.error(
-					"Invalid integer passed to parameter nthSmallestRssi, using default value: ",
+					"Invalid integer passed to parameter nthSmallestRssi, using default value",
 					e
 				);
 			}

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -58,16 +58,6 @@ public class MeasurementBasedApApTPC extends TPC {
 	 */
 	public static final int DEFAULT_NTH_SMALLEST_RSSI = 0;
 
-	/**
-	 * Args key for coverage threshold
-	 */
-	public static final String ARG_COVERAGE_THRESHOLD = "coverageThreshold";
-
-	/**
-	 * Args key for nth smallest RSSI
-	 */
-	public static final String ARG_NTH_SMALLEST_RSSI = "nthSmallestRssi";
-
 	/** coverage threshold between APs, in dB */
 	private final int coverageThreshold;
 
@@ -81,26 +71,39 @@ public class MeasurementBasedApApTPC extends TPC {
 		DeviceDataManager deviceDataManager,
 		Map<String, String> args
 	) {
+		int coverageThreshold = DEFAULT_COVERAGE_THRESHOLD;
+		int nthSmallestRssi = DEFAULT_NTH_SMALLEST_RSSI;
 
-		if (
-			args.containsKey(ARG_COVERAGE_THRESHOLD) &&
-				args.containsKey(ARG_NTH_SMALLEST_RSSI)
-		) {
-			int coverageThreshold =
-				Integer.parseInt(args.get(ARG_COVERAGE_THRESHOLD));
-			int nthSmallestRssi =
-				Integer.parseInt(args.get(ARG_NTH_SMALLEST_RSSI));
-			return new MeasurementBasedApApTPC(
-				model,
-				zone,
-				deviceDataManager,
-				coverageThreshold,
-				nthSmallestRssi
-			);
-		} else {
-
-			return new MeasurementBasedApApTPC(model, zone, deviceDataManager);
+		String arg;
+		if ((arg = args.get("coverageThreshold")) != null) {
+			try {
+				coverageThreshold = Integer.parseInt(arg);
+			} catch (NumberFormatException e) {
+				logger.error(
+					"Invalid integer passed to parameter coverageThreshold, using default value: ",
+					e
+				);
+			}
 		}
+
+		if ((arg = args.get("nthSmallestRssi")) != null) {
+			try {
+				nthSmallestRssi = Integer.parseInt(arg);
+			} catch (NumberFormatException e) {
+				logger.error(
+					"Invalid integer passed to parameter nthSmallestRssi, using default value: ",
+					e
+				);
+			}
+		}
+
+		return new MeasurementBasedApApTPC(
+			model,
+			zone,
+			deviceDataManager,
+			coverageThreshold,
+			nthSmallestRssi
+		);
 	}
 
 	/** Constructor. */

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -42,6 +42,11 @@ public class MeasurementBasedApClientTPC extends TPC {
 	/** Default tx power. */
 	public static final int DEFAULT_TX_POWER = 10;
 
+	/**
+	 * Args key for targetMcs
+	 */
+	public static final String ARG_TARGET_MCS = "targetMcs";
+
 	/** Mapping of MCS index to required SNR (dB) in 802.11ac. */
 	private static final List<Double> MCS_TO_SNR = Collections.unmodifiableList(
 		Arrays.asList(
@@ -60,6 +65,30 @@ public class MeasurementBasedApClientTPC extends TPC {
 
 	/** The target MCS index. */
 	private final int targetMcs;
+
+	/** Factory method to parse generic args map into the proper constructor */
+	public static MeasurementBasedApClientTPC makeWithArgs(
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		Map<String, String> args
+	) {
+		if (args.containsKey(ARG_TARGET_MCS)) {
+			int targetMcs = Integer.parseInt(args.get(ARG_TARGET_MCS));
+			return new MeasurementBasedApClientTPC(
+				model,
+				zone,
+				deviceDataManager,
+				targetMcs
+			);
+		} else {
+			return new MeasurementBasedApClientTPC(
+				model,
+				zone,
+				deviceDataManager
+			);
+		}
+	}
 
 	/** Constructor (uses default target MCS index). */
 	public MeasurementBasedApClientTPC(

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -74,18 +74,19 @@ public class MeasurementBasedApClientTPC extends TPC {
 		if ((arg = args.get("targetMcs")) != null) {
 
 			try {
-				targetMcs = Integer.parseInt(arg);
+				int parsedTargetMcs = Integer.parseInt(arg);
+				if (targetMcs < 0) {
+					logger.error(
+						"Invalid value passed for targetMcs - must be greater than 0. Using default value."
+					);
+				} else {
+					targetMcs = parsedTargetMcs;
+				}
 			} catch (NumberFormatException e) {
 				logger.error(
-					"Invalid integer passed to parameter targetMcs, using default value: ",
+					"Invalid integer passed to parameter targetMcs, using default value",
 					e
 				);
-			}
-			if (targetMcs < 0) {
-				logger.error(
-					"Invalid value passed for targetMcs - must be greater than 0. Using default value."
-				);
-				targetMcs = DEFAULT_TARGET_MCS;
 			}
 		}
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -42,11 +42,6 @@ public class MeasurementBasedApClientTPC extends TPC {
 	/** Default tx power. */
 	public static final int DEFAULT_TX_POWER = 10;
 
-	/**
-	 * Args key for targetMcs
-	 */
-	public static final String ARG_TARGET_MCS = "targetMcs";
-
 	/** Mapping of MCS index to required SNR (dB) in 802.11ac. */
 	private static final List<Double> MCS_TO_SNR = Collections.unmodifiableList(
 		Arrays.asList(
@@ -73,21 +68,33 @@ public class MeasurementBasedApClientTPC extends TPC {
 		DeviceDataManager deviceDataManager,
 		Map<String, String> args
 	) {
-		if (args.containsKey(ARG_TARGET_MCS)) {
-			int targetMcs = Integer.parseInt(args.get(ARG_TARGET_MCS));
-			return new MeasurementBasedApClientTPC(
-				model,
-				zone,
-				deviceDataManager,
-				targetMcs
-			);
-		} else {
-			return new MeasurementBasedApClientTPC(
-				model,
-				zone,
-				deviceDataManager
-			);
+		int targetMcs = DEFAULT_TARGET_MCS;
+
+		String arg;
+		if ((arg = args.get("targetMcs")) != null) {
+
+			try {
+				targetMcs = Integer.parseInt(arg);
+			} catch (NumberFormatException e) {
+				logger.error(
+					"Invalid integer passed to parameter targetMcs, using default value: ",
+					e
+				);
+			}
+			if (targetMcs < 0) {
+				logger.error(
+					"Invalid value passed for targetMcs - must be greater than 0. Using default value."
+				);
+				targetMcs = DEFAULT_TARGET_MCS;
+			}
 		}
+
+		return new MeasurementBasedApClientTPC(
+			model,
+			zone,
+			deviceDataManager,
+			targetMcs
+		);
 	}
 
 	/** Constructor (uses default target MCS index). */

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -31,13 +31,43 @@ public class RandomTxPowerInitializer extends TPC {
 	/** The RRM algorithm ID. */
 	public static final String ALGORITHM_ID = "random";
 
+	/**
+	 * Args key for setting different tx power per AP
+	 */
+	public static final String ARG_SET_DIFFERENT_TX_POWER_PER_AP =
+		"setDifferentTxPowerPerAp";
+
 	/** The PRNG instance. */
 	private final Random rng;
 
 	/** Whether to set a different value per AP or use a single value for all APs */
 	private final boolean setDifferentTxPowerPerAp;
 
-	/** Constructor (uses random tx power). */
+	/** Factory method to parse generic args map into the proper constructor */
+	public static RandomTxPowerInitializer makeWithArgs(
+		DataModel model,
+		String zone,
+		DeviceDataManager deviceDataManager,
+		Map<String, String> args
+	) {
+		if (args.containsKey(ARG_SET_DIFFERENT_TX_POWER_PER_AP)) {
+			boolean setDifferentTxPowerPerAp =
+				args.get(ARG_SET_DIFFERENT_TX_POWER_PER_AP) == "true";
+			return new RandomTxPowerInitializer(
+				model,
+				zone,
+				deviceDataManager,
+				setDifferentTxPowerPerAp
+			);
+		} else {
+			return new RandomTxPowerInitializer(model, zone, deviceDataManager);
+		}
+	}
+
+	/**
+	 * Constructor (uses random tx power per AP and allows passing in a custom
+	 * Random class to allow seeding).
+	 */
 	public RandomTxPowerInitializer(
 		DataModel model,
 		String zone,

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -31,11 +31,9 @@ public class RandomTxPowerInitializer extends TPC {
 	/** The RRM algorithm ID. */
 	public static final String ALGORITHM_ID = "random";
 
-	/**
-	 * Args key for setting different tx power per AP
-	 */
-	public static final String ARG_SET_DIFFERENT_TX_POWER_PER_AP =
-		"setDifferentTxPowerPerAp";
+	/** Default value for setDifferentTxPowerPerAp */
+	public static final boolean DEFAULT_SET_DIFFERENT_TX_POWER_PER_AP =
+		false;
 
 	/** The PRNG instance. */
 	private final Random rng;
@@ -50,18 +48,20 @@ public class RandomTxPowerInitializer extends TPC {
 		DeviceDataManager deviceDataManager,
 		Map<String, String> args
 	) {
-		if (args.containsKey(ARG_SET_DIFFERENT_TX_POWER_PER_AP)) {
-			boolean setDifferentTxPowerPerAp =
-				args.get(ARG_SET_DIFFERENT_TX_POWER_PER_AP) == "true";
-			return new RandomTxPowerInitializer(
-				model,
-				zone,
-				deviceDataManager,
-				setDifferentTxPowerPerAp
-			);
-		} else {
-			return new RandomTxPowerInitializer(model, zone, deviceDataManager);
+		boolean setDifferentTxPowerPerAp =
+			DEFAULT_SET_DIFFERENT_TX_POWER_PER_AP;
+
+		String arg;
+		if ((arg = args.get("setDifferentTxPowerPerAp")) != null) {
+			setDifferentTxPowerPerAp = Boolean.parseBoolean(arg);
 		}
+
+		return new RandomTxPowerInitializer(
+			model,
+			zone,
+			deviceDataManager,
+			setDifferentTxPowerPerAp
+		);
 	}
 
 	/**
@@ -73,7 +73,12 @@ public class RandomTxPowerInitializer extends TPC {
 		String zone,
 		DeviceDataManager deviceDataManager
 	) {
-		this(model, zone, deviceDataManager, false);
+		this(
+			model,
+			zone,
+			deviceDataManager,
+			DEFAULT_SET_DIFFERENT_TX_POWER_PER_AP
+		);
 	}
 
 	/** Constructor (uses random tx power per AP). */


### PR DESCRIPTION
Args were being parsed out but not actually passed into the constructors. Create and call a factory method to call the proper constructors based on what's present in the generic args map for all the algorithms available. Also updated ALGORITHMS.md with the available args for each algorithm.
