### PR TITLE
Add a simple k6 script for loadtesting/benching

### DIFF
--- a/scripts/k6/simple.js
+++ b/scripts/k6/simple.js
@@ -1,0 +1,24 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+
+const BASE_URL = 'http://localhost:16789/api/v1';
+
+export default function () {
+	const endpoints = [
+		'algorithms',
+		'provider',
+		'system',
+		'getToplogy',
+		'currentModel',
+	];
+	const requests = endpoints.map(endpoint => {
+		return {
+			method: 'GET',
+			url: `${BASE_URL}/${endpoint}`,
+		};
+	});
+
+	let responses = http.batch(requests);
+	sleep(0.1);
+}


### PR DESCRIPTION
Add a directory for [k6](https://github.com/grafana/k6) scripts. K6 is a loadtesting tool which gets configured by javascript and is very flexible AFAIK. I thought it'd be worth to have a base set of scripts for getting performance results. This adds a simple test that just calls a bunch of GET requests.

Maybe in the future we can also add a check for PRs or something - but for now occasional ad-hoc runs are still useful.

```
$ k6 run scripts/k6/simple.js --duration 10s

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: scripts/k6/simple.js
     output: -

  scenarios: (100.00%) 1 scenario, 1 max VUs, 40s max duration (incl. graceful stop):
           * default: 1 looping VUs for 10s (gracefulStop: 30s)


running (10.1s), 0/1 VUs, 81 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  10s

     data_received..................: 409 MB 41 MB/s
     data_sent......................: 39 kB  3.9 kB/s
     http_req_blocked...............: avg=27.49µs  min=0s       med=2µs      max=1.68ms  p(90)=31µs     p(95)=44.59µs
     http_req_connecting............: avg=11.68µs  min=0s       med=0s       max=989µs   p(90)=0s       p(95)=0s
     http_req_duration..............: avg=5.17ms   min=262µs    med=592µs    max=38.07ms p(90)=22.95ms  p(95)=24.05ms
       { expected_response:true }...: avg=8.23ms   min=344µs    med=639µs    max=38.07ms p(90)=23.78ms  p(95)=25.46ms
     http_req_failed................: 40.00% ✓ 162       ✗ 243
     http_req_receiving.............: avg=769.92µs min=5µs      med=23µs     max=8.5ms   p(90)=3.36ms   p(95)=4.17ms
     http_req_sending...............: avg=9.55µs   min=3µs      med=7µs      max=69µs    p(90)=14.6µs   p(95)=26µs
     http_req_tls_handshaking.......: avg=0s       min=0s       med=0s       max=0s      p(90)=0s       p(95)=0s
     http_req_waiting...............: avg=4.39ms   min=228µs    med=563µs    max=29.55ms p(90)=19.29ms  p(95)=20.08ms
     http_reqs......................: 405    40.114166/s
     iteration_duration.............: avg=124.61ms min=121.88ms med=123.99ms max=142.2ms p(90)=127.01ms p(95)=128.16ms
     iterations.....................: 81     8.022833/s
     vus............................: 1      min=1       max=1
     vus_max........................: 1      min=1       max=1
```