### PR TITLE
Measurement based ap ap tpc test fix

### DIFF
--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -141,6 +141,26 @@ public class TestUtils {
 	}
 
 	/**
+	 * Create an array with one radio info entry with the given tx power and
+	 * channel.
+	 */
+	public static JsonArray createDeviceStatusSingleBand(
+		int channel,
+		int txPower2G
+	) {
+		JsonArray jsonList = new JsonArray();
+		jsonList.add(
+			createDeviceStatusRadioObject(
+				UCentralUtils.getBandFromChannel(channel),
+				channel,
+				DEFAULT_CHANNEL_WIDTH,
+				txPower2G
+			)
+		);
+		return jsonList;
+	}
+
+	/**
 	 * Create an array with two radio info entries (2G and 5G), with the given
 	 * tx powers and channels.
 	 */


### PR DESCRIPTION
- Replace `createModel` into `createModelSingleBand` and `createModelDualBand`. Some of the tests earlier were using `createModel` (which did dual band) when they really only should have been single band (though this didn't affect the test).
- "synced" state and status (e.g., if an AP has a 5G radio in state, it should have it in status, and vice versa)
- instead of using "device B" to test what happens when an AP does not have a 5G radio, use device C. This is done to make it consistent with the existing wifiscans which show device B in the 5G band