### PR TITLE
Make AP-AP TPC algorithm use tx power from statistics and fix TPC application to correct band

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -97,7 +97,7 @@ public class Modeler implements Runnable {
 		public Map<String, State> latestState = new ConcurrentHashMap<>();
 
 		/** List of radio info per device. */
-		public Map<String, JsonArray> latestDeviceStatus =
+		public Map<String, JsonArray> latestDeviceStatusRadios =
 			new ConcurrentHashMap<>();
 
 		/** List of capabilities per device. */
@@ -379,7 +379,7 @@ public class Modeler implements Runnable {
 		// Get old vs new radios info and store the new radios info
 		JsonArray newRadioList = config.getRadioConfigList();
 		Set<String> newRadioBandsSet = config.getRadioBandsSet(newRadioList);
-		JsonArray oldRadioList = dataModel.latestDeviceStatus
+		JsonArray oldRadioList = dataModel.latestDeviceStatusRadios
 			.put(serialNumber, newRadioList);
 		Set<String> oldRadioBandsSet = config.getRadioBandsSet(oldRadioList);
 
@@ -429,7 +429,7 @@ public class Modeler implements Runnable {
 			logger.debug("Removed some state entries from data model");
 		}
 		if (
-			dataModel.latestDeviceStatus.entrySet()
+			dataModel.latestDeviceStatusRadios.entrySet()
 				.removeIf(e -> !isRRMEnabled(e.getKey()))
 		) {
 			logger.debug("Removed some status entries from data model");

--- a/src/main/java/com/facebook/openwifirrm/mysql/DatabaseManager.java
+++ b/src/main/java/com/facebook/openwifirrm/mysql/DatabaseManager.java
@@ -454,9 +454,10 @@ public class DatabaseManager {
 			.map(o -> gson.fromJson(o, State.Interface.class))
 			.collect(Collectors.toList())
 			.toArray(new State.Interface[0]);
-		state.radios = new JsonObject[radios.lastKey() + 1];
+		state.radios = new State.Radio[radios.lastKey() + 1];
 		for (Map.Entry<Integer, JsonObject> entry : radios.entrySet()) {
-			state.radios[entry.getKey()] = entry.getValue();
+			State.Radio radio = state.new Radio();
+			state.radios[entry.getKey()] = radio;
 		}
 		return state;
 	}

--- a/src/main/java/com/facebook/openwifirrm/mysql/DatabaseManager.java
+++ b/src/main/java/com/facebook/openwifirrm/mysql/DatabaseManager.java
@@ -456,7 +456,7 @@ public class DatabaseManager {
 			.toArray(new State.Interface[0]);
 		state.radios = new State.Radio[radios.lastKey() + 1];
 		for (Map.Entry<Integer, JsonObject> entry : radios.entrySet()) {
-			State.Radio radio = state.new Radio();
+			State.Radio radio = new State.Radio();
 			state.radios[entry.getKey()] = radio;
 		}
 		return state;

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
@@ -378,8 +378,13 @@ public abstract class ChannelOptimizer {
 			int tempChannel = state.radios[radioIndex].channel;
 			if (UCentralUtils.isChannelInBand(tempChannel, band)) {
 				currentChannel = tempChannel;
+				// treat as two separate 80MHz channel and only assign to one
+				// TODO: support 80p80 properly
 				Integer parsedChannelWidth = UCentralUtils
-					.parseChannelWidth(state.radios[radioIndex].channel_width);
+					.parseChannelWidth(
+						state.radios[radioIndex].channel_width,
+						true
+					);
 				if (parsedChannelWidth != null) {
 					currentChannelWidth = parsedChannelWidth;
 					break;

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
@@ -375,14 +375,16 @@ public abstract class ChannelOptimizer {
 			radioIndex < state.radios.length;
 			radioIndex++
 		) {
-			int tempChannel = state.radios[radioIndex]
-				.get("channel")
-				.getAsInt();
+			int tempChannel = state.radios[radioIndex].channel;
 			if (UCentralUtils.isChannelInBand(tempChannel, band)) {
 				currentChannel = tempChannel;
-				currentChannelWidth = state.radios[radioIndex]
-					.get("channel_width")
-					.getAsInt();
+				try {
+					currentChannelWidth = Integer
+						.parseInt(state.radios[radioIndex].channel_width);
+				} catch (NumberFormatException e) {
+					logger.error("Invalid channel width", e);
+					continue;
+				}
 				break;
 			}
 		}

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
@@ -378,14 +378,18 @@ public abstract class ChannelOptimizer {
 			int tempChannel = state.radios[radioIndex].channel;
 			if (UCentralUtils.isChannelInBand(tempChannel, band)) {
 				currentChannel = tempChannel;
-				try {
-					currentChannelWidth = Integer
-						.parseInt(state.radios[radioIndex].channel_width);
-				} catch (NumberFormatException e) {
-					logger.error("Invalid channel width", e);
-					continue;
+				Integer parsedChannelWidth = UCentralUtils
+					.parseChannelWidth(state.radios[radioIndex].channel_width);
+				if (parsedChannelWidth != null) {
+					currentChannelWidth = parsedChannelWidth;
+					break;
 				}
-				break;
+
+				logger.error(
+					"Invalid channel width {}",
+					state.radios[radioIndex].channel_width
+				);
+				continue;
 			}
 		}
 		return new int[] { currentChannel, currentChannelWidth };

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
@@ -156,7 +156,7 @@ public abstract class ChannelOptimizer {
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber));
 		this.model.latestState.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber));
-		this.model.latestDeviceStatus.keySet()
+		this.model.latestDeviceStatusRadios.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber));
 		this.model.latestDeviceCapabilities.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber));

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizer.java
@@ -331,11 +331,11 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 	public Map<String, Map<String, Integer>> computeChannelMap() {
 		Map<String, Map<String, Integer>> channelMap = new TreeMap<>();
 		Map<String, List<String>> bandsMap = UCentralUtils
-			.getBandsMap(model.latestDeviceStatus);
+			.getBandsMap(model.latestDeviceStatusRadios);
 
 		Map<String, Map<String, List<Integer>>> deviceAvailableChannels =
 			UCentralUtils.getDeviceAvailableChannels(
-				model.latestDeviceStatus,
+				model.latestDeviceStatusRadios,
 				model.latestDeviceCapabilities,
 				AVAILABLE_CHANNELS_BAND
 			);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -119,11 +119,11 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 	public Map<String, Map<String, Integer>> computeChannelMap() {
 		Map<String, Map<String, Integer>> channelMap = new TreeMap<>();
 		Map<String, List<String>> bandsMap =
-			UCentralUtils.getBandsMap(model.latestDeviceStatus);
+			UCentralUtils.getBandsMap(model.latestDeviceStatusRadios);
 
 		Map<String, Map<String, List<Integer>>> deviceAvailableChannels =
 			UCentralUtils.getDeviceAvailableChannels(
-				model.latestDeviceStatus,
+				model.latestDeviceStatusRadios,
 				model.latestDeviceCapabilities,
 				AVAILABLE_CHANNELS_BAND
 			);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -350,20 +350,14 @@ public class MeasurementBasedApApTPC extends TPC {
 				}
 
 				for (State.Interface.SSID ssid : iface.ssids) {
-					String radioRef = ssid.radio.get("$ref").getAsString();
-					int idx = -1;
-					try {
-						idx = Integer.parseInt(
-							radioRef,
-							radioRef.lastIndexOf("/") + 1,
-							radioRef.length(),
-							10
-						);
-					} catch (NumberFormatException e) {
+					Integer idx = UCentralUtils.parseReferenceIndex(
+						ssid.radio.get("$ref").getAsString()
+					);
+					if (idx == null) {
 						logger.error(
-							"Unable to get radio for {}, invalid radio ref",
-							e,
-							serialNumber
+							"Unable to get radio for {}, invalid radio ref {}",
+							serialNumber,
+							ssid.radio.get("$ref").getAsString()
 						);
 						continue;
 					}

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -310,7 +310,6 @@ public class MeasurementBasedApApTPC extends TPC {
 		Map<String, List<Integer>> bssidToRssiValues =
 			buildRssiMap(managedBSSIDs, model.latestWifiScans, band);
 		logger.debug("Starting TPC for the {} band", band);
-		Map<String, State> allStates = model.latestState;
 		for (String serialNumber : serialNumbers) {
 			State state = model.latestState.get(serialNumber);
 			if (
@@ -340,11 +339,9 @@ public class MeasurementBasedApApTPC extends TPC {
 				);
 				continue;
 			}
-			State deviceState =
-				allStates.get(serialNumber);
 
 			// An AP can have multiple interfaces, optimize for all of them
-			for (State.Interface iface : deviceState.interfaces) {
+			for (State.Interface iface : state.interfaces) {
 				if (iface.ssids == null) {
 					continue;
 				}
@@ -361,7 +358,7 @@ public class MeasurementBasedApApTPC extends TPC {
 						);
 						continue;
 					}
-					State.Radio radio = deviceState.radios[idx];
+					State.Radio radio = state.radios[idx];
 
 					// this specific SSID is not on the band of interest
 					if (

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -182,16 +182,16 @@ public class MeasurementBasedApApTPC extends TPC {
 	 * Get the current band radio tx power (the first one found) for an AP using
 	 * the latest device status.
 	 *
-	 * @param latestDeviceStatus JsonArray containing radio config for the AP
+	 * @param latestDeviceStatusRadios JsonArray containing radio config for the AP
 	 * @param band band (e.g., "2G")
 	 * @return an Optional containing the tx power if one exists, or else an
 	 *         empty Optional
 	 */
 	protected static Optional<Integer> getCurrentTxPower(
-		JsonArray latestDeviceStatus,
+		JsonArray latestDeviceStatusRadios,
 		String band
 	) {
-		for (JsonElement e : latestDeviceStatus) {
+		for (JsonElement e : latestDeviceStatusRadios) {
 			if (!e.isJsonObject()) {
 				continue;
 			}
@@ -340,7 +340,7 @@ public class MeasurementBasedApApTPC extends TPC {
 		Map<String, List<Integer>> bssidToRssiValues =
 			buildRssiMap(managedBSSIDs, model.latestWifiScans, band);
 		logger.debug("Starting TPC for the {} band", band);
-		Map<String, JsonArray> allStatuses = model.latestDeviceStatus;
+		Map<String, JsonArray> allStatuses = model.latestDeviceStatusRadios;
 		for (String serialNumber : serialNumbers) {
 			State state = model.latestState.get(serialNumber);
 			if (

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -41,6 +41,9 @@ public class MeasurementBasedApClientTPC extends TPC {
 	/** Default tx power. */
 	public static final int DEFAULT_TX_POWER = 10;
 
+	/** Default channel width in HMz */
+	public static final int DEFAULT_CHANNEL_WIDTH = 20;
+
 	/** Mapping of MCS index to required SNR (dB) in 802.11ac. */
 	private static final List<Double> MCS_TO_SNR = Collections.unmodifiableList(
 		Arrays.asList(
@@ -158,13 +161,10 @@ public class MeasurementBasedApClientTPC extends TPC {
 	) {
 		// Find current tx power and bandwidth
 		int currentTxPower = radio.tx_power;
-		int channelWidth = 20;
-		try {
-			channelWidth = Integer.parseInt(radio.channel_width);
-		} catch (NumberFormatException e) {
-			logger.error("Could not parse channel width in state radio", e);
-		}
-		channelWidth *= 1_000_000 /* convert MHz to Hz */;
+		Integer channelWidthMHz =
+			UCentralUtils.parseChannelWidth(radio.channel_width);
+		int channelWidth = (channelWidthMHz != null
+			? channelWidthMHz : DEFAULT_CHANNEL_WIDTH) * 1_000_000; // convert MHz to HZ
 		Collections.sort(txPowerChoices);
 		int minTxPower = txPowerChoices.get(0);
 		int maxTxPower = txPowerChoices.get(txPowerChoices.size() - 1);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -161,8 +161,9 @@ public class MeasurementBasedApClientTPC extends TPC {
 	) {
 		// Find current tx power and bandwidth
 		int currentTxPower = radio.tx_power;
+		// treat as one 160MHz channel vs two 80MHz channels
 		Integer channelWidthMHz =
-			UCentralUtils.parseChannelWidth(radio.channel_width);
+			UCentralUtils.parseChannelWidth(radio.channel_width, false);
 		int channelWidth = (channelWidthMHz != null
 			? channelWidthMHz : DEFAULT_CHANNEL_WIDTH) * 1_000_000; // convert MHz to HZ
 		Collections.sort(txPowerChoices);

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
@@ -75,7 +75,7 @@ public abstract class TPC {
 		this.model.latestState.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber)
 			);
-		this.model.latestDeviceStatus.keySet()
+		this.model.latestDeviceStatusRadios.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber)
 			);
 		this.model.latestDeviceCapabilities.keySet()

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
@@ -24,7 +24,6 @@ import com.facebook.openwifirrm.DeviceDataManager;
 import com.facebook.openwifirrm.modules.ConfigManager;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.ucentral.models.State;
-import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -203,12 +202,9 @@ public abstract class TPC {
 				continue;
 			}
 
-			for (JsonObject radio : state.radios) {
-				Integer currentChannel =
-					radio.has("channel") && !radio.get("channel").isJsonNull()
-						? radio.get("channel").getAsInt()
-						: null;
-				if (currentChannel == null) {
+			for (State.Radio radio : state.radios) {
+				Integer currentChannel = radio.channel;
+				if (currentChannel == 0) {
 					continue;
 				}
 				apsPerChannel

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -474,9 +474,8 @@ public class UCentralUtils {
 	 * index is used in the correct fields. If there's an error parsing, it will
 	 * return null.
 	 *
-	 * @param reference The reference string, keyed under `$ref`
+	 * @param reference The reference string, keyed under "$ref"
 	 * @return the index of the reference or null if an error occurred.
-	 * @
 	 */
 	public static Integer parseReferenceIndex(String reference) {
 		try {

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -443,12 +443,23 @@ public class UCentralUtils {
 
 	/**
 	 * Tries to parse channel width, if it encounters an error it will return null.
-	 * Note: Currently does not handle 80p80.
+	 * It can handle 80p80 in two ways. First it can just treat it as 160. Second,
+	 * it can just apply to the first 80 channel and ignore the second. This is
+	 * controlled by treatSeparate. For purposes of TPC algorithms, we treat it as
+	 * 160 while channel assignment treats it as separate.
 	 *
 	 * @param channelWidthStr the channel width
+	 * @param treatSeparate treats each band separately
 	 * @return channel width in MHz
 	 */
-	public static Integer parseChannelWidth(String channelWidthStr) {
+	public static Integer parseChannelWidth(
+		String channelWidthStr,
+		boolean treatSeparate
+	) {
+		// 80p80 is the only case where it can't be parsed into an integer
+		if (channelWidthStr.equals("80p80")) {
+			return treatSeparate ? 80 : 160;
+		}
 		try {
 			return Integer.parseInt(channelWidthStr);
 		} catch (NumberFormatException e) {

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -445,8 +445,7 @@ public class UCentralUtils {
 	 * Tries to parse channel width, if it encounters an error it will return null.
 	 * It can handle 80p80 in two ways. First it can just treat it as 160. Second,
 	 * it can just apply to the first 80 channel and ignore the second. This is
-	 * controlled by treatSeparate. For purposes of TPC algorithms, we treat it as
-	 * 160 while channel assignment treats it as separate.
+	 * controlled by treatSeparate.
 	 *
 	 * @param channelWidthStr the channel width
 	 * @param treatSeparate treats each band separately

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -440,4 +440,43 @@ public class UCentralUtils {
 		}
 		return null;
 	}
+
+	/**
+	 * Tries to parse channel width, if it encounters an error it will return null.
+	 * Note: Currently does not handle 80p80.
+	 *
+	 * @param channelWidthStr the channel width
+	 * @return channel width in MHz
+	 */
+	public static Integer parseChannelWidth(String channelWidthStr) {
+		try {
+			return Integer.parseInt(channelWidthStr);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Tries to parse the index from the reference string in the JSON returned from
+	 * other services. Note that this only returns the index, the caller is
+	 * responsible for making sure that the correct field is passed in and the
+	 * index is used in the correct fields. If there's an error parsing, it will
+	 * return null.
+	 *
+	 * @param reference The reference string, keyed under `$ref`
+	 * @return the index of the reference or null if an error occurred.
+	 * @
+	 */
+	public static Integer parseReferenceIndex(String reference) {
+		try {
+			return Integer.parseInt(
+				reference,
+				reference.lastIndexOf("/") + 1,
+				reference.length(),
+				10
+			);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
 }

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/State.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/State.java
@@ -112,8 +112,21 @@ public class State {
 
 	public Unit unit;
 
+	public class Radio {
+		public long active_ms;
+		public long busy_ms;
+		public int channel;
+		public String channel_width;
+		public long noise;
+		public String phy;
+		public long receive_ms;
+		public long transmit_ms;
+		public int tx_power;
+	}
+
+	public Radio[] radios;
+
 	// TODO
-	public JsonObject[] radios;
 	@SerializedName("link-state") public JsonObject linkState;
 	public JsonObject gps;
 	public JsonObject poe;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/State.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/State.java
@@ -112,7 +112,7 @@ public class State {
 
 	public Unit unit;
 
-	public class Radio {
+	public static class Radio {
 		public long active_ms;
 		public long busy_ms;
 		public int channel;

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -397,7 +397,7 @@ public class TestUtils {
 	}
 
 	/** Create an element of {@link State#radios}. */
-	private static JsonObject createStateRadio() {
+	private static State.Radio createStateRadio() {
 		// @formatter:off
 		return gson.fromJson(
 			String.format(
@@ -411,7 +411,7 @@ public class TestUtils {
 				"      \"transmit_ms\": 4893\n" +
 				"    }\n"
 			),
-			JsonObject.class
+			State.Radio.class
 		);
 		// @formatter:on
 	}
@@ -477,12 +477,12 @@ public class TestUtils {
 			state.interfaces[index] = createUpStateInterface(index);
 		}
 		state.interfaces[numRadios] = createDownStateInterface(numRadios);
-		state.radios = new JsonObject[numRadios];
+		state.radios = new State.Radio[numRadios];
 		for (int i = 0; i < numRadios; i++) {
 			state.radios[i] = createStateRadio();
-			state.radios[i].addProperty("channel", channels[i]);
-			state.radios[i].addProperty("channel_width", channelWidths[i]);
-			state.radios[i].addProperty("tx_power", txPowers[i]);
+			state.radios[i].channel = channels[i];
+			state.radios[i].channel_width = Integer.toString(channelWidths[i]);
+			state.radios[i].tx_power = txPowers[i];
 			state.interfaces[i].ssids[0].bssid = bssids[i];
 			state.interfaces[i].ssids[0].associations =
 				new State.Interface.SSID.Association[clientRssis[i].length];

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -398,22 +398,14 @@ public class TestUtils {
 
 	/** Create an element of {@link State#radios}. */
 	private static State.Radio createStateRadio() {
-		// @formatter:off
-		return gson.fromJson(
-			String.format(
-				"    {\n" +
-				"      \"active_ms\": 564328,\n" +
-				"      \"busy_ms\": 36998,\n" +
-				"      \"noise\": 4294967193,\n" +
-				"      \"phy\": \"platform/soc/c000000.wifi\",\n" +
-				"      \"receive_ms\": 28,\n" +
-				"      \"temperature\": 45,\n" +
-				"      \"transmit_ms\": 4893\n" +
-				"    }\n"
-			),
-			State.Radio.class
-		);
-		// @formatter:on
+		State.Radio radio = new State.Radio();
+		radio.active_ms = 564328;
+		radio.busy_ms = 36998;
+		radio.noise = 4294967193L;
+		radio.phy = "platform/soc/c000000.wifi";
+		radio.receive_ms = 28;
+		radio.transmit_ms = 4893;
+		return radio;
 	}
 
 	/** Create a {@code State.Unit}. */

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizerTest.java
@@ -51,7 +51,7 @@ public class LeastUsedChannelOptimizerTest {
 
 		// A -> No APs on current channel, so stay on it (48)
 		int aExpectedChannel = 48;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -73,7 +73,7 @@ public class LeastUsedChannelOptimizerTest {
 		LinkedList<Integer> channelsB = new LinkedList<>();
 		channelsB.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		int bExpectedChannel = channelsB.removeLast();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
@@ -94,7 +94,7 @@ public class LeastUsedChannelOptimizerTest {
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		int cExpectedChannel = channelsC.removeFirst();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
@@ -138,7 +138,7 @@ public class LeastUsedChannelOptimizerTest {
 
 		// A -> No APs on current channel, so stay on it (1)
 		int aExpectedChannel = 1;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -160,7 +160,7 @@ public class LeastUsedChannelOptimizerTest {
 		LinkedList<Integer> channelsB = new LinkedList<>();
 		channelsB.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		int bExpectedChannel = channelsB.removeLast();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 6)
 		);
@@ -178,7 +178,7 @@ public class LeastUsedChannelOptimizerTest {
 
 		// C -> Assigned to only free prioritized channel (1)
 		int cExpectedChannel = 1;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 6)
 		);
@@ -231,7 +231,7 @@ public class LeastUsedChannelOptimizerTest {
 
 		// A, B, C should just be assigned to the same userChannel
 		int aExpectedChannel = 48;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -252,7 +252,7 @@ public class LeastUsedChannelOptimizerTest {
 		LinkedList<Integer> channelsB = new LinkedList<>();
 		channelsB.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsB.removeLast();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
@@ -272,7 +272,7 @@ public class LeastUsedChannelOptimizerTest {
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsC.removeFirst();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
@@ -324,7 +324,7 @@ public class LeastUsedChannelOptimizerTest {
 		// A -> No APs on current channel and the current channel is in allowedChannels,
 		// so stay on it (48)
 		int aExpectedChannel = 48;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -347,7 +347,7 @@ public class LeastUsedChannelOptimizerTest {
 		LinkedList<Integer> channelsB = new LinkedList<>();
 		channelsB.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsB.removeLast();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
@@ -368,7 +368,7 @@ public class LeastUsedChannelOptimizerTest {
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsC.removeFirst();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
@@ -414,7 +414,7 @@ public class LeastUsedChannelOptimizerTest {
 
 		// A -> No APs on current channel, so stay on it (48)
 		int aExpectedChannel = 157;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -438,7 +438,7 @@ public class LeastUsedChannelOptimizerTest {
 		channelsB.addAll(Arrays.asList(40, 48, 153, 161));
 		channelsB.addAll(Arrays.asList(40, 48, 153, 161));
 		int bExpectedChannel = channelsB.removeLast() - 4; // upper extension
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
@@ -459,7 +459,7 @@ public class LeastUsedChannelOptimizerTest {
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		int cExpectedChannel = channelsC.removeFirst();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
@@ -479,7 +479,7 @@ public class LeastUsedChannelOptimizerTest {
 		LinkedList<Integer> channelsD = new LinkedList<>();
 		channelsD.addAll(Arrays.asList(36, 44, 149, 157));
 		int dExpectedChannel = channelsD.removeLast();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceD,
 			TestUtils.createDeviceStatus(band, 40)
 		);
@@ -532,7 +532,7 @@ public class LeastUsedChannelOptimizerTest {
 
 		// A -> No APs on current channel, so stay on it (36)
 		int aExpectedChannel = 36;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -554,7 +554,7 @@ public class LeastUsedChannelOptimizerTest {
 		LinkedList<Integer> channelsB = new LinkedList<>();
 		channelsB.addAll(Arrays.asList(40, 48, 149));
 		int bExpectedChannel = channelsB.removeLast();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 36)
 		);
@@ -575,7 +575,7 @@ public class LeastUsedChannelOptimizerTest {
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsC.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		int cExpectedChannel = channelsC.removeFirst();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
@@ -597,7 +597,7 @@ public class LeastUsedChannelOptimizerTest {
 		channelsD.addAll(Arrays.asList(40, 48, 153, 161));
 		channelsD.addAll(Arrays.asList(40, 48, 153, 161));
 		int dExpectedChannel = channelsD.removeLast() - 12;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceD,
 			TestUtils.createDeviceStatus(band, 36)
 		);
@@ -622,7 +622,7 @@ public class LeastUsedChannelOptimizerTest {
 			.put(UCentralConstants.BAND_5G, Arrays.asList(48, 165));
 		deviceDataManager.setDeviceApConfig(deviceE, apConfig);
 		int eExpectedChannel = 36;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceE,
 			TestUtils.createDeviceStatus(band, eExpectedChannel)
 		);
@@ -668,7 +668,7 @@ public class LeastUsedChannelOptimizerTest {
 
 		// A -> No APs on current channel, so stay on it (48)
 		int aExpectedChannel = 48;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -689,7 +689,7 @@ public class LeastUsedChannelOptimizerTest {
 		// B -> Same setting as A, but the scan results are bandwidth aware
 		// Assign to only free channel (165)
 		int bExpectedChannel = 165;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 48)
 		);
@@ -721,7 +721,7 @@ public class LeastUsedChannelOptimizerTest {
 		channelsC1.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		channelsC2.addAll(Arrays.asList(36, 157, 165));
 		int cExpectedChannel = channelsC1.removeFirst();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
@@ -54,11 +54,11 @@ public class RandomChannelInitializerTest {
 			deviceB,
 			TestUtils.createState(11, channelWidth, deviceBBssid)
 		);
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, 7)
 		);
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 8)
 		);
@@ -99,11 +99,11 @@ public class RandomChannelInitializerTest {
 			deviceB,
 			TestUtils.createState(11, channelWidth, deviceBBssid)
 		);
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, 7)
 		);
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 8)
 		);

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/UnmanagedApAwareChannelOptimizerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/UnmanagedApAwareChannelOptimizerTest.java
@@ -52,7 +52,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 
 		// A -> No APs on current channel, so stay on it (48)
 		int aExpectedChannel = 48;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -76,7 +76,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		LinkedList<Integer> channelsB = new LinkedList<>();
 		channelsB.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		int bExpectedChannel = channelsB.removeLast();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
@@ -110,7 +110,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 			)
 		);
 		int cExpectedChannel = 48;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
@@ -156,7 +156,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 
 		// A -> No APs on current channel, so stay on it (1)
 		int aExpectedChannel = 1;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
@@ -178,7 +178,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		LinkedList<Integer> channelsB = new LinkedList<>();
 		channelsB.addAll(ChannelOptimizer.AVAILABLE_CHANNELS_BAND.get(band));
 		int bExpectedChannel = channelsB.removeLast();
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 6)
 		);
@@ -196,7 +196,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 
 		// C -> Assigned to only free prioritized channel (1)
 		int cExpectedChannel = 1;
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			deviceC,
 			TestUtils.createDeviceStatus(band, 6)
 		);

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -128,7 +128,7 @@ public class LocationBasedOptimalTPCTest {
 
 		DataModel dataModel = new DataModel();
 		for (String device : Arrays.asList(deviceA, deviceB, deviceC)) {
-			dataModel.latestDeviceStatus.put(
+			dataModel.latestDeviceStatusRadios.put(
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
@@ -195,7 +195,7 @@ public class LocationBasedOptimalTPCTest {
 
 		DataModel dataModel2 = new DataModel();
 		for (String device : Arrays.asList(deviceA, deviceB)) {
-			dataModel2.latestDeviceStatus.put(
+			dataModel2.latestDeviceStatusRadios.put(
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
@@ -213,7 +213,7 @@ public class LocationBasedOptimalTPCTest {
 				)
 			);
 		}
-		dataModel2.latestDeviceStatus
+		dataModel2.latestDeviceStatusRadios
 			.put(
 				deviceC,
 				TestUtils.createDeviceStatus(
@@ -304,7 +304,7 @@ public class LocationBasedOptimalTPCTest {
 
 		DataModel dataModel2 = new DataModel();
 		for (String device : Arrays.asList(deviceA, deviceB, deviceC)) {
-			dataModel2.latestDeviceStatus.put(
+			dataModel2.latestDeviceStatusRadios.put(
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
@@ -363,7 +363,7 @@ public class LocationBasedOptimalTPCTest {
 
 		DataModel dataModel3 = new DataModel();
 		for (String device : Arrays.asList(deviceA, deviceB, deviceC)) {
-			dataModel3.latestDeviceStatus.put(
+			dataModel3.latestDeviceStatusRadios.put(
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
@@ -412,7 +412,7 @@ public class LocationBasedOptimalTPCTest {
 
 		DataModel dataModel4 = new DataModel();
 		for (String device : Arrays.asList(deviceA, deviceB, deviceC)) {
-			dataModel4.latestDeviceStatus.put(
+			dataModel4.latestDeviceStatusRadios.put(
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -297,32 +297,6 @@ public class MeasurementBasedApApTPCTest {
 
 	@Test
 	@Order(2)
-	void testGetCurrentTxPower() throws Exception {
-		final int expectedTxPower = 29;
-
-		DataModel model = new DataModel();
-		TestUtils.createDeviceStatusDualBand(1, 5, 36, expectedTxPower);
-		model.latestState.put(
-			DEVICE_A,
-			TestUtils.createState(
-				new int[] { 1, 36 },
-				new int[] { 20, 20 },
-				new int[] { 5, expectedTxPower },
-				new String[] { BSSID_A, BSSID_A },
-				new int[][] { new int[] {}, new int[] {} }
-			)
-		);
-
-		State state =
-			model.latestState.get(DEVICE_A);
-		int txPower = MeasurementBasedApApTPC
-			.getCurrentTxPower(state, UCentralConstants.BAND_5G)
-			.get();
-		assertEquals(expectedTxPower, txPower);
-	}
-
-	@Test
-	@Order(3)
 	void testBuildRssiMap() throws Exception {
 		// This example includes three APs, and one AP that is unmanaged
 		Set<String> bssidSet = Set.of(BSSID_A, BSSID_B, BSSID_C);
@@ -344,7 +318,7 @@ public class MeasurementBasedApApTPCTest {
 	}
 
 	@Test
-	@Order(4)
+	@Order(3)
 	void testComputeTxPower() throws Exception {
 		// Test examples here taken from algorithm design doc from @pohanhf
 		final String serialNumber = "testSerial";

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -34,7 +34,6 @@ import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.UCentralUtils.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.models.State;
-import com.google.gson.JsonArray;
 
 @TestMethodOrder(OrderAnnotation.class)
 public class MeasurementBasedApApTPCTest {
@@ -302,15 +301,22 @@ public class MeasurementBasedApApTPCTest {
 		final int expectedTxPower = 29;
 
 		DataModel model = new DataModel();
-		model.latestDeviceStatusRadios.put(
+		TestUtils.createDeviceStatusDualBand(1, 5, 36, expectedTxPower);
+		model.latestState.put(
 			DEVICE_A,
-			TestUtils.createDeviceStatusDualBand(1, 5, 36, expectedTxPower)
+			TestUtils.createState(
+				new int[] { 1, 36 },
+				new int[] { 20, 20 },
+				new int[] { 5, expectedTxPower },
+				new String[] { BSSID_A, BSSID_A },
+				new int[][] { new int[] {}, new int[] {} }
+			)
 		);
 
-		JsonArray radioStatuses =
-			model.latestDeviceStatusRadios.get(DEVICE_A).getAsJsonArray();
+		State state =
+			model.latestState.get(DEVICE_A);
 		int txPower = MeasurementBasedApApTPC
-			.getCurrentTxPower(radioStatuses, UCentralConstants.BAND_5G)
+			.getCurrentTxPower(state, UCentralConstants.BAND_5G)
 			.get();
 		assertEquals(expectedTxPower, txPower);
 	}
@@ -513,12 +519,13 @@ public class MeasurementBasedApApTPCTest {
 			)
 		);
 		// make device C not operate in the 5G band instead of dual band
-		dataModel.latestDeviceStatusRadios.put(
+		dataModel.latestState.put(
 			DEVICE_C,
-			TestUtils.createDeviceStatus(
-				UCentralConstants.BAND_2G,
+			TestUtils.createState(
 				1,
-				MAX_TX_POWER
+				DEFAULT_CHANNEL_WIDTH,
+				MAX_TX_POWER,
+				BSSID_C
 			)
 		);
 		DeviceDataManager deviceDataManager = createDeviceDataManager();

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -122,17 +122,17 @@ public class MeasurementBasedApApTPCTest {
 		model.latestState.put(DEVICE_B, stateB);
 		model.latestState.put(DEVICE_C, stateC);
 
-		model.latestDeviceStatus.put(
+		model.latestDeviceStatusRadios.put(
 			DEVICE_A,
 			TestUtils
 				.createDeviceStatusDualBand(1, MAX_TX_POWER, 36, MAX_TX_POWER)
 		);
-		model.latestDeviceStatus.put(
+		model.latestDeviceStatusRadios.put(
 			DEVICE_B,
 			TestUtils
 				.createDeviceStatusDualBand(1, MAX_TX_POWER, 36, MAX_TX_POWER)
 		);
-		model.latestDeviceStatus.put(
+		model.latestDeviceStatusRadios.put(
 			DEVICE_C,
 			TestUtils
 				.createDeviceStatusDualBand(1, MAX_TX_POWER, 36, MAX_TX_POWER)
@@ -302,13 +302,13 @@ public class MeasurementBasedApApTPCTest {
 		final int expectedTxPower = 29;
 
 		DataModel model = new DataModel();
-		model.latestDeviceStatus.put(
+		model.latestDeviceStatusRadios.put(
 			DEVICE_A,
 			TestUtils.createDeviceStatusDualBand(1, 5, 36, expectedTxPower)
 		);
 
 		JsonArray radioStatuses =
-			model.latestDeviceStatus.get(DEVICE_A).getAsJsonArray();
+			model.latestDeviceStatusRadios.get(DEVICE_A).getAsJsonArray();
 		int txPower = MeasurementBasedApApTPC
 			.getCurrentTxPower(radioStatuses, UCentralConstants.BAND_5G)
 			.get();
@@ -513,7 +513,7 @@ public class MeasurementBasedApApTPCTest {
 			)
 		);
 		// make device C not operate in the 5G band instead of dual band
-		dataModel.latestDeviceStatus.put(
+		dataModel.latestDeviceStatusRadios.put(
 			DEVICE_C,
 			TestUtils.createDeviceStatus(
 				UCentralConstants.BAND_2G,


### PR DESCRIPTION
# Get tx power from statistics
It was possible that the configuration would not have the tx power, which would cause the algorithm to not run. However, with this change tx power will be sourced from statistics instead which should always have tx power. 

- Typed `State`'s `Radio` object. This required changes across a number of files.
  - channel width is string, why???
- Changed `latestDeviceStatus` to `latestDeviceStatusRadios`. This is much clearer since the previous name was confused with `latestState`

# Apply TPC to the correct SSID
Previously, we just took the first SSID of the first interface to run TPC on. This is wrong as the first SSID won't necessarily match up with the band requested (i.e. working on 2.4 but 5 could be retrieved and vice versa). Loop through the interfaces as well as SSID in order to find the correct SSID for the band.