### PR TITLE
Use TPC user configs (allowedTxPowers, userTxPowers)

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/DeviceConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/DeviceConfig.java
@@ -69,7 +69,7 @@ public class DeviceConfig {
 	 */
 	public Map<String, List<Integer>> allowedTxPowers;
 
-	/** The RRM-assigned tx powers to use (map from radio to tx power) */
+	/** The RRM-assigned tx powers to use (map from band to tx power) */
 	public Map<String, Integer> autoTxPowers;
 
 	/** The user-assigned tx powers to use, overriding "autoTxPowers" */

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -143,7 +143,8 @@ public class LocationBasedOptimalTPC extends TPC {
 			}
 		}
 		if (optimalIndex == permutations.size()) {
-			return Collections.nCopies(numOfAPs, 30);
+			return Collections
+				.nCopies(numOfAPs, Collections.max(txPowerChoices));
 		} else {
 			return permutations.get(optimalIndex);
 		}

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,7 +166,8 @@ public class LocationBasedOptimalTPC extends TPC {
 		Map<String, Integer> validAPs = new TreeMap<>();
 		List<Double> apLocX = new ArrayList<>();
 		List<Double> apLocY = new ArrayList<>();
-		List<Integer> txPowerChoices = new ArrayList<>(DEFAULT_TX_POWER_CHOICES);
+		List<Integer> txPowerChoices =
+			new ArrayList<>(DEFAULT_TX_POWER_CHOICES);
 		// Filter out the invalid APs (e.g., no radio, no location data)
 		// Update txPowerChoices, boundary, apLocX, apLocY for the optimization
 		for (Map.Entry<String, State> e : model.latestState.entrySet()) {
@@ -211,7 +211,8 @@ public class LocationBasedOptimalTPC extends TPC {
 			}
 
 			// Update the txPowerChoices for the optimization
-			txPowerChoices = updateTxPowerChoices(band, serialNumber, txPowerChoices);
+			txPowerChoices =
+				updateTxPowerChoices(band, serialNumber, txPowerChoices);
 
 			// Update the boundary for the optimization
 			if (deviceCfg.boundary != null) {

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -167,11 +167,7 @@ public class LocationBasedOptimalTPC extends TPC {
 		Map<String, Integer> validAPs = new TreeMap<>();
 		List<Double> apLocX = new ArrayList<>();
 		List<Double> apLocY = new ArrayList<>();
-		List<Integer> txPowerChoices = IntStream
-			.rangeClosed(MIN_TX_POWER, MAX_TX_POWER)
-			.boxed()
-			.collect(Collectors.toList());
-
+		List<Integer> txPowerChoices = new ArrayList<>(DEFAULT_TX_POWER_CHOICES);
 		// Filter out the invalid APs (e.g., no radio, no location data)
 		// Update txPowerChoices, boundary, apLocX, apLocY for the optimization
 		for (Map.Entry<String, State> e : model.latestState.entrySet()) {
@@ -215,11 +211,7 @@ public class LocationBasedOptimalTPC extends TPC {
 			}
 
 			// Update the txPowerChoices for the optimization
-			Map<String, List<Integer>> allowedTxPowers =
-				deviceCfg.allowedTxPowers;
-			if (allowedTxPowers != null && allowedTxPowers.get(band) != null) {
-				txPowerChoices.retainAll(allowedTxPowers.get(band));
-			}
+			txPowerChoices = updateTxPowerChoices(band, serialNumber, txPowerChoices);
 
 			// Update the boundary for the optimization
 			if (deviceCfg.boundary != null) {

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -39,7 +39,6 @@ public class RandomTxPowerInitializer extends TPC {
 	/** The PRNG instance. */
 	private final Random rng;
 
-
 	/** Factory method to parse generic args map into the proper constructor */
 	public static RandomTxPowerInitializer makeWithArgs(
 		DataModel model,
@@ -53,7 +52,6 @@ public class RandomTxPowerInitializer extends TPC {
 			deviceDataManager
 		);
 	}
-
 
 	/** Constructor. */
 	public RandomTxPowerInitializer(

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -89,7 +89,7 @@ public class RandomTxPowerInitializer extends TPC {
 			Map<String, Integer> radioMap = new TreeMap<>();
 			for (String band : UCentralConstants.BANDS) {
 				List<Integer> availableTxPowersList =
-					getAvailableTxPowersList(band, serialNumber);
+					updateTxPowerChoices(band, serialNumber, DEFAULT_TX_POWER_CHOICES);
 				Integer txPower = availableTxPowersList
 					.get(rng.nextInt(availableTxPowersList.size()));
 				radioMap.put(band, txPower);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -89,7 +89,11 @@ public class RandomTxPowerInitializer extends TPC {
 			Map<String, Integer> radioMap = new TreeMap<>();
 			for (String band : UCentralConstants.BANDS) {
 				List<Integer> availableTxPowersList =
-					updateTxPowerChoices(band, serialNumber, DEFAULT_TX_POWER_CHOICES);
+					updateTxPowerChoices(
+						band,
+						serialNumber,
+						DEFAULT_TX_POWER_CHOICES
+					);
 				Integer txPower = availableTxPowersList
 					.get(rng.nextInt(availableTxPowersList.size()));
 				radioMap.put(band, txPower);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
@@ -10,6 +10,7 @@ package com.facebook.openwifirrm.optimizers.tpc;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -34,10 +35,14 @@ public abstract class TPC {
 	/** Maximum supported tx power (dBm), inclusive. */
 	public static final int MAX_TX_POWER = 30;
 
-	public static final List<Integer> DEFAULT_TX_POWER_CHOICES = IntStream
-		.rangeClosed(20, MAX_TX_POWER)
-		.boxed()
-		.collect(Collectors.toList());
+	/** Default tx power choices. */
+	public static final List<Integer> DEFAULT_TX_POWER_CHOICES =
+		Collections.unmodifiableList(
+			IntStream
+				.rangeClosed(20, MAX_TX_POWER)
+				.boxed()
+				.collect(Collectors.toList())
+		);
 
 	/** The input data model. */
 	protected final DataModel model;

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
@@ -8,22 +8,36 @@
 
 package com.facebook.openwifirrm.optimizers.tpc;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.facebook.openwifirrm.DeviceConfig;
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.modules.ConfigManager;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * TPC (Transmit Power Control) base class.
  */
 public abstract class TPC {
+	private static final Logger logger = LoggerFactory.getLogger(TPC.class);
+
 	/** Minimum supported tx power (dBm), inclusive. */
 	public static final int MIN_TX_POWER = 0;
 
 	/** Maximum supported tx power (dBm), inclusive. */
 	public static final int MAX_TX_POWER = 30;
+
+	public static final List<Integer> DEFAULT_TX_POWERS_LIST = IntStream
+		.rangeClosed(MIN_TX_POWER, MAX_TX_POWER)
+		.boxed()
+		.collect(Collectors.toList());
 
 	/** The input data model. */
 	protected final DataModel model;
@@ -44,8 +58,6 @@ public abstract class TPC {
 		this.zone = zone;
 		this.deviceConfigs = deviceDataManager.getAllDeviceConfigs(zone);
 
-		// TODO!! Actually use device configs (allowedTxPowers, userTxPowers)
-
 		// Remove model entries not in the given zone
 		this.model.latestWifiScans.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber)
@@ -59,6 +71,67 @@ public abstract class TPC {
 		this.model.latestDeviceCapabilities.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber)
 			);
+	}
+
+	/**
+	 * Get the available tx powers based on user and allowed channels from deviceConfig
+	 * @param band the operational band
+	 * @param serialNumber the device
+	 * @return the available tx powers of the device
+	 */
+	protected List<Integer> getAvailableTxPowersList(
+		String band,
+		String serialNumber
+	) {
+		List<Integer> newAvailableTxPowersList =
+			new ArrayList<>(DEFAULT_TX_POWERS_LIST);
+
+		// Update the available tx powers based on user tx powers or allowed tx powers
+		DeviceConfig deviceCfg = deviceConfigs.get(serialNumber);
+		if (deviceCfg == null) {
+			return newAvailableTxPowersList;
+		}
+		if (
+			deviceCfg.userTxPowers != null &&
+				deviceCfg.userTxPowers.get(band) != null
+		) {
+			newAvailableTxPowersList = Arrays.asList(
+				deviceCfg.userTxPowers.get(band)
+			);
+			logger.debug(
+				"Device {}: userTxPowers {}",
+				serialNumber,
+				deviceCfg.userTxPowers.get(band)
+			);
+		} else if (
+			deviceCfg.allowedTxPowers != null &&
+				deviceCfg.allowedTxPowers.get(band) != null
+		) {
+			List<Integer> allowedTxPowers = deviceCfg.allowedTxPowers.get(band);
+			logger.debug(
+				"Device {}: allowedTxPowers {}",
+				serialNumber,
+				allowedTxPowers
+			);
+			newAvailableTxPowersList.retainAll(allowedTxPowers);
+		}
+
+		// If the intersection of the above steps gives an empty list,
+		// turn back to use the default available tx powers list
+		if (newAvailableTxPowersList.isEmpty()) {
+			logger.debug(
+				"Device {}: the updated availableTxPowersList is empty!!! " +
+					"userTxPowers or allowedTxPowers might be invalid " +
+					"Fall back to the default available tx powers list"
+			);
+			newAvailableTxPowersList = new ArrayList<>(DEFAULT_TX_POWERS_LIST);
+		}
+		logger.debug(
+			"Device {}: the updated availableTxPowersList is {}",
+			serialNumber,
+			newAvailableTxPowersList
+		);
+		return newAvailableTxPowersList;
 	}
 
 	/**

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
@@ -35,7 +35,7 @@ public abstract class TPC {
 	public static final int MAX_TX_POWER = 30;
 
 	public static final List<Integer> DEFAULT_TX_POWER_CHOICES = IntStream
-		.rangeClosed(MIN_TX_POWER, MAX_TX_POWER)
+		.rangeClosed(20, MAX_TX_POWER)
 		.boxed()
 		.collect(Collectors.toList());
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
@@ -39,7 +39,7 @@ public abstract class TPC {
 	public static final List<Integer> DEFAULT_TX_POWER_CHOICES =
 		Collections.unmodifiableList(
 			IntStream
-				.rangeClosed(20, MAX_TX_POWER)
+				.rangeClosed(MIN_TX_POWER, MAX_TX_POWER)
 				.boxed()
 				.collect(Collectors.toList())
 		);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
@@ -34,7 +34,7 @@ public abstract class TPC {
 	/** Maximum supported tx power (dBm), inclusive. */
 	public static final int MAX_TX_POWER = 30;
 
-	public static final List<Integer> DEFAULT_TX_POWERS_LIST = IntStream
+	public static final List<Integer> DEFAULT_TX_POWER_CHOICES = IntStream
 		.rangeClosed(MIN_TX_POWER, MAX_TX_POWER)
 		.boxed()
 		.collect(Collectors.toList());
@@ -74,28 +74,30 @@ public abstract class TPC {
 	}
 
 	/**
-	 * Get the available tx powers based on user and allowed channels from deviceConfig
+	 * Update the tx power choices based on user and allowed channels from deviceConfig
 	 * @param band the operational band
 	 * @param serialNumber the device
-	 * @return the available tx powers of the device
+	 * @param txPowerChoices the available tx powers of the device
+	 * @return the updated tx powers of the device
 	 */
-	protected List<Integer> getAvailableTxPowersList(
+	protected List<Integer> updateTxPowerChoices(
 		String band,
-		String serialNumber
+		String serialNumber,
+		List<Integer> txPowerChoices
 	) {
-		List<Integer> newAvailableTxPowersList =
-			new ArrayList<>(DEFAULT_TX_POWERS_LIST);
+		List<Integer> newTxPowerChoices =
+			new ArrayList<>(txPowerChoices);
 
 		// Update the available tx powers based on user tx powers or allowed tx powers
 		DeviceConfig deviceCfg = deviceConfigs.get(serialNumber);
 		if (deviceCfg == null) {
-			return newAvailableTxPowersList;
+			return newTxPowerChoices;
 		}
 		if (
 			deviceCfg.userTxPowers != null &&
 				deviceCfg.userTxPowers.get(band) != null
 		) {
-			newAvailableTxPowersList = Arrays.asList(
+			newTxPowerChoices = Arrays.asList(
 				deviceCfg.userTxPowers.get(band)
 			);
 			logger.debug(
@@ -113,25 +115,25 @@ public abstract class TPC {
 				serialNumber,
 				allowedTxPowers
 			);
-			newAvailableTxPowersList.retainAll(allowedTxPowers);
+			newTxPowerChoices.retainAll(allowedTxPowers);
 		}
 
 		// If the intersection of the above steps gives an empty list,
 		// turn back to use the default available tx powers list
-		if (newAvailableTxPowersList.isEmpty()) {
+		if (newTxPowerChoices.isEmpty()) {
 			logger.debug(
 				"Device {}: the updated availableTxPowersList is empty!!! " +
 					"userTxPowers or allowedTxPowers might be invalid " +
 					"Fall back to the default available tx powers list"
 			);
-			newAvailableTxPowersList = new ArrayList<>(DEFAULT_TX_POWERS_LIST);
+			newTxPowerChoices = new ArrayList<>(DEFAULT_TX_POWER_CHOICES);
 		}
 		logger.debug(
 			"Device {}: the updated availableTxPowersList is {}",
 			serialNumber,
-			newAvailableTxPowersList
+			newTxPowerChoices
 		);
-		return newAvailableTxPowersList;
+		return newTxPowerChoices;
 	}
 
 	/**

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -224,7 +224,7 @@ public class LocationBasedOptimalTPCTest {
 			expected2.computeIfAbsent(deviceC, k -> new TreeMap<>())
 				.put(
 					band,
-					20
+					0
 				);
 		}
 

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -224,7 +224,7 @@ public class LocationBasedOptimalTPCTest {
 			expected2.computeIfAbsent(deviceC, k -> new TreeMap<>())
 				.put(
 					band,
-					0
+					20
 				);
 		}
 

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -91,7 +91,7 @@ public class LocationBasedOptimalTPCTest {
 				new ArrayList<>(Arrays.asList(0, 1))
 			);
 		assertEquals(
-			new ArrayList<>(Arrays.asList(30, 30, 30, 30)),
+			new ArrayList<>(Arrays.asList(1, 1, 1, 1)),
 			txPowerList2
 		);
 	}

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -65,38 +65,28 @@ public class RandomTxPowerInitializerTest {
 
 	@Test
 	@Order(1)
-	void testSeededTxPower() throws Exception {
+	void testSeededSameTxPower() throws Exception {
 		TPC optimizer = new RandomTxPowerInitializer(
 			createModel(),
 			TEST_ZONE,
 			createDeviceDataManager(),
+			false,
 			new Random(0)
 		);
 
 		Map<String, Map<String, Integer>> txPowerMap =
 			optimizer.computeTxPowerMap();
 
-		assertEquals(
-			28,
-			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G)
-		);
-		assertEquals(
-			25,
-			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G)
-		);
-		assertEquals(
-			20,
-			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G)
-		);
-		assertEquals(
-			26,
-			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G)
-		);
+		int txPower = 20;
+		for (String band : UCentralConstants.BANDS) {
+			assertEquals(txPower, txPowerMap.get(DEVICE_A).get(band));
+			assertEquals(txPower, txPowerMap.get(DEVICE_B).get(band));
+		}
 	}
 
 	@Test
 	@Order(2)
-	void testRandomTxPowerInAvailableList() throws Exception {
+	void testSeededDifferentTxPowers() throws Exception {
 		DeviceDataManager deviceDataManager = createDeviceDataManager();
 		DeviceLayeredConfig deviceLayeredConfig = new DeviceLayeredConfig();
 		DeviceConfig deviceConfigA = new DeviceConfig();
@@ -117,6 +107,7 @@ public class RandomTxPowerInitializerTest {
 			createModel(),
 			TEST_ZONE,
 			deviceDataManager,
+			true,
 			new Random(0)
 		);
 		Map<String, Map<String, Integer>> txPowerMap =

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -22,7 +22,6 @@ import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.models.State;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -69,52 +69,37 @@ public class RandomTxPowerInitializerTest {
 			createModel(),
 			TEST_ZONE,
 			createDeviceDataManager(),
-			false,
 			new Random(0)
 		);
 
 		Map<String, Map<String, Integer>> txPowerMap =
 			optimizer.computeTxPowerMap();
 
-		// first generated random number for seed of 0
-		int txPower = 2;
-		for (String band : UCentralConstants.BANDS) {
-			assertEquals(txPower, txPowerMap.get(DEVICE_A).get(band));
-			assertEquals(txPower, txPowerMap.get(DEVICE_B).get(band));
-		}
+		assertEquals(
+			20,
+			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G)
+		);
+		assertEquals(
+			11,
+			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G)
+		);
+		assertEquals(
+			2,
+			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G)
+		);
+		assertEquals(
+			2,
+			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G)
+		);
 	}
 
 	@Test
 	@Order(2)
-	void testRandomTxPower() throws Exception {
-		TPC optimizer = new RandomTxPowerInitializer(
-			createModel(),
-			TEST_ZONE,
-			createDeviceDataManager()
-		);
-		Map<String, Map<String, Integer>> txPowerMap =
-			optimizer.computeTxPowerMap();
-		Set<Integer> txPowerSet = new TreeSet<>();
-		for (String serialNumber : txPowerMap.keySet()) {
-			txPowerSet.addAll(txPowerMap.get(serialNumber).values());
-		}
-		// One unique tx power for all devices and bands
-		assertEquals(1, txPowerSet.size());
-		for (int txPower : txPowerSet) {
-			assertTrue(
-				txPower >= TPC.MIN_TX_POWER && txPower <= TPC.MAX_TX_POWER
-			);
-		}
-	}
-
-	@Test
-	@Order(3)
-	void testRandomTxPowerPerAp() throws Exception {
+	void testRandomTxPowerInAvailableList() throws Exception {
 		TPC optimizer = new RandomTxPowerInitializer(
 			createModel(),
 			TEST_ZONE,
 			createDeviceDataManager(),
-			true,
 			new Random(0)
 		);
 		Map<String, Map<String, Integer>> txPowerMap =

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -77,19 +77,19 @@ public class RandomTxPowerInitializerTest {
 			optimizer.computeTxPowerMap();
 
 		assertEquals(
-			20,
+			28,
 			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G)
 		);
 		assertEquals(
-			11,
+			25,
 			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G)
 		);
 		assertEquals(
-			2,
+			20,
 			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G)
 		);
 		assertEquals(
-			2,
+			26,
 			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G)
 		);
 	}
@@ -123,20 +123,20 @@ public class RandomTxPowerInitializerTest {
 			optimizer.computeTxPowerMap();
 
 		assertEquals(
-			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G),
-			6
+			6,
+			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G)
 		);
 		assertEquals(
-			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G),
-			13
+			25,
+			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G)
 		);
 		assertEquals(
-			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G),
-			7
+			7,
+			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G)
 		);
 		assertEquals(
-			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G),
-			2
+			26,
+			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G)
 		);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -77,7 +77,7 @@ public class RandomTxPowerInitializerTest {
 		Map<String, Map<String, Integer>> txPowerMap =
 			optimizer.computeTxPowerMap();
 
-		int txPower = 20;
+		int txPower = 2;
 		for (String band : UCentralConstants.BANDS) {
 			assertEquals(txPower, txPowerMap.get(DEVICE_A).get(band));
 			assertEquals(txPower, txPowerMap.get(DEVICE_B).get(band));
@@ -118,7 +118,7 @@ public class RandomTxPowerInitializerTest {
 			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G)
 		);
 		assertEquals(
-			25,
+			13,
 			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G)
 		);
 		assertEquals(
@@ -126,7 +126,7 @@ public class RandomTxPowerInitializerTest {
 			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G)
 		);
 		assertEquals(
-			26,
+			2,
 			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G)
 		);
 	}

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -8,6 +8,8 @@
 
 package com.facebook.openwifirrm.optimizers.tpc;
 
+import com.facebook.openwifirrm.DeviceConfig;
+import com.facebook.openwifirrm.DeviceLayeredConfig;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -19,13 +21,13 @@ import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.models.State;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(OrderAnnotation.class)
 public class RandomTxPowerInitializerTest {
@@ -96,25 +98,46 @@ public class RandomTxPowerInitializerTest {
 	@Test
 	@Order(2)
 	void testRandomTxPowerInAvailableList() throws Exception {
+		DeviceDataManager deviceDataManager = createDeviceDataManager();
+		DeviceLayeredConfig deviceLayeredConfig = new DeviceLayeredConfig();
+		DeviceConfig deviceConfigA = new DeviceConfig();
+		deviceConfigA.allowedTxPowers = new TreeMap<>();
+		deviceConfigA.allowedTxPowers
+			.put(UCentralConstants.BAND_2G, Arrays.asList(11, 12, 13, 14, 15));
+		deviceConfigA.userTxPowers = new TreeMap<>();
+		deviceConfigA.userTxPowers.put(UCentralConstants.BAND_2G, 6);
+		deviceConfigA.allowedTxPowers
+			.put(UCentralConstants.BAND_5G, Arrays.asList(11, 12, 13, 14, 15));
+		deviceLayeredConfig.apConfig.put(DEVICE_A, deviceConfigA);
+		DeviceConfig deviceConfigB = new DeviceConfig();
+		deviceConfigB.userTxPowers = new TreeMap<>();
+		deviceConfigB.userTxPowers.put(UCentralConstants.BAND_2G, 7);
+		deviceLayeredConfig.apConfig.put(DEVICE_B, deviceConfigB);
+		deviceDataManager.setDeviceLayeredConfig(deviceLayeredConfig);
 		TPC optimizer = new RandomTxPowerInitializer(
 			createModel(),
 			TEST_ZONE,
-			createDeviceDataManager(),
+			deviceDataManager,
 			new Random(0)
 		);
 		Map<String, Map<String, Integer>> txPowerMap =
 			optimizer.computeTxPowerMap();
-		Set<Integer> txPowerSet = new TreeSet<>();
-		for (String serialNumber : txPowerMap.keySet()) {
-			txPowerSet.addAll(txPowerMap.get(serialNumber).values());
-		}
 
-		// different values per AP
-		assertTrue(txPowerSet.size() > 1);
-		for (int txPower : txPowerSet) {
-			assertTrue(
-				txPower >= TPC.MIN_TX_POWER && txPower <= TPC.MAX_TX_POWER
-			);
-		}
+		assertEquals(
+			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G),
+			6
+		);
+		assertEquals(
+			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G),
+			13
+		);
+		assertEquals(
+			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G),
+			7
+		);
+		assertEquals(
+			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G),
+			2
+		);
 	}
 }


### PR DESCRIPTION
The TPC algorithms did not use some user config fields from DeviceConfig (the device configuration):
- allowedTxPowers
- userTxPowers

This PR uses those field in TPC algorithms.

Here's the list of major updates and some questions:
1. For available channel lists, we have different default channel lists for different channel widths and bands, but for TPC we don't. I use all the tx powers in the range of [`MIN_TX_POWER`, `MAX_TX_POWER`] as default for now. Any idea to have more specific default? @pohanhf 
2. `RandomTxPowerIntializer`: since different AP and band may have different available tx powers now, `setDifferentTxPowerPerAp` is removed. If we want to keep this arg, we can pick random one from the common tx power choices.
3. `LocationBasedOptimalTPC`: leverage the new method when computing tx powers, but there's a little functionally different. `userTxPowers` is not considered before, but is used to update `txPowerChoices` in the new method.
4. `MeasurementBasedApClientTPC` and `MeasurementBasedApApTPC`: these two compute the tx power directly without any choices, so the new method is not used in these two optimizers. We can check if the computed tx power is valid, i.e. in the `txPowerChoices`, but that's not done in this PR.