### PR TITLE
Implement per-channel TPC

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +23,6 @@ import com.facebook.openwifirrm.DeviceConfig;
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.modules.ModelerUtils;
-import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.models.State;
 
 /**
@@ -153,17 +153,20 @@ public class LocationBasedOptimalTPC extends TPC {
 	/**
 	 * Calculate new tx powers for the given band.
 	 *
-	 * @param band       band
+	 * @param channel channel
+	 * @param serialNumbers The serial numbers of the APs with the channel
 	 * @param txPowerMap this map from serial number to band to new tx power
 	 *                   (dBm) must be passed in empty, and it is filled in by
 	 *                   this method with the new tx powers.
 	 */
-	private void buildTxPowerMapForBand(
-		String band,
+	private void buildTxPowerMapForChannel(
+		int channel,
+		List<String> serialNumbers,
 		Map<String, Map<String, Integer>> txPowerMap
 	) {
 		int numOfAPs = 0;
 		int boundary = 100;
+		String band = UCentralUtils.getBandFromChannel(channel);
 		Map<String, Integer> validAPs = new TreeMap<>();
 		List<Double> apLocX = new ArrayList<>();
 		List<Double> apLocY = new ArrayList<>();
@@ -171,9 +174,8 @@ public class LocationBasedOptimalTPC extends TPC {
 			new ArrayList<>(DEFAULT_TX_POWER_CHOICES);
 		// Filter out the invalid APs (e.g., no radio, no location data)
 		// Update txPowerChoices, boundary, apLocX, apLocY for the optimization
-		for (Map.Entry<String, State> e : model.latestState.entrySet()) {
-			String serialNumber = e.getKey();
-			State state = e.getValue();
+		for (String serialNumber : serialNumbers) {
+			State state = model.latestState.get(serialNumber);
 
 			// Ignore the device if its radio is not active
 			if (state.radios == null || state.radios.length == 0) {
@@ -280,8 +282,9 @@ public class LocationBasedOptimalTPC extends TPC {
 	@Override
 	public Map<String, Map<String, Integer>> computeTxPowerMap() {
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
-		for (String band : UCentralConstants.BANDS) {
-			buildTxPowerMapForBand(band, txPowerMap);
+		Map<Integer, List<String>> apsPerChannel = getApsPerChannel();
+		for (Map.Entry<Integer, List<String>> e : apsPerChannel.entrySet()) {
+			buildTxPowerMapForChannel(e.getKey(), e.getValue(), txPowerMap);
 		}
 		return txPowerMap;
 	}

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +22,7 @@ import com.facebook.openwifirrm.DeviceConfig;
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.modules.ModelerUtils;
+import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.models.State;
 
 /**

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
-import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.UCentralUtils.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.models.State;
@@ -326,21 +325,24 @@ public class MeasurementBasedApApTPC extends TPC {
 	/**
 	 * Calculate new tx powers for the given band.
 	 *
-	 * @param band       "2G" or "5G"
+	 * @param channel channel
+	 * @param serialNumbers The serial numbers of the APs with the channel
 	 * @param txPowerMap this map from serial number to band to new tx power (dBm)
 	 *                   must be passed in empty, and it is filled in by this method
 	 *                   with the new tx powers.
 	 */
-	protected void buildTxPowerMapForBand(
-		String band,
+	protected void buildTxPowerMapForChannel(
+		int channel,
+		List<String> serialNumbers,
 		Map<String, Map<String, Integer>> txPowerMap
 	) {
+		String band = UCentralUtils.getBandFromChannel(channel);
 		Set<String> managedBSSIDs = getManagedBSSIDs(model);
 		Map<String, List<Integer>> bssidToRssiValues =
 			buildRssiMap(managedBSSIDs, model.latestWifiScans, band);
 		logger.debug("Starting TPC for the {} band", band);
 		Map<String, JsonArray> allStatuses = model.latestDeviceStatus;
-		for (String serialNumber : allStatuses.keySet()) {
+		for (String serialNumber : serialNumbers) {
 			State state = model.latestState.get(serialNumber);
 			if (
 				state == null || state.radios == null ||
@@ -409,8 +411,9 @@ public class MeasurementBasedApApTPC extends TPC {
 	@Override
 	public Map<String, Map<String, Integer>> computeTxPowerMap() {
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
-		for (String band : UCentralConstants.BANDS) {
-			buildTxPowerMapForBand(band, txPowerMap);
+		Map<Integer, List<String>> apsPerChannel = getApsPerChannel();
+		for (Map.Entry<Integer, List<String>> e : apsPerChannel.entrySet()) {
+			buildTxPowerMapForChannel(e.getKey(), e.getValue(), txPowerMap);
 		}
 		return txPowerMap;
 	}

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -323,13 +323,12 @@ public class MeasurementBasedApApTPC extends TPC {
 	}
 
 	/**
-	 * Calculate new tx powers for the given band.
+	 * Calculate new tx powers for the given channel on the given APs .
 	 *
 	 * @param channel channel
-	 * @param serialNumbers The serial numbers of the APs with the channel
-	 * @param txPowerMap this map from serial number to band to new tx power (dBm)
-	 *                   must be passed in empty, and it is filled in by this method
-	 *                   with the new tx powers.
+	 * @param serialNumbers the serial numbers of the APs with the channel
+	 * @param txPowerMap this maps from serial number to band to new tx power (dBm)
+	 *                   and is updated by this method with the new tx powers.
 	 */
 	protected void buildTxPowerMapForChannel(
 		int channel,

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -194,7 +194,7 @@ public class LocationBasedOptimalTPCTest {
 		deviceDataManager2.setDeviceApConfig(deviceC, apCfgC2);
 
 		DataModel dataModel2 = new DataModel();
-		for (String device : Arrays.asList(deviceA, deviceB, deviceC)) {
+		for (String device : Arrays.asList(deviceA, deviceB)) {
 			dataModel2.latestDeviceStatus.put(
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
@@ -213,6 +213,22 @@ public class LocationBasedOptimalTPCTest {
 				)
 			);
 		}
+		dataModel2.latestDeviceStatus
+			.put(
+				deviceC,
+				TestUtils.createDeviceStatus(
+					Arrays.asList(UCentralConstants.BAND_5G)
+				)
+			);
+		dataModel2.latestState.put(
+			deviceC,
+			TestUtils.createState(
+				DEFAULT_CHANNEL_5G,
+				DEFAULT_CHANNEL_WIDTH,
+				DEFAULT_TX_POWER,
+				dummyBssid
+			)
+		);
 
 		Map<String, Map<String, Integer>> expected2 = new HashMap<>();
 		for (String band : UCentralConstants.BANDS) {
@@ -221,12 +237,12 @@ public class LocationBasedOptimalTPCTest {
 					band,
 					30
 				);
-			expected2.computeIfAbsent(deviceC, k -> new TreeMap<>())
-				.put(
-					band,
-					0
-				);
 		}
+		expected2.computeIfAbsent(deviceC, k -> new TreeMap<>())
+			.put(
+				UCentralConstants.BAND_5G,
+				0
+			);
 
 		LocationBasedOptimalTPC optimizer2 = new LocationBasedOptimalTPC(
 			dataModel2,

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -431,6 +431,16 @@ public class MeasurementBasedApApTPCTest {
 	void testComputeTxPowerMapMultiBand() {
 		// test both bands simultaneously with different setups on each band
 		DataModel dataModel = createModel();
+		dataModel.latestState.remove(DEVICE_B);
+		dataModel.latestState.put(
+			DEVICE_B,
+			TestUtils.createState(
+				1,
+				DEFAULT_CHANNEL_WIDTH,
+				MAX_TX_POWER,
+				BSSID_B
+			)
+		);
 		// make device C not operate in the 5G band instead of dual band
 		dataModel.latestDeviceStatus.put(
 			DEVICE_C,
@@ -495,9 +505,9 @@ public class MeasurementBasedApApTPCTest {
 			0,
 			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G)
 		);
-		assertEquals(
-			0,
-			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G)
+		// deivce B does not have 5G radio
+		assertFalse(
+			txPowerMap.get(DEVICE_B).containsKey(UCentralConstants.BAND_5G)
 		);
 		// device C is not in the 5G band
 		assertFalse(

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -19,7 +19,6 @@ import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
-import com.facebook.openwifirrm.ucentral.models.State;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -27,6 +26,7 @@ import java.util.Random;
 import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @TestMethodOrder(OrderAnnotation.class)
 public class RandomTxPowerInitializerTest {
@@ -37,10 +37,15 @@ public class RandomTxPowerInitializerTest {
 	private static final String DEVICE_A = "aaaaaaaaaaaa";
 	private static final String DEVICE_B = "bbbbbbbbbbbb";
 
-	/** Create an empty device state object. */
-	private static State createState() {
-		return new State();
-	}
+	// Default channel width
+	private static final int DEFAULT_CHANNEL_WIDTH = 20;
+
+	// Default tx power
+	private static final int DEFAULT_TX_POWER = 20;
+
+	// bssids
+	private static final String BSSID_A = "aa:aa:aa:aa:aa:aa";
+	private static final String BSSID_B = "bb:bb:bb:bb:bb:bb";
 
 	/**
 	 * Creates a manager with 2 devices.
@@ -58,8 +63,28 @@ public class RandomTxPowerInitializerTest {
 	 */
 	private static DataModel createModel() {
 		DataModel dataModel = new DataModel();
-		dataModel.latestState.put(DEVICE_A, createState());
-		dataModel.latestState.put(DEVICE_B, createState());
+		dataModel.latestState.put(
+			DEVICE_A,
+			TestUtils.createState(
+				36,
+				DEFAULT_CHANNEL_WIDTH,
+				DEFAULT_TX_POWER,
+				BSSID_A,
+				2,
+				DEFAULT_CHANNEL_WIDTH,
+				DEFAULT_TX_POWER,
+				BSSID_A
+			)
+		);
+		dataModel.latestState.put(
+			DEVICE_B,
+			TestUtils.createState(
+				2,
+				DEFAULT_CHANNEL_WIDTH,
+				DEFAULT_TX_POWER,
+				BSSID_B
+			)
+		);
 		return dataModel;
 	}
 
@@ -77,11 +102,20 @@ public class RandomTxPowerInitializerTest {
 		Map<String, Map<String, Integer>> txPowerMap =
 			optimizer.computeTxPowerMap();
 
-		int txPower = 2;
-		for (String band : UCentralConstants.BANDS) {
-			assertEquals(txPower, txPowerMap.get(DEVICE_A).get(band));
-			assertEquals(txPower, txPowerMap.get(DEVICE_B).get(band));
-		}
+		int expectedTxPower = 2;
+		assertEquals(
+			expectedTxPower,
+			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G)
+		);
+		assertEquals(
+			expectedTxPower,
+			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G)
+		);
+		assertEquals(
+			expectedTxPower,
+			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G)
+		);
+		assertNull(txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G));
 	}
 
 	@Test
@@ -118,16 +152,13 @@ public class RandomTxPowerInitializerTest {
 			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_2G)
 		);
 		assertEquals(
-			13,
+			15,
 			txPowerMap.get(DEVICE_A).get(UCentralConstants.BAND_5G)
 		);
 		assertEquals(
 			7,
 			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_2G)
 		);
-		assertEquals(
-			2,
-			txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G)
-		);
+		assertNull(txPowerMap.get(DEVICE_B).get(UCentralConstants.BAND_5G));
 	}
 }


### PR DESCRIPTION
Signed-off-by: Wuwei Cai <wuweicai@fb.com>

## Summary

Implement per-channel operation to all TPC optimizers. This PR also fixes the bug that TPC always run for both 2G and 5G bands for `LocationBasedOptimalTPC`, `MeasurementApApTPC` and `RandomTxPowerInitializer`.
1. New method `getApsPerChannel` in the base `TPC` class. 
2. For `LocationBasedOptimalTPC`, instead of running algorithm per band, only consider APs with the same channel.
3. For `MeasurementApApTPC` and `RandomTxPowerInitializer`, only runs TPC on bands with channels on each AP.


## Test Plan
1. Per-band TPC test ran as expected with real APs
2. Modified the unit tests and tested with the cases that not channels in both 2G and 5G bands are used for each device.