### PR TITLE
stats aggregation and reports to json format string

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/aggregators/Aggregator.java
+++ b/src/main/java/com/facebook/openwifirrm/aggregators/Aggregator.java
@@ -8,6 +8,8 @@
 
 package com.facebook.openwifirrm.aggregators;
 
+import java.util.List;
+
 /**
  * Aggregates added values into one "aggregate" measure.
  *
@@ -19,6 +21,9 @@ public interface Aggregator<T> {
 
 	/** Returns the aggregate measure of all added values. */
 	T getAggregate();
+
+	/** Returns a list of all added values. */
+	List<T> getList();
 
 	/** Returns the number of values that are aggregated. */
 	long getCount();

--- a/src/main/java/com/facebook/openwifirrm/aggregators/MeanAggregator.java
+++ b/src/main/java/com/facebook/openwifirrm/aggregators/MeanAggregator.java
@@ -8,16 +8,30 @@
 
 package com.facebook.openwifirrm.aggregators;
 
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * Tracks the mean of all added values. If no values are added, the mean is 0.
  */
 public class MeanAggregator implements Aggregator<Double> {
-
+	protected List<Double> valueList = new LinkedList<>();
 	protected double mean = 0;
 	protected long count = 0;
 
+	/** Constructor with no args */
+	public MeanAggregator() {}
+
+	/** Constructor with list of values*/
+	public MeanAggregator(List<Double> values) {
+		for (Double value : values) {
+			addValue(value);
+		}
+	}
+
 	@Override
 	public void addValue(Double value) {
+		valueList.add(value);
 		mean = ((double) count / (count + 1)) * mean + (value / (count + 1));
 		count++;
 	}
@@ -26,10 +40,14 @@ public class MeanAggregator implements Aggregator<Double> {
 	public Double getAggregate() { return mean; }
 
 	@Override
+	public List<Double> getList() { return valueList; }
+
+	@Override
 	public long getCount() { return count; }
 
 	@Override
 	public void reset() {
+		valueList = new LinkedList<>();
 		mean = 0;
 		count = 0;
 	}

--- a/src/test/java/com/facebook/openwifirrm/aggregators/MeanAggregatorTest.java
+++ b/src/test/java/com/facebook/openwifirrm/aggregators/MeanAggregatorTest.java
@@ -10,6 +10,9 @@ package com.facebook.openwifirrm.aggregators;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
+import java.util.LinkedList;
+
 import org.junit.jupiter.api.Test;
 
 public class MeanAggregatorTest {
@@ -22,35 +25,51 @@ public class MeanAggregatorTest {
 		// default mean is 0
 		assertEquals(0, agg.getAggregate(), eps);
 		assertEquals(0, agg.getCount());
+		assertEquals(new LinkedList<>(), agg.getList());
 
 		// adding 0 (the mean) does not change the mean
 		agg.addValue(0.0);
 		assertEquals(0, agg.getAggregate(), eps);
 		assertEquals(1, agg.getCount());
+		assertEquals(new LinkedList<>(Arrays.asList(0.0)), agg.getList());
 
 		// add an "int"
 		agg.addValue(1.0);
 		assertEquals(0.5, agg.getAggregate(), eps);
 		assertEquals(2, agg.getCount());
+		assertEquals(new LinkedList<>(Arrays.asList(0.0, 1.0)), agg.getList());
 
 		// add a double
 		agg.addValue(3.5);
 		assertEquals(1.5, agg.getAggregate(), eps);
 		assertEquals(3, agg.getCount());
+		assertEquals(
+			new LinkedList<>(Arrays.asList(0.0, 1.0, 3.5)),
+			agg.getList()
+		);
 
 		// add a negative number
 		agg.addValue(-0.5);
 		assertEquals(1.0, agg.getAggregate(), eps);
 		assertEquals(4, agg.getCount());
+		assertEquals(
+			new LinkedList<>(Arrays.asList(0.0, 1.0, 3.5, -0.5)),
+			agg.getList()
+		);
 
 		// adding the mean does not change the mean
 		agg.addValue(1.0);
 		assertEquals(1.0, agg.getAggregate(), eps);
 		assertEquals(5, agg.getCount());
+		assertEquals(
+			new LinkedList<>(Arrays.asList(0.0, 1.0, 3.5, -0.5, 1.0)),
+			agg.getList()
+		);
 
 		// test reset
 		agg.reset();
 		assertEquals(0, agg.getAggregate(), eps);
 		assertEquals(0, agg.getCount());
+		assertEquals(new LinkedList<>(), agg.getList());
 	}
 }


### PR DESCRIPTION
Signed-off-by: zhiqiand <zhiqian@fb.com>
### Summary
This PR Aggregates the stats info per AP so we can have a clear picture of the current system. 
- Aggregation condition: 
The following condition is true then two stats results need to be aggregated
channel, channel width, and tx_power under "radios" match
- Aggregation rules:
The current data structure is AP has many clients under “associations”. 
For a client with the same mac address, average/list all the stats over time.

### Implementation 
- The mainly functional method is `ModelerUtils.getAggregatedStates`, which group States by given `aggregatedFields`(RSSI, MCS...) and `aggregatedKeys`(channel, channel width, tx_power...). Only States that are non-obsolete are to be aggregated. The aggregation map is a large nested map. The following picture shows the what the structure is.

![IMG_7ED79495C2BE-1](https://user-images.githubusercontent.com/60716841/189301641-bfd12167-e675-42f5-9ef7-25dfcb102703.jpeg)

- `ModelerUtils.aggregatedStatesToJson` serializes the aggregated map to a Json String. There are two formats to represent the values : list of values(a list of all the non-obsolete stats) or single value(take mean/median... of all the stats). A custom serializer is used to switch over between the two formats.
- Add `getList` in `Aggregator`, which supports the json serializer to give a list view.

### Questions
- A new field `latestStates` which is a list of most recent X States (X = 10...) is added, whereas `latestState` is the most recent State. Not sure if [PR#61](https://github.com/Telecominfraproject/wlan-cloud-rrm/pull/61) get affected.
- Please let me know if the keys in the nested aggregation map are redundant or need to be flattened.
- Not confident with the wording in javadoc. Please check the method description carefully.