### PR TITLE
[WIFI-10736] Spin up separate ports for internal and external

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /owrrm-data
 WORKDIR /usr/src/java
 COPY docker-entrypoint.sh /
 COPY --from=build /usr/src/java/owrrm/target/openwifi-rrm.jar /usr/local/bin/
-EXPOSE 16789
+EXPOSE 16789 16790
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["java", "-XX:+IdleTuningGcOnIdle", "-Xtune:virtualized", \
      "-jar", "/usr/local/bin/openwifi-rrm.jar", \

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralClient.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralClient.java
@@ -313,7 +313,11 @@ public class UCentralClient {
 		Map<String, Object> parameters
 	) {
 		return httpGet(
-			endpoint, service, parameters, connectTimeoutMs, socketTimeoutMs
+			endpoint,
+			service,
+			parameters,
+			connectTimeoutMs,
+			socketTimeoutMs
 		);
 	}
 
@@ -353,7 +357,11 @@ public class UCentralClient {
 		Object body
 	) {
 		return httpPost(
-			endpoint, service, body, connectTimeoutMs, socketTimeoutMs
+			endpoint,
+			service,
+			body,
+			connectTimeoutMs,
+			socketTimeoutMs
 		);
 	}
 

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/gw/WebTokenResult.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/gw/WebTokenResult.java
@@ -12,7 +12,7 @@ public class WebTokenResult {
 	public String access_token;
 	public String refresh_token;
 	public String token_type;
-	public int expires_in;
+	public long expires_in;
 	public int idle_timeout;
 	public String username;
 	public long created;

--- a/owrrm/openapi.yaml
+++ b/owrrm/openapi.yaml
@@ -16,7 +16,7 @@ paths:
       - SDK
       summary: Get RRM algorithms
       description: Returns the RRM algorithm list.
-      operationId: algorithms
+      operationId: algorithms_1
       responses:
         "200":
           description: Success
@@ -32,7 +32,7 @@ paths:
       - Optimization
       summary: Get current RRM model
       description: Returns the current RRM data model.
-      operationId: getCurrentModel
+      operationId: getCurrentModel_1
       responses:
         "200":
           description: Data model
@@ -47,7 +47,7 @@ paths:
       summary: Get device configuration
       description: Returns the device configuration by applying all configuration
         layers.
-      operationId: getDeviceConfig
+      operationId: getDeviceConfig_1
       parameters:
       - name: serial
         in: query
@@ -70,7 +70,7 @@ paths:
       - Config
       summary: Get device layered configuration
       description: Returns the device layered configuration.
-      operationId: getDeviceLayeredConfig
+      operationId: getDeviceLayeredConfig_1
       responses:
         "200":
           description: Device layered configuration
@@ -84,7 +84,7 @@ paths:
       - Config
       summary: Get device topology
       description: Returns the device topology.
-      operationId: getTopology
+      operationId: getTopology_1
       responses:
         "200":
           description: Device topology
@@ -99,7 +99,7 @@ paths:
       summary: Modify device AP configuration
       description: Modify the AP layer of the network configuration for the given
         AP. Any existing fields absent from the request body will be preserved.
-      operationId: modifyDeviceApConfig
+      operationId: modifyDeviceApConfig_1
       parameters:
       - name: serial
         in: query
@@ -125,7 +125,7 @@ paths:
       - Optimization
       summary: Optimize channel configuration
       description: Run channel optimizer and return the new channel allocation.
-      operationId: optimizeChannel
+      operationId: optimizeChannel_1
       parameters:
       - name: mode
         in: query
@@ -165,7 +165,7 @@ paths:
       - Optimization
       summary: Optimize tx power configuration
       description: Run tx power optimizer and return the new tx power allocation.
-      operationId: optimizeTxPower
+      operationId: optimizeTxPower_1
       parameters:
       - name: mode
         in: query
@@ -207,7 +207,7 @@ paths:
       - SDK
       summary: Get RRM provider info
       description: Returns the RRM provider info.
-      operationId: provider
+      operationId: provider_1
       responses:
         "200":
           description: Success
@@ -221,7 +221,7 @@ paths:
       - SDK
       summary: Run RRM algorithm
       description: Run a specific RRM algorithm now.
-      operationId: runRRM
+      operationId: runRRM_1
       parameters:
       - name: algorithm
         in: query
@@ -260,7 +260,7 @@ paths:
       - Config
       summary: Set device AP configuration
       description: Set the AP layer of the network configuration for the given AP.
-      operationId: setDeviceApConfig
+      operationId: setDeviceApConfig_1
       parameters:
       - name: serial
         in: query
@@ -286,7 +286,7 @@ paths:
       - Config
       summary: Set device network configuration
       description: Set the network layer of the device configuration.
-      operationId: setDeviceNetworkConfig
+      operationId: setDeviceNetworkConfig_1
       requestBody:
         description: The device network configuration
         content:
@@ -305,7 +305,7 @@ paths:
       - Config
       summary: Set device zone configuration
       description: Set the zone layer of the network configuration for the given zone.
-      operationId: setDeviceZoneConfig
+      operationId: setDeviceZoneConfig_1
       parameters:
       - name: zone
         in: query
@@ -331,7 +331,7 @@ paths:
       - SDK
       summary: Get system info
       description: Returns the system info from the running service.
-      operationId: system
+      operationId: system_1
       parameters:
       - name: command
         in: query
@@ -355,7 +355,7 @@ paths:
       - SDK
       summary: Run system commands
       description: Perform some system-wide commands.
-      operationId: setSystem
+      operationId: setSystem_1
       requestBody:
         description: Command details
         content:
@@ -378,7 +378,7 @@ paths:
       - Config
       summary: Set device topology
       description: Set the device topology.
-      operationId: setTopology
+      operationId: setTopology_1
       requestBody:
         description: The device topology
         content:

--- a/owrrm/openapi.yaml
+++ b/owrrm/openapi.yaml
@@ -16,7 +16,7 @@ paths:
       - SDK
       summary: Get RRM algorithms
       description: Returns the RRM algorithm list.
-      operationId: algorithms_1
+      operationId: algorithms
       responses:
         "200":
           description: Success
@@ -32,7 +32,7 @@ paths:
       - Optimization
       summary: Get current RRM model
       description: Returns the current RRM data model.
-      operationId: getCurrentModel_1
+      operationId: getCurrentModel
       responses:
         "200":
           description: Data model
@@ -47,7 +47,7 @@ paths:
       summary: Get device configuration
       description: Returns the device configuration by applying all configuration
         layers.
-      operationId: getDeviceConfig_1
+      operationId: getDeviceConfig
       parameters:
       - name: serial
         in: query
@@ -70,7 +70,7 @@ paths:
       - Config
       summary: Get device layered configuration
       description: Returns the device layered configuration.
-      operationId: getDeviceLayeredConfig_1
+      operationId: getDeviceLayeredConfig
       responses:
         "200":
           description: Device layered configuration
@@ -84,7 +84,7 @@ paths:
       - Config
       summary: Get device topology
       description: Returns the device topology.
-      operationId: getTopology_1
+      operationId: getTopology
       responses:
         "200":
           description: Device topology
@@ -99,7 +99,7 @@ paths:
       summary: Modify device AP configuration
       description: Modify the AP layer of the network configuration for the given
         AP. Any existing fields absent from the request body will be preserved.
-      operationId: modifyDeviceApConfig_1
+      operationId: modifyDeviceApConfig
       parameters:
       - name: serial
         in: query
@@ -125,7 +125,7 @@ paths:
       - Optimization
       summary: Optimize channel configuration
       description: Run channel optimizer and return the new channel allocation.
-      operationId: optimizeChannel_1
+      operationId: optimizeChannel
       parameters:
       - name: mode
         in: query
@@ -165,7 +165,7 @@ paths:
       - Optimization
       summary: Optimize tx power configuration
       description: Run tx power optimizer and return the new tx power allocation.
-      operationId: optimizeTxPower_1
+      operationId: optimizeTxPower
       parameters:
       - name: mode
         in: query
@@ -207,7 +207,7 @@ paths:
       - SDK
       summary: Get RRM provider info
       description: Returns the RRM provider info.
-      operationId: provider_1
+      operationId: provider
       responses:
         "200":
           description: Success
@@ -221,7 +221,7 @@ paths:
       - SDK
       summary: Run RRM algorithm
       description: Run a specific RRM algorithm now.
-      operationId: runRRM_1
+      operationId: runRRM
       parameters:
       - name: algorithm
         in: query
@@ -260,7 +260,7 @@ paths:
       - Config
       summary: Set device AP configuration
       description: Set the AP layer of the network configuration for the given AP.
-      operationId: setDeviceApConfig_1
+      operationId: setDeviceApConfig
       parameters:
       - name: serial
         in: query
@@ -286,7 +286,7 @@ paths:
       - Config
       summary: Set device network configuration
       description: Set the network layer of the device configuration.
-      operationId: setDeviceNetworkConfig_1
+      operationId: setDeviceNetworkConfig
       requestBody:
         description: The device network configuration
         content:
@@ -305,7 +305,7 @@ paths:
       - Config
       summary: Set device zone configuration
       description: Set the zone layer of the network configuration for the given zone.
-      operationId: setDeviceZoneConfig_1
+      operationId: setDeviceZoneConfig
       parameters:
       - name: zone
         in: query
@@ -331,7 +331,7 @@ paths:
       - SDK
       summary: Get system info
       description: Returns the system info from the running service.
-      operationId: system_1
+      operationId: system
       parameters:
       - name: command
         in: query
@@ -355,7 +355,7 @@ paths:
       - SDK
       summary: Run system commands
       description: Perform some system-wide commands.
-      operationId: setSystem_1
+      operationId: setSystem
       requestBody:
         description: Command details
         content:
@@ -378,7 +378,7 @@ paths:
       - Config
       summary: Set device topology
       description: Set the device topology.
-      operationId: setTopology_1
+      operationId: setTopology
       requestBody:
         description: The device topology
         content:

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
@@ -38,7 +38,7 @@ public class CustomJettyServerFactory implements JettyServerFactory {
 		this.externalPort = externalPort;
 	}
 
-	public setTrustForwardHeaders(boolean trustForwardHeaders) {
+	public void setTrustForwardHeaders(boolean trustForwardHeaders) {
 		this.trustForwardHeaders = trustForwardHeaders;
 	}
 

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
@@ -30,7 +30,7 @@ import spark.utils.Assert;
  * on the server, Spark uses the existing conectors instead of trying to spin
  * up its own connectors. The other difference is that it uses a different
  * ServerConnector constructor to avoid allocating additional threads that
- * aren't necessary (@{@link #makeConnector})
+ * aren't necessary ({@link #makeConnector})
  * @see EmbeddedJettyFactory
  */
 public class CustomJettyServerFactory implements JettyServerFactory {

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
@@ -48,7 +48,12 @@ public class CustomJettyServerFactory implements JettyServerFactory {
 	 * the only difference being that we use a different constructor for the
 	 * Connector and that the private methods called are just inlined.
 	 */
-	public Connector makeConnector(Server server, String host, int port, boolean trustForwardHeaders) {
+	public Connector makeConnector(
+		Server server,
+		String host,
+		int port,
+		boolean trustForwardHeaders
+	) {
 		Assert.notNull(server, "'server' must not be null");
 		Assert.notNull(host, "'host' must not be null");
 
@@ -101,14 +106,35 @@ public class CustomJettyServerFactory implements JettyServerFactory {
 			server = new Server();
 		}
 
-		Connector internalConnector =
-			makeConnector(server, "localhost", internalPort, trustForwardHeaders);
-		Connector externalConnector =
-			makeConnector(server, "localhost", externalPort, trustForwardHeaders);
+		Connector internalConnector = null;
+		if (internalPort != -1) {
+			internalConnector = makeConnector(
+				server,
+				"localhost",
+				internalPort,
+				trustForwardHeaders
+			);
+		}
 
-		server.setConnectors(
-			new Connector[] { internalConnector, externalConnector }
-		);
+		Connector externalConnector = null;
+		if (externalPort != -1) {
+			externalConnector = makeConnector(
+				server,
+				"localhost",
+				externalPort,
+				trustForwardHeaders
+			);
+		}
+
+		if (internalConnector == null) {
+			server.setConnectors(new Connector[] { externalConnector });
+		} else if (externalConnector == null) {
+			server.setConnectors(new Connector[] { internalConnector });
+		} else {
+			server.setConnectors(
+				new Connector[] { internalConnector, externalConnector }
+			);
+		}
 
 		return server;
 	}

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
@@ -28,10 +28,10 @@ import spark.utils.Assert;
  * set two connectors (original class doesn't set any connectors at all and
  * leaves it up to the serivce start logic). Since we set two connectors here
  * on the server, Spark uses the existing conectors instead of trying to spin
- * up its own connectors. See
- * main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java in spark. The
- * other difference is that it uses a different ServerConnector constructor to
- * avoid allocating additional threads that aren't necessary (see makeConnector)
+ * up its own connectors. The other difference is that it uses a different
+ * ServerConnector constructor to avoid allocating additional threads that
+ * aren't necessary (@{@link #makeConnector})
+ * @see EmbeddedJettyFactory
  */
 public class CustomJettyServerFactory implements JettyServerFactory {
 	// normally this is set in EmbeddedJettyServer but since we create our own connectors here,

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
@@ -30,9 +30,9 @@ public class CustomJettyServerFactory implements JettyServerFactory {
 	private final int internalPort;
 	private final int externalPort;
 
-	public CustomJettyServerFactory(int externalPort, int internalPort) {
-		this.externalPort = externalPort;
+	public CustomJettyServerFactory(int internalPort, int externalPort) {
 		this.internalPort = internalPort;
+		this.externalPort = externalPort;
 	}
 
 	/**
@@ -94,13 +94,13 @@ public class CustomJettyServerFactory implements JettyServerFactory {
 			server = new Server();
 		}
 
-		Connector externalConnector =
-			makeConnector(server, "localhost", externalPort);
 		Connector internalConnector =
 			makeConnector(server, "localhost", internalPort);
+		Connector externalConnector =
+			makeConnector(server, "localhost", externalPort);
 
 		server.setConnectors(
-			new Connector[] { externalConnector, internalConnector }
+			new Connector[] { internalConnector, externalConnector }
 		);
 
 		return server;

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
@@ -19,7 +19,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import spark.embeddedserver.jetty.JettyServerFactory;
-import spark.embeddedserver.jetty.SocketConnectorFactory;
 import spark.utils.Assert;
 
 /**

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifi.rrm;
+
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
+import spark.embeddedserver.jetty.JettyServerFactory;
+import spark.embeddedserver.jetty.SocketConnectorFactory;
+
+/**
+ * Creates Jetty Server instances. Majority of the logic is taken
+ * from JettyServerFactory with port logic added.
+ */
+public class CustomJettyServerFactory implements JettyServerFactory {
+	private final int internalPort;
+	private final int externalPort;
+
+	public CustomJettyServerFactory(int externalPort, int internalPort) {
+		this.externalPort = externalPort;
+		this.internalPort = internalPort;
+	}
+
+	/**
+	 * Creates a Jetty server.
+	 *
+	 * @param maxThreads          maxThreads
+	 * @param minThreads          minThreads
+	 * @param threadTimeoutMillis threadTimeoutMillis
+	 * @return a new jetty server instance
+	 */
+	public Server create(
+		int maxThreads,
+		int minThreads,
+		int threadTimeoutMillis
+	) {
+		Server server;
+
+		if (maxThreads > 0) {
+			int max = maxThreads;
+			int min = (minThreads > 0) ? minThreads : 8;
+			int idleTimeout =
+				(threadTimeoutMillis > 0) ? threadTimeoutMillis : 60000;
+
+			server = new Server(new QueuedThreadPool(max, min, idleTimeout));
+		} else {
+			server = new Server();
+		}
+
+		Connector externalConnector = SocketConnectorFactory
+			.createSocketConnector(server, "localhost", externalPort);
+		Connector internalConnector = SocketConnectorFactory
+			.createSocketConnector(server, "localhost", internalPort);
+
+		server.setConnectors(
+			new Connector[] { externalConnector, internalConnector }
+		);
+
+		return server;
+	}
+
+	/**
+	 * Creates a Jetty server with supplied thread pool
+	 * @param threadPool thread pool
+	 * @return a new jetty server instance
+	 */
+	@Override
+	public Server create(ThreadPool threadPool) {
+		return threadPool != null ? new Server(threadPool) : new Server();
+	}
+}

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/CustomJettyServerFactory.java
@@ -23,8 +23,15 @@ import spark.embeddedserver.jetty.SocketConnectorFactory;
 import spark.utils.Assert;
 
 /**
- * Creates Jetty Server instances. Majority of the logic is taken
- * from JettyServerFactory with port logic added.
+ * Creates Jetty Server instances. Majority of the logic is taken from
+ * JettyServerFactory. The additional feature is that this class will actually
+ * set two connectors (original class doesn't set any connectors at all and
+ * leaves it up to the serivce start logic). Since we set two connectors here
+ * on the server, Spark uses the existing conectors instead of trying to spin
+ * up its own connectors. See
+ * main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java in spark. The
+ * other difference is that it uses a different ServerConnector constructor to
+ * avoid allocating additional threads that aren't necessary (see makeConnector)
  */
 public class CustomJettyServerFactory implements JettyServerFactory {
 	// normally this is set in EmbeddedJettyServer but since we create our own connectors here,

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/RRMConfig.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/RRMConfig.java
@@ -34,13 +34,13 @@ public class RRMConfig {
 		 * Private endpoint for the RRM service
 		 * ({@code SERVICECONFIG_PRIVATEENDPOINT})
 		 */
-		public String privateEndpoint = "http://owrrm.wlan.local:16789"; // see ApiServerParams.httpPort
+		public String privateEndpoint = "http://owrrm.wlan.local:16790"; // see ApiServerParams.externalHttpPort
 
 		/**
 		 * Public endpoint for the RRM service
 		 * ({@code SERVICECONFIG_PUBLICENDPOINT})
 		 */
-		public String publicEndpoint = "";
+		public String publicEndpoint = "http://owrrm.wlan.local:16789"; // see ApiServerParams.internalHttpPOrt
 
 		/**
 		 * RRM vendor name
@@ -325,10 +325,16 @@ public class RRMConfig {
 		 */
 		public class ApiServerParams {
 			/**
-			 * The HTTP port to listen on, or -1 to disable
-			 * ({@code APISERVERPARAMS_HTTPPORT})
+			 * The HTTP port to listen on for internal traffic, or -1 to disable
+			 * ({@code APISERVERPARAMS_INTERNALHTTPPORT})
 			 */
-			public int httpPort = 16789;
+			public int internalHttpPort = 16789;
+
+			/**
+			 * The HTTP port to listen on for external traffic, or -1 to disable
+			 * ({@code APISERVERPARAMS_EXTERNALHTTPPORT})
+			 */
+			public int externalHttpPort = 16790;
 
 			/**
 			 * Comma-separated list of all allowed CORS domains (exact match
@@ -543,8 +549,11 @@ public class RRMConfig {
 		}
 		ModuleConfig.ApiServerParams apiServerParams =
 			config.moduleConfig.apiServerParams;
-		if ((v = env.get("APISERVERPARAMS_HTTPPORT")) != null) {
-			apiServerParams.httpPort = Integer.parseInt(v);
+		if ((v = env.get("APISERVERPARAMS_INTERNALHTTPPORT")) != null) {
+			apiServerParams.internalHttpPort = Integer.parseInt(v);
+		}
+		if ((v = env.get("APISERVERPARAMS_EXTERNALHTTPPORT")) != null) {
+			apiServerParams.externalHttpPort = Integer.parseInt(v);
 		}
 		if ((v = env.get("APISERVERPARAMS_CORSDOMAINLIST")) != null) {
 			apiServerParams.corsDomainList = v;

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/RRMConfig.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/RRMConfig.java
@@ -34,13 +34,13 @@ public class RRMConfig {
 		 * Private endpoint for the RRM service
 		 * ({@code SERVICECONFIG_PRIVATEENDPOINT})
 		 */
-		public String privateEndpoint = "http://owrrm.wlan.local:16790"; // see ApiServerParams.externalHttpPort
+		public String privateEndpoint = "http://owrrm.wlan.local:16789"; // see ApiServerParams.internalHttpPort
 
 		/**
 		 * Public endpoint for the RRM service
 		 * ({@code SERVICECONFIG_PUBLICENDPOINT})
 		 */
-		public String publicEndpoint = "http://owrrm.wlan.local:16789"; // see ApiServerParams.internalHttpPOrt
+		public String publicEndpoint = "";
 
 		/**
 		 * RRM vendor name

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/RRMConfig.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/RRMConfig.java
@@ -34,7 +34,7 @@ public class RRMConfig {
 		 * Private endpoint for the RRM service
 		 * ({@code SERVICECONFIG_PRIVATEENDPOINT})
 		 */
-		public String privateEndpoint = "http://owrrm.wlan.local:16789"; // see ApiServerParams.internalHttpPort
+		public String privateEndpoint = "http://owrrm.wlan.local:16790"; // see ApiServerParams.internalHttpPort
 
 		/**
 		 * Public endpoint for the RRM service
@@ -328,13 +328,13 @@ public class RRMConfig {
 			 * The HTTP port to listen on for internal traffic, or -1 to disable
 			 * ({@code APISERVERPARAMS_INTERNALHTTPPORT})
 			 */
-			public int internalHttpPort = 16789;
+			public int internalHttpPort = 16790;
 
 			/**
 			 * The HTTP port to listen on for external traffic, or -1 to disable
 			 * ({@code APISERVERPARAMS_EXTERNALHTTPPORT})
 			 */
-			public int externalHttpPort = 16790;
+			public int externalHttpPort = 16789;
 
 			/**
 			 * Comma-separated list of all allowed CORS domains (exact match

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ApiServer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ApiServer.java
@@ -201,14 +201,23 @@ public class ApiServer implements Runnable {
 	public void run() {
 		this.startTimeMs = System.currentTimeMillis();
 
-		if (params.httpPort == -1) {
+		if (params.internalHttpPort == -1 && params.externalHttpPort == -1) {
 			logger.info("API server is disabled.");
 			return;
+		} else if (params.internalHttpPort == -1) {
+			logger.info("Internal API server is disabled");
+		} else if (params.externalHttpPort == -1) {
+			logger.info("External API server is disabled");
 		}
 
 		EmbeddedServers.add(
 			EmbeddedServers.defaultIdentifier(),
-			new EmbeddedJettyFactory(new CustomJettyServerFactory(16789, 16790))
+			new EmbeddedJettyFactory(
+				new CustomJettyServerFactory(
+					params.internalHttpPort,
+					params.externalHttpPort
+				)
+			)
 		);
 
 		Spark.port(0);
@@ -254,7 +263,11 @@ public class ApiServer implements Runnable {
 		Spark.get("/api/v1/optimizeChannel", new OptimizeChannelEndpoint());
 		Spark.get("/api/v1/optimizeTxPower", new OptimizeTxPowerEndpoint());
 
-		logger.info("API server listening on HTTP port {}", params.httpPort);
+		logger.info(
+			"API server listening for HTTP internal on port {} and external on port {}",
+			params.internalHttpPort,
+			params.externalHttpPort
+		);
 	}
 
 	/** Stop the server. */

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ApiServer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ApiServer.java
@@ -110,13 +110,28 @@ import spark.embeddedserver.jetty.EmbeddedJettyFactory;
 	scheme = "bearer"
 )
 public class ApiServer implements Runnable {
-	private static final String SPARK_EMBEDDED_SERVER_IDENTIFIER =
-		ApiServer.class.getName();
-
 	private static final Logger logger =
 		LoggerFactory.getLogger(ApiServer.class);
 
-	/** The Spark service instance */
+	/**
+	 * This is the identifier for the server factory that Spark should use. This
+	 * particular identifier points to the custom factory that we register to
+	 * enable running multiple ports on one service.
+	 *
+	 * @see #run()
+	 */
+	private static final String SPARK_EMBEDDED_SERVER_IDENTIFIER =
+		ApiServer.class.getName();
+
+	/**
+	 * The Spark service instance. Normally, you would use the static methods on
+	 * Spark, but since we need to spin up multiple instances of Spark for testing,
+	 * we choose to go with instantiating the service ourselves. There is really no
+	 * difference except with the static method, Spark calls ignite and holds a
+	 * singleton instance for us.
+	 *
+	 * @see Spark
+	 */
 	private final Service service;
 
 	/** The module parameters. */
@@ -212,13 +227,6 @@ public class ApiServer implements Runnable {
 		service.awaitInitialization();
 	}
 
-	/**
-	 * Block until stop finishes. Just calls the method on the underlying service.
-	 */
-	public void awaitStop() {
-		service.awaitStop();
-	}
-
 	@Override
 	public void run() {
 		this.startTimeMs = System.currentTimeMillis();
@@ -307,6 +315,13 @@ public class ApiServer implements Runnable {
 	/** Stop the server. */
 	public void shutdown() {
 		service.stop();
+	}
+
+	/**
+	 * Block until stop finishes. Just calls the method on the underlying service.
+	 */
+	public void awaitStop() {
+		service.awaitStop();
 	}
 
 	/** Reconstructs a URL. */

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ApiServer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ApiServer.java
@@ -240,6 +240,13 @@ public class ApiServer implements Runnable {
 			logger.info("External API server is disabled");
 		}
 
+		if (params.internalHttpPort == params.externalHttpPort) {
+			logger.error(
+				"Internal and external port cannot be the same - not starting API server"
+			);
+			return;
+		}
+
 		EmbeddedServers.add(
 			SPARK_EMBEDDED_SERVER_IDENTIFIER,
 			new EmbeddedJettyFactory(

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
@@ -55,17 +55,17 @@ import kong.unirest.json.JSONObject;
  */
 @TestMethodOrder(OrderAnnotation.class)
 public class ApiServerTest {
-	/** The test server port for internal calls. */
-	private static final int TEST_INTERNAL_PORT =
-		spark.Service.SPARK_DEFAULT_PORT;
-
 	/** The test server port for external calls. */
 	private static final int TEST_EXTERNAL_PORT =
-		TEST_INTERNAL_PORT + 1;
+		spark.Service.SPARK_DEFAULT_PORT;
+
+	/** The test server port for internal calls. */
+	private static final int TEST_INTERNAL_PORT =
+		TEST_EXTERNAL_PORT + 1;
 
 	/** The mock ow sec service port */
 	private static final int TEST_OWSEC_PORT =
-		TEST_EXTERNAL_PORT + 1;
+		TEST_INTERNAL_PORT + 1;
 
 	/** Test device data manager. */
 	private DeviceDataManager deviceDataManager;

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
@@ -48,6 +48,11 @@ import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
 import kong.unirest.json.JSONObject;
 
+/**
+ * A class for testing ApiServer. In order to test auth logic, you must tag
+ * the test "auth". Doing so will spin up a mock ow security service and
+ * enable auth on the server.
+ */
 @TestMethodOrder(OrderAnnotation.class)
 public class ApiServerTest {
 	/** The test server port for internal calls. */
@@ -118,7 +123,7 @@ public class ApiServerTest {
 				fail("Could not instantiate OWSec.", e);
 			}
 
-			// Create central client with mock services as necessary
+			// Create uCentral client with mock services as necessary
 			client = new UCentralClient(
 				"rrm",
 				false,

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
@@ -72,6 +72,11 @@ public class ApiServerTest {
 	/** The Gson instance. */
 	private final Gson gson = new Gson();
 
+	/** Build an internal endpoint URL. */
+	private String endpoint(String path) {
+		return endpoint(path, true);
+	}
+
 	/** Build an endpoint URL. */
 	private String endpoint(String path, boolean internal) {
 		return String.format(
@@ -169,7 +174,7 @@ public class ApiServerTest {
 
 		// Fetch topology
 		HttpResponse<String> resp =
-			Unirest.get(endpoint("/api/v1/getTopology", true)).asString();
+			Unirest.get(endpoint("/api/v1/getTopology")).asString();
 		assertEquals(200, resp.getStatus());
 		assertEquals(deviceDataManager.getTopologyJson(), resp.getBody());
 	}
@@ -177,7 +182,7 @@ public class ApiServerTest {
 	@Test
 	@Order(2)
 	void test_setTopology() throws Exception {
-		String url = endpoint("/api/v1/setTopology", true);
+		String url = endpoint("/api/v1/setTopology");
 
 		// Create topology
 		DeviceTopology topology = new DeviceTopology();
@@ -222,7 +227,7 @@ public class ApiServerTest {
 
 		// Fetch config
 		HttpResponse<String> resp =
-			Unirest.get(endpoint("/api/v1/getDeviceLayeredConfig", true)).asString();
+			Unirest.get(endpoint("/api/v1/getDeviceLayeredConfig")).asString();
 		assertEquals(200, resp.getStatus());
 		assertEquals(
 			deviceDataManager.getDeviceLayeredConfigJson(),
@@ -233,7 +238,7 @@ public class ApiServerTest {
 	@Test
 	@Order(4)
 	void test_getDeviceConfig() throws Exception {
-		String url = endpoint("/api/v1/getDeviceConfig", true);
+		String url = endpoint("/api/v1/getDeviceConfig");
 
 		// Create topology
 		final String zone = "test-zone";
@@ -269,7 +274,7 @@ public class ApiServerTest {
 
 		// Set config
 		HttpResponse<String> resp = Unirest
-			.post(endpoint("/api/v1/setDeviceNetworkConfig", true))
+			.post(endpoint("/api/v1/setDeviceNetworkConfig"))
 			.body(gson.toJson(config))
 			.asString();
 		assertEquals(200, resp.getStatus());
@@ -283,7 +288,7 @@ public class ApiServerTest {
 	@Test
 	@Order(6)
 	void test_setDeviceZoneConfig() throws Exception {
-		String url = endpoint("/api/v1/setDeviceZoneConfig", true);
+		String url = endpoint("/api/v1/setDeviceZoneConfig");
 
 		// Create topology
 		final String zone = "test-zone";
@@ -330,7 +335,7 @@ public class ApiServerTest {
 	@Test
 	@Order(7)
 	void test_setDeviceApConfig() throws Exception {
-		String url = endpoint("/api/v1/setDeviceApConfig", true);
+		String url = endpoint("/api/v1/setDeviceApConfig");
 
 		// Create topology
 		final String zone = "test-zone";
@@ -377,7 +382,7 @@ public class ApiServerTest {
 	@Test
 	@Order(8)
 	void test_modifyDeviceApConfig() throws Exception {
-		String url = endpoint("/api/v1/modifyDeviceApConfig", true);
+		String url = endpoint("/api/v1/modifyDeviceApConfig");
 
 		// Create topology
 		final String zone = "test-zone";
@@ -444,7 +449,7 @@ public class ApiServerTest {
 	void test_currentModel() throws Exception {
 		// Fetch RRM model
 		HttpResponse<String> resp =
-			Unirest.get(endpoint("/api/v1/currentModel", true)).asString();
+			Unirest.get(endpoint("/api/v1/currentModel")).asString();
 		assertEquals(200, resp.getStatus());
 		assertEquals(gson.toJson(modeler.getDataModel()), resp.getBody());
 	}
@@ -452,7 +457,7 @@ public class ApiServerTest {
 	@Test
 	@Order(101)
 	void test_optimizeChannel() throws Exception {
-		String url = endpoint("/api/v1/optimizeChannel", true);
+		String url = endpoint("/api/v1/optimizeChannel");
 
 		// Create topology
 		final String zone = "test-zone";
@@ -486,7 +491,7 @@ public class ApiServerTest {
 	@Test
 	@Order(102)
 	void test_optimizeTxPower() throws Exception {
-		String url = endpoint("/api/v1/optimizeTxPower", true);
+		String url = endpoint("/api/v1/optimizeTxPower");
 
 		// Create topology
 		final String zone = "test-zone";
@@ -525,19 +530,19 @@ public class ApiServerTest {
 		// Index page paths
 		assertEquals(
 			200,
-			Unirest.get(endpoint("/", true)).asString().getStatus()
+			Unirest.get(endpoint("/")).asString().getStatus()
 		);
 		assertEquals(
 			200,
-			Unirest.get(endpoint("/index.html", true)).asString().getStatus()
+			Unirest.get(endpoint("/index.html")).asString().getStatus()
 		);
 
 		// OpenAPI YAML/JSON
 		HttpResponse<String> yamlResp =
-			Unirest.get(endpoint("/openapi.yaml", true)).asString();
+			Unirest.get(endpoint("/openapi.yaml")).asString();
 		assertEquals(200, yamlResp.getStatus());
 		HttpResponse<JsonNode> jsonResp =
-			Unirest.get(endpoint("/openapi.json", true)).asJson();
+			Unirest.get(endpoint("/openapi.json")).asJson();
 		assertEquals(200, jsonResp.getStatus());
 		// Check that we got the OpenAPI 3.x version string
 		assertTrue(
@@ -561,7 +566,7 @@ public class ApiServerTest {
 	@Test
 	@Order(1001)
 	void test404() throws Exception {
-		final String fakeEndpoint = endpoint("/test123", true);
+		final String fakeEndpoint = endpoint("/test123");
 		assertEquals(404, Unirest.get(fakeEndpoint).asString().getStatus());
 		assertEquals(404, Unirest.post(fakeEndpoint).asString().getStatus());
 		assertEquals(404, Unirest.put(fakeEndpoint).asString().getStatus());
@@ -573,7 +578,7 @@ public class ApiServerTest {
 	@Test
 	@Order(1002)
 	void testCORS() throws Exception {
-		final String fakeEndpoint = endpoint("/test123", true);
+		final String fakeEndpoint = endpoint("/test123");
 		final String HEADERS = "authorization";
 		final String METHOD = "GET";
 		final String ORIGIN = "https://example.com";
@@ -609,7 +614,7 @@ public class ApiServerTest {
 	void test_system() throws Exception {
 		// Test on GET api
 		HttpResponse<JsonNode> get_resp =
-			Unirest.get(endpoint("/api/v1/system?command=info", true)).asJson();
+			Unirest.get(endpoint("/api/v1/system?command=info")).asJson();
 		assertEquals(200, get_resp.getStatus());
 		assertEquals(
 			VersionProvider.get(),
@@ -617,7 +622,7 @@ public class ApiServerTest {
 		);
 
 		// Test on POST api
-		String url = endpoint("/api/v1/system", true);
+		String url = endpoint("/api/v1/system");
 		// Valid command
 		HttpResponse<String> post_resp = Unirest
 			.post(url)
@@ -640,7 +645,7 @@ public class ApiServerTest {
 	@Order(2001)
 	void test_provider() throws Exception {
 		HttpResponse<JsonNode> resp =
-			Unirest.get(endpoint("/api/v1/provider", true)).asJson();
+			Unirest.get(endpoint("/api/v1/provider")).asJson();
 		assertEquals(200, resp.getStatus());
 		assertEquals(
 			rrmConfig.serviceConfig.vendor,
@@ -660,7 +665,7 @@ public class ApiServerTest {
 	@Order(2002)
 	void test_algorithms() throws Exception {
 		HttpResponse<JsonNode> resp =
-			Unirest.get(endpoint("/api/v1/algorithms", true)).asJson();
+			Unirest.get(endpoint("/api/v1/algorithms")).asJson();
 		assertEquals(200, resp.getStatus());
 		assertEquals(
 			RRMAlgorithm.AlgorithmType.values().length,
@@ -671,7 +676,7 @@ public class ApiServerTest {
 	@Test
 	@Order(2003)
 	void test_runRRM() throws Exception {
-		String url = endpoint("/api/v1/runRRM", true);
+		String url = endpoint("/api/v1/runRRM");
 
 		// Create topology
 		final String zone = "test-zone";

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -39,13 +40,13 @@ import com.facebook.openwifi.rrm.RRMAlgorithm;
 import com.facebook.openwifi.rrm.RRMConfig;
 import com.facebook.openwifi.rrm.VersionProvider;
 import com.facebook.openwifi.rrm.mysql.DatabaseManager;
+import com.facebook.openwifi.rrm.services.MockOWSecService;
 import com.google.gson.Gson;
 
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
 import kong.unirest.json.JSONObject;
-import spark.Spark;
 
 @TestMethodOrder(OrderAnnotation.class)
 public class ApiServerTest {
@@ -55,7 +56,11 @@ public class ApiServerTest {
 
 	/** The test server port for external calls. */
 	private static final int TEST_EXTERNAL_PORT =
-		spark.Service.SPARK_DEFAULT_PORT + 1;
+		TEST_INTERNAL_PORT + 1;
+
+	/** The mock ow sec service port */
+	private static final int TEST_OWSEC_PORT =
+		TEST_EXTERNAL_PORT + 1;
 
 	/** Test device data manager. */
 	private DeviceDataManager deviceDataManager;
@@ -65,6 +70,9 @@ public class ApiServerTest {
 
 	/** Test API server instance. */
 	private ApiServer server;
+
+	/** Mock OW sec service */
+	private MockOWSecService owSecService;
 
 	/** Test modeler instance. */
 	private Modeler modeler;
@@ -97,8 +105,36 @@ public class ApiServerTest {
 		rrmConfig.moduleConfig.apiServerParams.externalHttpPort =
 			TEST_EXTERNAL_PORT;
 
-		// Create clients (null for now)
 		UCentralClient client = null;
+
+		boolean useAuth = testInfo.getTags().contains("auth");
+		if (useAuth) {
+			this.rrmConfig.moduleConfig.apiServerParams.useOpenWifiAuth = true;
+
+			// spin up mock owsec service
+			try {
+				owSecService = new MockOWSecService(TEST_OWSEC_PORT);
+			} catch (Exception e) {
+				fail("Could not instantiate OWSec.", e);
+			}
+
+			// Create central client with mock services as necessary
+			client = new UCentralClient(
+				"rrm",
+				false,
+				null,
+				null,
+				null,
+				rrmConfig.uCentralConfig.uCentralSocketParams
+			);
+			ServiceEvent owsecServiceEvent = new ServiceEvent();
+			owsecServiceEvent.type = "owsec";
+			owsecServiceEvent.privateEndPoint =
+				String.format("http://localhost:%d", owSecService.getPort());
+			client.setServiceEndpoint("owsec", owsecServiceEvent);
+		}
+
+		// Create clients (null for now)
 		UCentralKafkaConsumer consumer = null;
 		DatabaseManager dbManager = null;
 
@@ -143,7 +179,7 @@ public class ApiServerTest {
 		);
 		try {
 			server.run();
-			Spark.awaitInitialization();
+			server.awaitInitialization();
 		} catch (Exception e) {
 			fail("Could not instantiate ApiServer.", e);
 		}
@@ -154,9 +190,15 @@ public class ApiServerTest {
 		// Destroy ApiServer
 		if (server != null) {
 			server.shutdown();
-			Spark.awaitStop();
+			server.awaitStop();
 		}
 		server = null;
+
+		// reset owsec server
+		if (owSecService != null) {
+			owSecService.stop();
+		}
+		owSecService = null;
 
 		// Reset Unirest client
 		// Without this, Unirest randomly throws:
@@ -708,5 +750,57 @@ public class ApiServerTest {
 			400,
 			Unirest.put(url + "?venue=asdf&algorithm=" + algorithms.get(0)).asString().getStatus()
 		);
+	}
+
+	@Test
+	@Tag("auth")
+	@Order(3000)
+	void test_publicEndpoint() throws Exception {
+		// no token
+		HttpResponse<String> resp =
+			Unirest.get(endpoint("/api/v1/getTopology", false)).asString();
+		assertEquals(403, resp.getStatus());
+
+		// bad token
+		resp = Unirest.get(endpoint("/api/v1/getTopology", false))
+			.header("Authorization", "Bearer some_bad_token")
+			.asString();
+		assertEquals(403, resp.getStatus());
+
+		// valid for 300 seconds (5 minutes)
+		String token = "this_is_a_good_token";
+		owSecService.addToken(token, 300);
+		// good token
+		resp = Unirest.get(endpoint("/api/v1/getTopology", false))
+			.header("Authorization", "Bearer " + token)
+			.asString();
+		assertEquals(200, resp.getStatus());
+	}
+
+	@Test
+	@Tag("auth")
+	@Order(3001)
+	void test_privateEndpoint() throws Exception {
+		// no headers
+		HttpResponse<String> resp =
+			Unirest.get(endpoint("/api/v1/getTopology", true)).asString();
+		assertEquals(403, resp.getStatus());
+
+		// bad headers
+		resp = Unirest.get(endpoint("/api/v1/getTopology", true))
+			.header("X-INTERNAL-NAME", "internal_name")
+			.header("X-API-KEY", "not_a_valid_key")
+			.asString();
+		assertEquals(403, resp.getStatus());
+
+		// good headers
+		resp = Unirest.get(endpoint("/api/v1/getTopology", true))
+			.header("X-INTERNAL-NAME", "internal_name")
+			.header(
+				"X-API-KEY",
+				UCentralUtils.generateServiceKey(rrmConfig.serviceConfig)
+			)
+			.asString();
+		assertEquals(200, resp.getStatus());
 	}
 }

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ApiServerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import com.facebook.openwifi.cloudsdk.models.gw.ServiceEvent;
 import com.facebook.openwifi.cloudsdk.UCentralClient;
 import com.facebook.openwifi.cloudsdk.UCentralConstants;
 import com.facebook.openwifi.cloudsdk.kafka.UCentralKafkaConsumer;
@@ -41,6 +42,7 @@ import com.facebook.openwifi.rrm.RRMConfig;
 import com.facebook.openwifi.rrm.VersionProvider;
 import com.facebook.openwifi.rrm.mysql.DatabaseManager;
 import com.facebook.openwifi.rrm.services.MockOWSecService;
+import com.facebook.openwifi.rrm.Utils;
 import com.google.gson.Gson;
 
 import kong.unirest.HttpResponse;
@@ -130,7 +132,9 @@ public class ApiServerTest {
 				null,
 				null,
 				null,
-				rrmConfig.uCentralConfig.uCentralSocketParams
+				rrmConfig.uCentralConfig.uCentralSocketParams.connectTimeoutMs,
+				rrmConfig.uCentralConfig.uCentralSocketParams.socketTimeoutMs,
+				rrmConfig.uCentralConfig.uCentralSocketParams.wifiScanTimeoutMs
 			);
 			ServiceEvent owsecServiceEvent = new ServiceEvent();
 			owsecServiceEvent.type = "owsec";
@@ -803,7 +807,7 @@ public class ApiServerTest {
 			.header("X-INTERNAL-NAME", "internal_name")
 			.header(
 				"X-API-KEY",
-				UCentralUtils.generateServiceKey(rrmConfig.serviceConfig)
+				Utils.generateServiceKey(rrmConfig.serviceConfig)
 			)
 			.asString();
 		assertEquals(200, resp.getStatus());

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/services/MockOWSecService.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/services/MockOWSecService.java
@@ -22,8 +22,13 @@ import spark.Request;
 import spark.Response;
 import spark.Route;
 
+/**
+ * This is a mock OW Security service meant to be used in tests.
+ *
+ * @see <a href="https://github.com/Telecominfraproject/wlan-cloud-ucentralsec">owsec</a>
+ */
 public class MockOWSecService {
-	public class Time {
+	private class TokenInfo {
 		long expiry;
 		long created;
 	}
@@ -31,7 +36,7 @@ public class MockOWSecService {
 	private final Gson gson = new Gson();
 
 	/** A mapping of valid tokens to their expiry time in seconds since epoch */
-	private Map<String, Time> validTokens;
+	private Map<String, TokenInfo> validTokens;
 
 	/** The Spark service */
 	private Service service;
@@ -54,7 +59,7 @@ public class MockOWSecService {
 	}
 
 	public void addToken(String token, long expiresInSec) {
-		Time time = new Time();
+		TokenInfo time = new TokenInfo();
 		time.created = Instant.now().getEpochSecond();
 		time.expiry = expiresInSec;
 
@@ -92,13 +97,13 @@ public class MockOWSecService {
 				return "Forbidden";
 			}
 
-			Time times = validTokens.get(token);
-			if (times == null) {
+			TokenInfo info = validTokens.get(token);
+			if (info == null) {
 				response.status(403);
 				return "Forbidden";
 			}
 
-			if (times.created + times.expiry < Instant.now().getEpochSecond()) {
+			if (info.created + info.expiry < Instant.now().getEpochSecond()) {
 				response.status(403);
 				return "Forbidden";
 			}
@@ -107,8 +112,8 @@ public class MockOWSecService {
 			result.userInfo = new UserInfo();
 			result.tokenInfo = new WebTokenResult();
 			result.tokenInfo.access_token = token;
-			result.tokenInfo.created = times.created;
-			result.tokenInfo.expires_in = times.expiry;
+			result.tokenInfo.created = info.created;
+			result.tokenInfo.expires_in = info.expiry;
 
 			return gson.toJson(result);
 		}

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/services/MockOWSecService.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/services/MockOWSecService.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifi.rrm.services;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.time.Instant;
+
+import com.facebook.openwifirrm.ucentral.gw.models.TokenValidationResult;
+import com.facebook.openwifirrm.ucentral.gw.models.UserInfo;
+import com.facebook.openwifirrm.ucentral.gw.models.WebTokenResult;
+
+import com.google.gson.Gson;
+import spark.Service;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+public class MockOWSecService {
+	public class Time {
+		long expiry;
+		long created;
+	}
+
+	private final Gson gson = new Gson();
+
+	/** A mapping of valid tokens to their expiry time in seconds since epoch */
+	private Map<String, Time> validTokens;
+
+	/** The Spark service */
+	private Service service;
+
+	public MockOWSecService(int port) {
+		validTokens = new HashMap<>();
+		service = Service.ignite();
+		service.port(port);
+
+		service.get("/api/v1/validateToken", new ValidateTokenEndpoint());
+		service.get("/api/v1/oauth2", new ValidateTokenEndpoint());
+		service.get("/api/v1/systemEndpoints", new SystemEndpoint());
+
+		service.awaitInitialization();
+	}
+
+	public void stop() {
+		service.stop();
+		service.awaitStop();
+	}
+
+	public void addToken(String token, long expiresInSec) {
+		Time time = new Time();
+		time.created = Instant.now().getEpochSecond();
+		time.expiry = expiresInSec;
+
+		validTokens.put(token, time);
+	}
+
+	public void removeToken(String token) {
+		validTokens.remove(token);
+	}
+
+	public int getPort() { return service.port(); }
+
+	public class Oauth2Endpoint implements Route {
+		@Override
+		public String handle(Request request, Response response) {
+			response.status(501);
+			return "Not Implemented";
+		}
+	}
+
+	public class SystemEndpoint implements Route {
+		@Override
+		public String handle(Request request, Response response) {
+			response.status(501);
+			return "Not Implemented";
+		}
+	}
+
+	public class ValidateTokenEndpoint implements Route {
+		@Override
+		public String handle(Request request, Response response) {
+			String token = request.queryParams("token");
+			if (token == null) {
+				response.status(403);
+				return "Forbidden";
+			}
+
+			Time times = validTokens.get(token);
+			if (times == null) {
+				response.status(403);
+				return "Forbidden";
+			}
+
+			if (times.created + times.expiry < Instant.now().getEpochSecond()) {
+				response.status(403);
+				return "Forbidden";
+			}
+
+			TokenValidationResult result = new TokenValidationResult();
+			result.userInfo = new UserInfo();
+			result.tokenInfo = new WebTokenResult();
+			result.tokenInfo.access_token = token;
+			result.tokenInfo.created = times.created;
+			result.tokenInfo.expires_in = times.expiry;
+
+			return gson.toJson(result);
+		}
+	}
+}

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/services/MockOWSecService.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/services/MockOWSecService.java
@@ -12,9 +12,9 @@ import java.util.Map;
 import java.util.HashMap;
 import java.time.Instant;
 
-import com.facebook.openwifirrm.ucentral.gw.models.TokenValidationResult;
-import com.facebook.openwifirrm.ucentral.gw.models.UserInfo;
-import com.facebook.openwifirrm.ucentral.gw.models.WebTokenResult;
+import com.facebook.openwifi.cloudsdk.models.gw.TokenValidationResult;
+import com.facebook.openwifi.cloudsdk.models.gw.UserInfo;
+import com.facebook.openwifi.cloudsdk.models.gw.WebTokenResult;
 
 import com.google.gson.Gson;
 import spark.Service;

--- a/scripts/k6/simple.js
+++ b/scripts/k6/simple.js
@@ -2,8 +2,8 @@ import http from 'k6/http';
 import { sleep } from 'k6';
 
 
-const INTERNAL_BASE_URL = 'http://localhost:16789/api/v1';
-const EXTERNAL_BASE_URL = __ENV.SEPARATE_INTERNAL_EXTERNAL_PORTS ? 'http://localhost:16790/api/v1' : INTERNAL_BASE_URL;
+const INTERNAL_BASE_URL = 'http://localhost:16790/api/v1';
+const EXTERNAL_BASE_URL = __ENV.SEPARATE_INTERNAL_EXTERNAL_PORTS ? 'http://localhost:16789/api/v1' : INTERNAL_BASE_URL;
 
 
 export default function () {

--- a/scripts/k6/simple.js
+++ b/scripts/k6/simple.js
@@ -2,7 +2,9 @@ import http from 'k6/http';
 import { sleep } from 'k6';
 
 
-const BASE_URL = 'http://localhost:16789/api/v1';
+const INTERNAL_BASE_URL = 'http://localhost:16789/api/v1';
+const EXTERNAL_BASE_URL = __ENV.SEPARATE_INTERNAL_EXTERNAL_PORTS ? 'http://localhost:16790/api/v1' : INTERNAL_BASE_URL;
+
 
 export default function () {
 	const endpoints = [
@@ -12,13 +14,19 @@ export default function () {
 		'getToplogy',
 		'currentModel',
 	];
-	const requests = endpoints.map(endpoint => {
+	const internalRequests = endpoints.map(endpoint => {
 		return {
 			method: 'GET',
-			url: `${BASE_URL}/${endpoint}`,
+			url: `${INTERNAL_BASE_URL}/${endpoint}`,
+		};
+	});
+	const externalRequests = endpoints.map(endpoint => {
+		return {
+			method: 'GET',
+			url: `${EXTERNAL_BASE_URL}/${endpoint}`,
 		};
 	});
 
-	let responses = http.batch(requests);
+	let responses = http.batch([...internalRequests, ...externalRequests]);
 	sleep(0.1);
 }


### PR DESCRIPTION
Override the default embedded server, allowing us to define our own connectors. So define new parameters and pass them in to open another port for external calls. We already have the port information, so use that to determine whether it was an internal or external call in the request filter.

External, no `Authorization` header
```
$ http GET localhost:16790/api/v1/getTopology
HTTP/1.1 401 Unauthorized
Content-Type: text/html;charset=utf-8
Date: Wed, 14 Sep 2022 01:07:38 GMT
Server:
Transfer-Encoding: chunked
WWW-Authenticate: Bearer error="invalid_token"
```

External, bad token
```
% http GET localhost:16790/api/v1/getTopology 'Authorization: Bearer asd'
HTTP/1.1 401 Unauthorized
Content-Type: text/html;charset=utf-8
Date: Wed, 14 Sep 2022 01:08:56 GMT
Server:
Transfer-Encoding: chunked
WWW-Authenticate: Bearer error="invalid_token"

Unauthorized
```

External, good token
```
$ http GET localhost:16790/api/v1/getTopology 'Authorization: Bearer <a_good_token>'
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Type: application/json
Date: Wed, 14 Sep 2022 01:10:26 GMT
Server:
Transfer-Encoding: chunked

{
  ... // response
}
```

Internal, no headers
```
$ http GET localhost:16789/api/v1/getTopology
HTTP/1.1 401 Unauthorized
Content-Type: text/html;charset=utf-8
Date: Wed, 14 Sep 2022 01:14:24 GMT
Server:
Transfer-Encoding: chunked

Unauthorized
```

Internal, bad headers
```
$ http GET localhost:16789/api/v1/getTopology 'X-INTERNAL-NAME: <name>' 'X-API-KEY: somebadkey'
HTTP/1.1 401 Unauthorized
Content-Type: text/html;charset=utf-8
Date: Wed, 14 Sep 2022 01:17:00 GMT
Server:
Transfer-Encoding: chunked

Unauthorized
```

Internal, good key
```
$ http GET localhost:16789/api/v1/getTopology 'X-INTERNAL-NAME: <name>' 'X-API-KEY: <good key>'
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Type: application/json
Date: Wed, 14 Sep 2022 01:17:19 GMT
Server:
Transfer-Encoding: chunked

{
    ... // response
}

```