### PR TITLE
States aggregation 

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/RRMConfig.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMConfig.java
@@ -309,6 +309,12 @@ public class RRMConfig {
 			 * ({@code MODELERPARAMS_WIFISCANBUFFERSIZE})
 			 */
 			public int wifiScanBufferSize = 10;
+
+			/**
+			 * Maximum rounds of States to store per device
+			 * ({@code MODELERPARAMS_STATEBUFFERSIZE})
+			 */
+			public int stateBufferSize = 10;
 		}
 
 		/** Modeler parameters. */
@@ -531,6 +537,9 @@ public class RRMConfig {
 			config.moduleConfig.modelerParams;
 		if ((v = env.get("MODELERPARAMS_WIFISCANBUFFERSIZE")) != null) {
 			modelerParams.wifiScanBufferSize = Integer.parseInt(v);
+		}
+		if ((v = env.get("MODELERPARAMS_STATEBUFFERSIZE")) != null) {
+			modelerParams.stateBufferSize = Integer.parseInt(v);
 		}
 		ModuleConfig.ApiServerParams apiServerParams =
 			config.moduleConfig.apiServerParams;

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -8,7 +8,6 @@
 
 package com.facebook.openwifirrm.modules;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -272,7 +271,7 @@ public class Modeler implements Runnable {
 					State stateModel = gson.fromJson(state, State.class);
 					dataModel.latestStates.computeIfAbsent(
 						device.serialNumber,
-						k -> Collections.synchronizedList(new ArrayList<>())
+						k -> Collections.synchronizedList(new LinkedList<>())
 					).add(stateModel);
 					logger.debug(
 						"Device {}: added initial state from uCentralGw",
@@ -309,7 +308,7 @@ public class Modeler implements Runnable {
 							.computeIfAbsent(
 								record.serialNumber,
 								k -> Collections
-									.synchronizedList(new ArrayList<>())
+									.synchronizedList(new LinkedList<>())
 							);
 						if (latestStatesList.size() >= params.stateBufferSize) {
 							latestStatesList.remove(0);

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -305,13 +305,18 @@ public class Modeler implements Runnable {
 				if (state != null) {
 					try {
 						State stateModel = gson.fromJson(state, State.class);
-						dataModel.latestStates
+						List<State> latestStatesList = dataModel.latestStates
 							.computeIfAbsent(
 								record.serialNumber,
 								k -> Collections
 									.synchronizedList(new ArrayList<>())
-							)
-							.add(stateModel);
+							);
+						if (latestStatesList.size() >= params.stateBufferSize) {
+							latestStatesList.remove(0);
+						}
+						latestStatesList.add(stateModel);
+						dataModel.latestStates
+							.put(record.serialNumber, latestStatesList);
 						stateUpdates.add(record.serialNumber);
 					} catch (JsonSyntaxException e) {
 						logger.error(

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -9,6 +9,7 @@
 package com.facebook.openwifirrm.modules;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -271,7 +272,7 @@ public class Modeler implements Runnable {
 					State stateModel = gson.fromJson(state, State.class);
 					dataModel.latestStates.computeIfAbsent(
 						device.serialNumber,
-						k -> new ArrayList<>()
+						k -> Collections.synchronizedList(new ArrayList<>())
 					).add(stateModel);
 					logger.debug(
 						"Device {}: added initial state from uCentralGw",
@@ -307,7 +308,8 @@ public class Modeler implements Runnable {
 						dataModel.latestStates
 							.computeIfAbsent(
 								record.serialNumber,
-								k -> new ArrayList<>()
+								k -> Collections
+									.synchronizedList(new ArrayList<>())
 							)
 							.add(stateModel);
 						stateUpdates.add(record.serialNumber);

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -9,7 +9,6 @@
 package com.facebook.openwifirrm.modules;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -270,10 +269,10 @@ public class Modeler implements Runnable {
 			if (state != null) {
 				try {
 					State stateModel = gson.fromJson(state, State.class);
-					dataModel.latestStates.put(
+					dataModel.latestStates.computeIfAbsent(
 						device.serialNumber,
-						new ArrayList<>(Arrays.asList(stateModel))
-					);
+						k -> new ArrayList<>()
+					).add(stateModel);
 					logger.debug(
 						"Device {}: added initial state from uCentralGw",
 						device.serialNumber

--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -423,8 +423,7 @@ public class ModelerUtils {
 					if (association == null) {
 						continue;
 					}
-					String key = String.format(
-						"bssid: %s, station: %s",
+					String key = getBssidStationKeyPair(
 						association.bssid,
 						association.station
 					);
@@ -434,16 +433,21 @@ public class ModelerUtils {
 					AggregatedState aggState =
 						new AggregatedState(association, radioInfo);
 
-					boolean toBeAggregated = false;
+					/**
+					 * Indicate if the aggState can be merged into some old AggregatedState.
+					 * If true, it will be merged by appending its mcs/rssi field to the old one.
+					 * If false, it will be added to the list aggregatedStates.
+					*/
+					boolean canBeMergedToOldAggregatedState = false;
 					for (
 						AggregatedState oldAggregatedState : aggregatedStates
 					) {
 						if (oldAggregatedState.add(aggState)) {
-							toBeAggregated = true;
+							canBeMergedToOldAggregatedState = true;
 							break;
 						}
 					}
-					if (!toBeAggregated) {
+					if (!canBeMergedToOldAggregatedState) {
 						aggregatedStates.add(aggState);
 					}
 					bssidToAggregatedStates.put(key, aggregatedStates);
@@ -517,7 +521,6 @@ public class ModelerUtils {
 				addStateToAggregation(bssidToAggregatedStates, state);
 			}
 		}
-
 		return aggregatedStates;
 	}
 
@@ -543,5 +546,14 @@ public class ModelerUtils {
 			}
 		}
 		return latestState;
+	}
+
+	/**  Create a key pair consisted of bssid and station string */
+	public static String getBssidStationKeyPair(String bssid, String station) {
+		return String.format(
+			"bssid: %s, station: %s",
+			bssid,
+			station
+		);
 	}
 }

--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -525,7 +525,7 @@ public class ModelerUtils {
 	}
 
 	/**
-	 * This method gets the most latest State from latestStates per device.
+	 * This method gets the most recent State from latestStates per device.
 	 *
 	 * @param latestStates list of latest States per device.
 	 * @return Map<String, State> a map from device String to latest State.

--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -510,7 +510,7 @@ public class ModelerUtils {
 			for (State state : states) {
 				if (refTimeMs - state.unit.localtime > obsoletionPeriodMs) {
 					// discard obsolete entries
-					continue;
+					break;
 				}
 
 				addStateToAggregation(bssidToAggregatedStates, state);
@@ -535,7 +535,10 @@ public class ModelerUtils {
 		) {
 			String key = stateEntry.getKey();
 			List<State> value = stateEntry.getValue();
-			latestState.put(key, value.get(value.size() - 1));
+			if(value.isEmpty()){
+				latestState.put(key, null);
+			}
+			else{latestState.put(key, value.get(value.size() - 1));}
 		}
 		return latestState;
 	}

--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -387,7 +387,8 @@ public class ModelerUtils {
 		return aggregatedWifiScans;
 	}
 
-	/** This method converts the input State info to an AggregatedState
+	/**
+	 * This method converts the input State info to an AggregatedState
 	 * and adds it to the bssidToAggregatedStates map. If the bssid&station
 	 * of the input State does not exist in the map, create a new
 	 * AggregatedState list. If the bssid&station of the input State exists,
@@ -408,10 +409,14 @@ public class ModelerUtils {
 				continue;
 			}
 			for (SSID ssid : stateInterface.ssids) {
-
-				int[] radios = new int[] { ssid.radio.get("channel").getAsInt(),
-					ssid.radio.get("channel_width").getAsInt(),
-					ssid.radio.get("tx_power").getAsInt() };
+				Map<String, Integer> radioInfo = new HashMap<>();
+				radioInfo.put("channel", ssid.radio.get("channel").getAsInt());
+				radioInfo.put(
+					"channel_width",
+					ssid.radio.get("channel_width").getAsInt()
+				);
+				radioInfo
+					.put("tx_power", ssid.radio.get("tx_power").getAsInt());
 
 				for (Association association : ssid.associations) {
 					if (association == null) {
@@ -426,7 +431,7 @@ public class ModelerUtils {
 						bssidToAggregatedStates
 							.computeIfAbsent(key, k -> new ArrayList<>());
 					AggregatedState aggState =
-						new AggregatedState(association, radios);
+						new AggregatedState(association, radioInfo);
 
 					boolean toBeAggregated = false;
 					for (
@@ -515,9 +520,11 @@ public class ModelerUtils {
 		return aggregatedStates;
 	}
 
-	/** This method gets the most latest State from latestStates per device.
+	/**
+	 * This method gets the most latest State from latestStates per device.
+	 *
 	 * @param latestStates list of latest States per device.
-	 * @return Map<String, State>  a map from device String to  most latest State.
+	 * @return Map<String, State> a map from device String to latest State.
 	 */
 	public static Map<String, State> getLatestState(
 		Map<String, List<State>> latestStates

--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -529,16 +530,17 @@ public class ModelerUtils {
 	public static Map<String, State> getLatestState(
 		Map<String, List<State>> latestStates
 	) {
-		Map<String, State> latestState = new HashMap<>();
+		Map<String, State> latestState = new ConcurrentHashMap<>();
 		for (
 			Map.Entry<String, List<State>> stateEntry : latestStates.entrySet()
 		) {
 			String key = stateEntry.getKey();
 			List<State> value = stateEntry.getValue();
-			if(value.isEmpty()){
+			if (value.isEmpty()) {
 				latestState.put(key, null);
+			} else {
+				latestState.put(key, value.get(value.size() - 1));
 			}
-			else{latestState.put(key, value.get(value.size() - 1));}
 		}
 		return latestState;
 	}

--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -24,6 +24,11 @@ import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.ucentral.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.informationelement.HTOperation;
 import com.facebook.openwifirrm.ucentral.informationelement.VHTOperation;
+import com.facebook.openwifirrm.ucentral.models.AggregatedState;
+import com.facebook.openwifirrm.ucentral.models.State;
+import com.facebook.openwifirrm.ucentral.models.State.Interface;
+import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID;
+import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association;
 
 /**
  * Modeler utilities.
@@ -380,5 +385,151 @@ public class ModelerUtils {
 			}
 		}
 		return aggregatedWifiScans;
+	}
+
+	/** This method converts the input State info to an AggregatedState
+	 * and adds it to the bssidToAggregatedStates map. If the bssid&station
+	 * of the input State does not exist in the map, create a new
+	 * AggregatedState list. If the bssid&station of the input State exists,
+	 * then convert State to AggregatedState and check if there exits an
+	 * AggregatedState of the same radio. If there does, append the value
+	 * of aggregation field to the existing AggregatedState, if not, create
+	 * a new AggregatedState and add it to the list.
+	 *
+	 * @param bssidToAggregatedStates map from bssid&station to a list of AggregatedState.
+	 * @param state the state that is to be added.
+	 */
+	static void addStateToAggregation(
+		Map<String, List<AggregatedState>> bssidToAggregatedStates,
+		State state
+	) {
+		for (Interface stateInterface : state.interfaces) {
+			if (stateInterface.ssids == null) {
+				continue;
+			}
+			for (SSID ssid : stateInterface.ssids) {
+
+				int[] radios = new int[] { ssid.radio.get("channel").getAsInt(),
+					ssid.radio.get("channel_width").getAsInt(),
+					ssid.radio.get("tx_power").getAsInt() };
+
+				for (Association association : ssid.associations) {
+					if (association == null) {
+						continue;
+					}
+					String key = String.format(
+						"bssid: %s, station: %s",
+						association.bssid,
+						association.station
+					);
+					List<AggregatedState> aggregatedStates =
+						bssidToAggregatedStates
+							.computeIfAbsent(key, k -> new ArrayList<>());
+					AggregatedState aggState =
+						new AggregatedState(association, radios);
+
+					boolean toBeAggregated = false;
+					for (
+						AggregatedState oldAggregatedState : aggregatedStates
+					) {
+						if (oldAggregatedState.add(aggState)) {
+							toBeAggregated = true;
+							break;
+						}
+					}
+					if (!toBeAggregated) {
+						aggregatedStates.add(aggState);
+					}
+					bssidToAggregatedStates.put(key, aggregatedStates);
+				}
+			}
+		}
+	}
+
+	/**
+	 * This method aggregates States by bssid&station key pair and radio info.
+	 * if two States of the same bssid&station match in channel, channel width and tx_power
+	 * need to be aggregated to one {@code AggregatedState}. Currently only mcs and
+	 * rssi fields are being aggregated. They are of List<Integer> type in AggregatedState,
+	 * which list all the values over the time.
+	 *
+	 * @param dataModel the data model which includes the latest recorded States.
+	 * @param obsoletionPeriodMs the maximum amount of time (in milliseconds) it
+	 *                           is worth aggregating over, starting from the
+	 *                           most recent States and working backwards in time.
+	 * 							 A State exactly {@code obsoletionPeriodMs} ms earlier
+	 * 							 than the most recent State is considered non-obsolete
+	 *                           (i.e., the "non-obsolete" window is inclusive).
+	 *                           Must be non-negative.
+	 * @param refTimeMs	the reference time were passed to make testing easier
+	 * @return  Map<String, Map<String, List<AggregatedState>>> A map from serial number to
+	 * 							a map from bssid_station String pair to a list of AggregatedState.
+	 */
+	public static Map<String, Map<String, List<AggregatedState>>> getAggregatedStates(
+		Modeler.DataModel dataModel,
+		long obsoletionPeriodMs,
+		long refTimeMs
+	) {
+		if (obsoletionPeriodMs < 0) {
+			throw new IllegalArgumentException(
+				"obsoletionPeriodMs must be non-negative."
+			);
+		}
+		Map<String, Map<String, List<AggregatedState>>> aggregatedStates =
+			new HashMap<>();
+
+		for (
+			Map.Entry<String, List<State>> deviceToStateList : dataModel.latestStates
+				.entrySet()
+		) {
+			String serialNumber = deviceToStateList.getKey();
+			List<State> states = deviceToStateList.getValue();
+
+			if (states.isEmpty()) {
+				continue;
+			}
+
+			/**
+			 * Sort in reverse chronological order. Sorting is done just in case the
+			 * States in the original list are not chronological already - although
+			 * they are inserted chronologically, perhaps latency, synchronization, etc.
+			 */
+			states.sort(
+				(state1, state2) -> -Long.compare(state1.unit.localtime, state2.unit.localtime)
+			);
+
+			Map<String, List<AggregatedState>> bssidToAggregatedStates =
+				aggregatedStates
+					.computeIfAbsent(serialNumber, k -> new HashMap<>());
+
+			for (State state : states) {
+				if (refTimeMs - state.unit.localtime > obsoletionPeriodMs) {
+					// discard obsolete entries
+					continue;
+				}
+
+				addStateToAggregation(bssidToAggregatedStates, state);
+			}
+		}
+
+		return aggregatedStates;
+	}
+
+	/** This method gets the most latest State from latestStates per device.
+	 * @param latestStates list of latest States per device.
+	 * @return Map<String, State>  a map from device String to  most latest State.
+	 */
+	public static Map<String, State> getLatestState(
+		Map<String, List<State>> latestStates
+	) {
+		Map<String, State> latestState = new HashMap<>();
+		for (
+			Map.Entry<String, List<State>> stateEntry : latestStates.entrySet()
+		) {
+			String key = stateEntry.getKey();
+			List<State> value = stateEntry.getValue();
+			latestState.put(key, value.get(value.size() - 1));
+		}
+		return latestState;
 	}
 }

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
@@ -154,7 +154,7 @@ public abstract class ChannelOptimizer {
 		// Remove model entries not in the given zone
 		this.model.latestWifiScans.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber));
-		this.model.latestState.keySet()
+		this.model.latestStates.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber));
 		this.model.latestDeviceStatusRadios.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber));

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizer.java
@@ -376,8 +376,7 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 				}
 
 				// Get current channel of the device
-				List<State> states = model.latestStates.get(serialNumber);
-				State state = states.get(states.size() - 1);
+				State state = latestState.get(serialNumber);
 				if (state == null) {
 					logger.debug(
 						"Device {}: No state found, skipping...",

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizer.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifirrm.DeviceDataManager;
+import com.facebook.openwifirrm.modules.ModelerUtils;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.UCentralUtils;
@@ -340,8 +341,10 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 				AVAILABLE_CHANNELS_BAND
 			);
 
+		Map<String, State> latestState =
+			ModelerUtils.getLatestState(model.latestStates);
 		Map<String, String> bssidsMap =
-			UCentralUtils.getBssidsMap(model.latestState);
+			UCentralUtils.getBssidsMap(latestState);
 
 		for (String band : bandsMap.keySet()) {
 			// Performance metrics
@@ -373,7 +376,8 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 				}
 
 				// Get current channel of the device
-				State state = model.latestState.get(serialNumber);
+				List<State> states = model.latestStates.get(serialNumber);
+				State state = states.get(states.size() - 1);
 				if (state == null) {
 					logger.debug(
 						"Device {}: No state found, skipping...",

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializer.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifirrm.DeviceDataManager;
+import com.facebook.openwifirrm.modules.ModelerUtils;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.WifiScanEntry;
@@ -128,8 +129,10 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 				AVAILABLE_CHANNELS_BAND
 			);
 
+		Map<String, State> latestState =
+			ModelerUtils.getLatestState(model.latestStates);
 		Map<String, String> bssidsMap =
-			UCentralUtils.getBssidsMap(model.latestState);
+			UCentralUtils.getBssidsMap(latestState);
 
 		for (Map.Entry<String, List<String>> entry : bandsMap.entrySet()) {
 			// Performance metrics
@@ -183,7 +186,7 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 						? rng.nextInt(availableChannelsList.size()) : defaultChannelIndex
 				);
 
-				State state = model.latestState.get(serialNumber);
+				State state = latestState.get(serialNumber);
 				if (state == null) {
 					logger.debug(
 						"Device {}: No state found, skipping...",

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -175,7 +175,9 @@ public class LocationBasedOptimalTPC extends TPC {
 		// Filter out the invalid APs (e.g., no radio, no location data)
 		// Update txPowerChoices, boundary, apLocX, apLocY for the optimization
 		for (String serialNumber : serialNumbers) {
-			State state = model.latestState.get(serialNumber);
+
+			List<State> states = model.latestStates.get(serialNumber);
+			State state = states.get(states.size() - 1);
 
 			// Ignore the device if its radio is not active
 			if (state.radios == null || state.radios.length == 0) {

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -175,7 +175,6 @@ public class LocationBasedOptimalTPC extends TPC {
 		// Filter out the invalid APs (e.g., no radio, no location data)
 		// Update txPowerChoices, boundary, apLocX, apLocY for the optimization
 		for (String serialNumber : serialNumbers) {
-
 			List<State> states = model.latestStates.get(serialNumber);
 			State state = states.get(states.size() - 1);
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -154,8 +154,9 @@ public class MeasurementBasedApApTPC extends TPC {
 	 */
 	protected static Set<String> getManagedBSSIDs(DataModel model) {
 		Set<String> managedBSSIDs = new HashSet<>();
-		for (Map.Entry<String, State> e : model.latestState.entrySet()) {
-			State state = e.getValue();
+		for (Map.Entry<String, List<State>> e : model.latestStates.entrySet()) {
+			List<State> states = e.getValue();
+			State state = states.get(states.size() - 1);
 			if (state.interfaces == null) {
 				continue;
 			}
@@ -311,7 +312,8 @@ public class MeasurementBasedApApTPC extends TPC {
 			buildRssiMap(managedBSSIDs, model.latestWifiScans, band);
 		logger.debug("Starting TPC for the {} band", band);
 		for (String serialNumber : serialNumbers) {
-			State state = model.latestState.get(serialNumber);
+			List<State> states = model.latestStates.get(serialNumber);
+			State state = states.get(states.size() - 1);
 			if (
 				state == null || state.radios == null ||
 					state.radios.length == 0

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -291,10 +291,10 @@ public class MeasurementBasedApClientTPC extends TPC {
 	public Map<String, Map<String, Integer>> computeTxPowerMap() {
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
 
-		for (Map.Entry<String, State> e : model.latestState.entrySet()) {
+		for (Map.Entry<String, List<State>> e : model.latestStates.entrySet()) {
 			String serialNumber = e.getKey();
-			State state = e.getValue();
-
+			List<State> states = e.getValue();
+			State state = states.get(states.size() - 1);
 			if (state.radios == null || state.radios.length == 0) {
 				logger.debug(
 					"Device {}: No radios found, skipping...",

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -122,7 +122,7 @@ public class RandomTxPowerInitializer extends TPC {
 		if (!setDifferentTxPowerPerAp) {
 			List<Integer> txPowerChoices =
 				new ArrayList<>(DEFAULT_TX_POWER_CHOICES);
-			for (String serialNumber : model.latestState.keySet()) {
+			for (String serialNumber : model.latestStates.keySet()) {
 				for (String band : UCentralConstants.BANDS) {
 					txPowerChoices = updateTxPowerChoices(
 						band,

--- a/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/tpc/TPC.java
@@ -70,7 +70,7 @@ public abstract class TPC {
 		this.model.latestWifiScans.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber)
 			);
-		this.model.latestState.keySet()
+		this.model.latestStates.keySet()
 			.removeIf(serialNumber -> !deviceConfigs.containsKey(serialNumber)
 			);
 		this.model.latestDeviceStatusRadios.keySet()
@@ -184,9 +184,10 @@ public abstract class TPC {
 	 */
 	protected Map<Integer, List<String>> getApsPerChannel() {
 		Map<Integer, List<String>> apsPerChannel = new TreeMap<>();
-		for (Map.Entry<String, State> e : model.latestState.entrySet()) {
+		for (Map.Entry<String, List<State>> e : model.latestStates.entrySet()) {
 			String serialNumber = e.getKey();
-			State state = e.getValue();
+			List<State> states = e.getValue();
+			State state = states.get(states.size() - 1);
 
 			if (state.radios == null || state.radios.length == 0) {
 				logger.debug(

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -69,7 +69,7 @@ public class AggregatedState {
 			mcs.addAll(rate.mcs);
 		}
 	}
-	
+
 	/**
 	 * Radio information with channel, channel_width and tx_power.
 	 */

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -66,8 +66,7 @@ public class AggregatedState {
 		public int channelWidth;
 		public int txPower;
 
-		public Radio() {
-		}
+		public Radio() {}
 
 		public Radio(int channel, int channelWidth, int txPower) {
 			this.channel = channel;
@@ -99,9 +98,8 @@ public class AggregatedState {
 			}
 
 			Radio other = (Radio) obj;
-			return channel == other.channel
-					&& channelWidth == other.channelWidth
-					&& txPower == other.txPower;
+			return channel == other.channel &&
+				channelWidth == other.channelWidth && txPower == other.txPower;
 		}
 	}
 
@@ -140,8 +138,10 @@ public class AggregatedState {
 	}
 
 	/** Construct from Association and radio */
-	public AggregatedState(Association association,
-			Map<String, Integer> radioInfo) {
+	public AggregatedState(
+		Association association,
+		Map<String, Integer> radioInfo
+	) {
 		this.rxRate = new AggregatedRate();
 		this.txRate = new AggregatedRate();
 		this.rssi = new ArrayList<>();
@@ -184,21 +184,20 @@ public class AggregatedState {
 
 		AggregatedState other = (AggregatedState) obj;
 
-		return bssid == other.bssid && station == other.station
-				&& connected == other.connected && inactive == other.inactive
-				&& rssi.equals(other.rssi) && rxBytes == other.rxBytes
-				&& rxBytes == other.rxPackets
-				&& rxRate.bitRate == other.rxRate.bitRate
-				&& rxRate.chWidth == other.rxRate.chWidth
-				&& rxRate.mcs.equals(other.rxRate.mcs)
-				&& txBytes == other.txBytes && txDuration == other.txDuration
-				&& txFailed == other.txFailed && txPackets == other.txPackets
-				&& txRate.bitRate == other.txRate.bitRate
-				&& txRate.chWidth == other.txRate.chWidth
-				&& txRate.mcs.equals(other.txRate.mcs)
-				&& txRetries == other.txRetries && ackSignal == other.ackSignal
-				&& ackSignalAvg == other.ackSignalAvg
-				&& radio.equals(other.radio);
+		return bssid == other.bssid && station == other.station &&
+			connected == other.connected && inactive == other.inactive && rssi
+				.equals(other.rssi) &&
+			rxBytes == other.rxBytes && rxBytes == other.rxPackets &&
+			rxRate.bitRate == other.rxRate.bitRate &&
+			rxRate.chWidth == other.rxRate.chWidth && rxRate.mcs
+				.equals(other.rxRate.mcs) &&
+			txBytes == other.txBytes && txDuration == other.txDuration &&
+			txFailed == other.txFailed && txPackets == other.txPackets &&
+			txRate.bitRate == other.txRate.bitRate &&
+			txRate.chWidth == other.txRate.chWidth && txRate.mcs
+				.equals(other.txRate.mcs) &&
+			txRetries == other.txRetries && ackSignal == other.ackSignal &&
+			ackSignalAvg == other.ackSignalAvg && radio.equals(other.radio);
 	}
 
 	/**
@@ -210,7 +209,10 @@ public class AggregatedState {
 	 *         channel_width and tx_power
 	 */
 	public boolean add(AggregatedState state) {
-		if ((bssid == null && station == null && radio == null) || hashCode() == state.hashCode()) {
+		if (
+			(bssid == null && station == null && radio == null) ||
+				hashCode() == state.hashCode()
+		) {
 			this.bssid = state.bssid;
 			this.station = state.station;
 			this.connected = state.connected;
@@ -227,8 +229,11 @@ public class AggregatedState {
 			this.txRetries = state.txRetries;
 			this.ackSignal = state.ackSignal;
 			this.ackSignalAvg = state.ackSignalAvg;
-			this.radio = new Radio(state.radio.channel,
-					state.radio.channelWidth, state.radio.txPower);
+			this.radio = new Radio(
+				state.radio.channel,
+				state.radio.channelWidth,
+				state.radio.txPower
+			);
 			return true;
 		}
 		return false;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -17,7 +17,8 @@ import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association
 import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association.Rate;
 
 /**
- * Aggregation model for State aggregation. Only contains info useful for analysis.
+ * Aggregation model for State aggregation. Only contains info useful for
+ * analysis.
  */
 public class AggregatedState {
 
@@ -39,11 +40,15 @@ public class AggregatedState {
 			if (mcs == null || mcs.isEmpty()) {
 				bitRate = rate.bitrate;
 				chWidth = rate.chwidth;
+				mcs = new ArrayList<>();
 			}
 			mcs.add(rate.mcs);
 		}
 
-		/** Add an AggregatedRate with the same channel_width to the AggregatedRate */
+		/**
+		 * Add an AggregatedRate with the same channel_width to the
+		 * AggregatedRate
+		 */
 		public void add(AggregatedRate rate) {
 			if (rate.chWidth != chWidth) {
 				return;
@@ -53,6 +58,50 @@ public class AggregatedState {
 				chWidth = rate.chWidth;
 			}
 			mcs.addAll(rate.mcs);
+		}
+	}
+
+	public static class Radio {
+		public int channel;
+		public int channelWidth;
+		public int txPower;
+
+		public Radio() {
+		}
+
+		public Radio(int channel, int channelWidth, int txPower) {
+			this.channel = channel;
+			this.channelWidth = channelWidth;
+			this.txPower = txPower;
+		}
+
+		public Radio(Map<String, Integer> radioInfo) {
+			channel = radioInfo.getOrDefault("channel", -1);
+			channelWidth = radioInfo.getOrDefault("channel_width", -1);
+			txPower = radioInfo.getOrDefault("tx_power", -1);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(channel, channelWidth, txPower);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+
+			Radio other = (Radio) obj;
+			return channel == other.channel
+					&& channelWidth == other.channelWidth
+					&& txPower == other.txPower;
 		}
 	}
 
@@ -74,85 +123,6 @@ public class AggregatedState {
 	public int ackSignalAvg;
 	public Radio radio;
 
-	public static class Radio {
-		public int channel;
-		public int channelWidth;
-		public int txPower;
-
-		public Radio() {}
-
-		public Radio(int channel, int channelWidth, int txPower) {
-			this.channel = channel;
-			this.channelWidth = channelWidth;
-			this.txPower = txPower;
-		}
-
-		public Radio(Map<String, Integer> radioInfo) {
-			channel = radioInfo.getOrDefault("channel", null);
-			channelWidth = radioInfo.getOrDefault("channel_width", null);
-			txPower = radioInfo.getOrDefault("tx_power", null);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(channel, channelWidth, txPower);
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj) {
-				return true;
-			}
-			if (obj == null) {
-				return false;
-			}
-			if (getClass() != obj.getClass()) {
-				return false;
-			}
-
-			Radio other = (Radio) obj;
-			return channel == other.channel &&
-				channelWidth == other.channelWidth &&
-				txPower == other.txPower;
-		}
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(bssid, station, radio);
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-
-		AggregatedState other = (AggregatedState) obj;
-
-		return bssid == other.bssid &&
-			station == other.station &&
-			connected == other.connected && inactive == other.inactive && rssi
-				.equals(other.rssi) &&
-			rxBytes == other.rxBytes && rxBytes == other.rxPackets &&
-			rxRate.bitRate == other.rxRate.bitRate &&
-			rxRate.chWidth == other.rxRate.chWidth && rxRate.mcs
-				.equals(other.rxRate.mcs) &&
-			txBytes == other.txBytes && txDuration == other.txDuration &&
-			txFailed == other.txFailed && txPackets == other.txPackets &&
-			txRate.bitRate == other.txRate.bitRate &&
-			txRate.chWidth == other.txRate.chWidth && txRate.mcs
-				.equals(other.txRate.mcs) &&
-			txRetries == other.txRetries && ackSignal == other.ackSignal &&
-			ackSignalAvg == other.ackSignalAvg && radio.equals(other.radio);
-	}
-
 	/** Constructor with no args */
 	public AggregatedState() {
 		this.rxRate = new AggregatedRate();
@@ -170,10 +140,8 @@ public class AggregatedState {
 	}
 
 	/** Construct from Association and radio */
-	public AggregatedState(
-		Association association,
-		Map<String, Integer> radioInfo
-	) {
+	public AggregatedState(Association association,
+			Map<String, Integer> radioInfo) {
 		this.rxRate = new AggregatedRate();
 		this.txRate = new AggregatedRate();
 		this.rssi = new ArrayList<>();
@@ -197,15 +165,52 @@ public class AggregatedState {
 		this.radio = new Radio(radioInfo);
 	}
 
+	@Override
+	public int hashCode() {
+		return Objects.hash(bssid, station, radio);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+
+		AggregatedState other = (AggregatedState) obj;
+
+		return bssid == other.bssid && station == other.station
+				&& connected == other.connected && inactive == other.inactive
+				&& rssi.equals(other.rssi) && rxBytes == other.rxBytes
+				&& rxBytes == other.rxPackets
+				&& rxRate.bitRate == other.rxRate.bitRate
+				&& rxRate.chWidth == other.rxRate.chWidth
+				&& rxRate.mcs.equals(other.rxRate.mcs)
+				&& txBytes == other.txBytes && txDuration == other.txDuration
+				&& txFailed == other.txFailed && txPackets == other.txPackets
+				&& txRate.bitRate == other.txRate.bitRate
+				&& txRate.chWidth == other.txRate.chWidth
+				&& txRate.mcs.equals(other.txRate.mcs)
+				&& txRetries == other.txRetries && ackSignal == other.ackSignal
+				&& ackSignalAvg == other.ackSignalAvg
+				&& radio.equals(other.radio);
+	}
+
 	/**
 	 * Add an AggregatedState to this AggregatedState. Succeed only when the two
 	 * matches in hashCode.
 	 *
 	 * @param state input AggregatedState
-	 * @return boolean true if the two matches in bssid, station, channel, channel_width and tx_power
+	 * @return boolean true if the two matches in bssid, station, channel,
+	 *         channel_width and tx_power
 	 */
 	public boolean add(AggregatedState state) {
-		if (hashCode() == state.hashCode()) {
+		if ((bssid == null && station == null && radio == null) || hashCode() == state.hashCode()) {
 			this.bssid = state.bssid;
 			this.station = state.station;
 			this.connected = state.connected;
@@ -222,11 +227,8 @@ public class AggregatedState {
 			this.txRetries = state.txRetries;
 			this.ackSignal = state.ackSignal;
 			this.ackSignalAvg = state.ackSignalAvg;
-			this.radio = new Radio(
-				state.radio.channel,
-				state.radio.channelWidth,
-				state.radio.txPower
-			);
+			this.radio = new Radio(state.radio.channel,
+					state.radio.channelWidth, state.radio.txPower);
 			return true;
 		}
 		return false;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -22,6 +22,7 @@ import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association
  */
 public class AggregatedState {
 
+	/** Rate information with aggregated fields. */
 	public static class AggregatedRate {
 		/**
 		 * This is the common bitRate for all the aggregated fields.
@@ -68,7 +69,10 @@ public class AggregatedState {
 			mcs.addAll(rate.mcs);
 		}
 	}
-
+	
+	/**
+	 * Radio information with channel, channel_width and tx_power.
+	 */
 	public static class Radio {
 		public int channel;
 		public int channelWidth;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -40,10 +40,10 @@ public class AggregatedState {
 		public List<Integer> mcs = new ArrayList<>();
 
 		/** Constructor with no args */
-		public AggregatedRate() {}
+		private AggregatedRate() {}
 
 		/** Add a Rate to the AggregatedRate */
-		public void add(Rate rate) {
+		private void add(Rate rate) {
 			if (rate == null) {
 				return;
 			}
@@ -58,7 +58,7 @@ public class AggregatedState {
 		 * Add an AggregatedRate with the same channel_width to the
 		 * AggregatedRate
 		 */
-		public void add(AggregatedRate rate) {
+		private void add(AggregatedRate rate) {
 			if (rate == null || rate.chWidth != chWidth) {
 				return;
 			}
@@ -78,7 +78,7 @@ public class AggregatedState {
 		public int channelWidth;
 		public int txPower;
 
-		public Radio() {}
+		private Radio() {}
 
 		public Radio(int channel, int channelWidth, int txPower) {
 			this.channel = channel;
@@ -86,7 +86,7 @@ public class AggregatedState {
 			this.txPower = txPower;
 		}
 
-		public Radio(Map<String, Integer> radioInfo) {
+		private Radio(Map<String, Integer> radioInfo) {
 			channel = radioInfo.getOrDefault("channel", -1);
 			channelWidth = radioInfo.getOrDefault("channel_width", -1);
 			txPower = radioInfo.getOrDefault("tx_power", -1);
@@ -211,27 +211,9 @@ public class AggregatedState {
 	 */
 	public boolean add(AggregatedState state) {
 		if (hashCode() == state.hashCode()) {
-			this.bssid = state.bssid;
-			this.station = state.station;
-			this.connected = state.connected;
-			this.inactive = state.inactive;
 			this.rssi.addAll(state.rssi);
-			this.rxBytes = state.rxBytes;
-			this.rxPackets = state.rxPackets;
 			this.rxRate.add(state.rxRate);
-			this.txBytes = state.txBytes;
-			this.txDuration = state.txDuration;
-			this.txFailed = state.txFailed;
-			this.txPackets = state.txPackets;
 			this.txRate.add(state.txRate);
-			this.txRetries = state.txRetries;
-			this.ackSignal = state.ackSignal;
-			this.ackSignalAvg = state.ackSignalAvg;
-			this.radio = new Radio(
-				state.radio.channel,
-				state.radio.channelWidth,
-				state.radio.txPower
-			);
 			return true;
 		}
 		return false;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.models;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association;
+import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association.Rate;
+
+public class AggregatedState {
+
+	public class AggregatedRate {
+		public long bitrate;
+		public int chwidth;
+		public List<Integer> mcs;
+
+		/** Constructor with no args */
+		public AggregatedRate() {
+			this.mcs = new ArrayList<>();
+		}
+
+		/** Constructor */
+		public AggregatedRate(List<Rate> rates) {
+			int size = rates.size();
+			if (size == 0) {
+				return;
+			}
+			add(rates);
+		}
+
+		/** Add a list of Rates to the AggregatedRate */
+		public void add(List<Rate> rates) {
+			if (rates.isEmpty()) {
+				return;
+			}
+			for (Rate rate : rates) {
+				this.mcs.add(rate.mcs);
+			}
+		}
+
+		/** Add a Rate to the AggregatedRate */
+		public void add(Rate rate) {
+			if (rate == null) {
+				return;
+			}
+			if (mcs == null || mcs.isEmpty()) {
+				this.bitrate = rate.bitrate;
+				this.chwidth = rate.chwidth;
+			}
+			this.mcs.add(rate.mcs);
+		}
+
+		/** Add an AggregatedRate with the same channel_width to the AggregatedRate */
+		public void add(AggregatedRate rate) {
+			if (rate.chwidth != chwidth) {
+				return;
+			}
+			if (mcs == null || mcs.isEmpty()) {
+				this.bitrate = rate.bitrate;
+				this.chwidth = rate.chwidth;
+			}
+			this.mcs.addAll(rate.mcs);
+		}
+	}
+
+	public String bssid;
+	public String station;
+	public long connected;
+	public long inactive;
+	public List<Integer> rssi;
+	public long rx_bytes;
+	public long rx_packets;
+	public AggregatedRate rx_rate;
+	public long tx_bytes;
+	public long tx_duration;
+	public long tx_failed;
+	public long tx_packets;
+	public AggregatedRate tx_rate;
+	public long tx_retries;
+	public int ack_signal;
+	public int ack_signal_avg;
+	public Radio radio;
+
+	public class Radio {
+		public int channel;
+		public int channel_width;
+		public int tx_power;
+
+		public Radio() {}
+
+		public Radio(int channel, int channel_width, int tx_power) {
+			this.channel = channel;
+			this.channel_width = channel_width;
+			this.tx_power = tx_power;
+		}
+
+		public Radio(int[] radios) {
+			this.channel = radios[0];
+			this.channel_width = radios[1];
+			this.tx_power = radios[2];
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(channel, channel_width, tx_power);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+
+			Radio other = (Radio) obj;
+			return channel == other.channel &&
+				channel_width == other.channel_width &&
+				tx_power == other.tx_power;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(bssid, station, radio);
+	}
+
+	/** Constructor with no args */
+	public AggregatedState() {
+		this.rx_rate = new AggregatedRate();
+		this.tx_rate = new AggregatedRate();
+		this.rssi = new ArrayList<>();
+		this.radio = new Radio();
+	}
+
+	/** Construct from Aggregatedstate */
+	public AggregatedState(AggregatedState state) {
+		this.rx_rate = new AggregatedRate();
+		this.tx_rate = new AggregatedRate();
+		this.rssi = new ArrayList<>();
+		add(state);
+	}
+
+	/** Construt from Asscociation and radio */
+	public AggregatedState(Association association, int[] radios) {
+		this.rx_rate = new AggregatedRate();
+		this.tx_rate = new AggregatedRate();
+		this.rssi = new ArrayList<>();
+
+		this.bssid = association.bssid;
+		this.station = association.station;
+		this.connected = association.connected;
+		this.inactive = association.inactive;
+		this.rssi.add(association.rssi);
+		this.rx_bytes = association.rx_bytes;
+		this.rx_packets = association.rx_packets;
+		this.rx_rate.add(association.rx_rate);
+		this.tx_bytes = association.tx_bytes;
+		this.tx_duration = association.tx_duration;
+		this.tx_failed = association.tx_failed;
+		this.tx_packets = association.tx_packets;
+		this.tx_rate.add(association.tx_rate);
+		this.tx_retries = association.tx_retries;
+		this.ack_signal = association.ack_signal;
+		this.ack_signal_avg = association.ack_signal_avg;
+		this.radio = new Radio(radios);
+	}
+
+	/** Add an AggregatedState to this AggregatedState. Succeed only when the two
+	 * matches in hashCode.
+	 *
+	 * @param state input AggregatedState
+	 * @return boolean true if the two matches in bssid, station, channel, channel_width and tx_power
+	 */
+	public boolean add(AggregatedState state) {
+		if (hashCode() == state.hashCode()) {
+			this.bssid = state.bssid;
+			this.station = state.station;
+			this.connected = state.connected;
+			this.inactive = state.inactive;
+			this.rssi.addAll(state.rssi);
+			this.rx_bytes = state.rx_bytes;
+			this.rx_packets = state.rx_packets;
+			this.rx_rate.add(state.rx_rate);
+			this.tx_bytes = state.tx_bytes;
+			this.tx_duration = state.tx_duration;
+			this.tx_failed = state.tx_failed;
+			this.tx_packets = state.tx_packets;
+			this.tx_rate.add(state.tx_rate);
+			this.tx_retries = state.tx_retries;
+			this.ack_signal = state.ack_signal;
+			this.ack_signal_avg = state.ack_signal_avg;
+			this.radio = new Radio(
+				state.radio.channel,
+				state.radio.channel_width,
+				state.radio.tx_power
+			);
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -23,24 +23,32 @@ import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association
 public class AggregatedState {
 
 	public static class AggregatedRate {
+		/**
+		 * This is the common bitRate for all the aggregated fields.
+		 */
 		public long bitRate;
+
+		/**
+		 * This is the common channel width for all the aggregated fields.
+		 */
 		public int chWidth;
-		public List<Integer> mcs;
+
+		/**
+		 * Aggregated fields mcs
+		 */
+		public List<Integer> mcs = new ArrayList<>();
 
 		/** Constructor with no args */
-		public AggregatedRate() {
-			mcs = new ArrayList<>();
-		}
+		public AggregatedRate() {}
 
 		/** Add a Rate to the AggregatedRate */
 		public void add(Rate rate) {
 			if (rate == null) {
 				return;
 			}
-			if (mcs == null || mcs.isEmpty()) {
+			if (mcs.isEmpty()) {
 				bitRate = rate.bitrate;
 				chWidth = rate.chwidth;
-				mcs = new ArrayList<>();
 			}
 			mcs.add(rate.mcs);
 		}
@@ -50,10 +58,10 @@ public class AggregatedState {
 		 * AggregatedRate
 		 */
 		public void add(AggregatedRate rate) {
-			if (rate.chWidth != chWidth) {
+			if (rate == null || rate.chWidth != chWidth) {
 				return;
 			}
-			if (mcs == null || mcs.isEmpty()) {
+			if (mcs.isEmpty()) {
 				bitRate = rate.bitRate;
 				chWidth = rate.chWidth;
 			}
@@ -129,14 +137,6 @@ public class AggregatedState {
 		this.radio = new Radio();
 	}
 
-	/** Construct from Aggregatedstate */
-	public AggregatedState(AggregatedState state) {
-		this.rxRate = new AggregatedRate();
-		this.txRate = new AggregatedRate();
-		this.rssi = new ArrayList<>();
-		add(state);
-	}
-
 	/** Construct from Association and radio */
 	public AggregatedState(
 		Association association,
@@ -188,16 +188,13 @@ public class AggregatedState {
 			connected == other.connected && inactive == other.inactive && rssi
 				.equals(other.rssi) &&
 			rxBytes == other.rxBytes && rxBytes == other.rxPackets &&
-			rxRate.bitRate == other.rxRate.bitRate &&
-			rxRate.chWidth == other.rxRate.chWidth && rxRate.mcs
-				.equals(other.rxRate.mcs) &&
+			Objects.equals(rxRate, other.rxRate) &&
 			txBytes == other.txBytes && txDuration == other.txDuration &&
 			txFailed == other.txFailed && txPackets == other.txPackets &&
-			txRate.bitRate == other.txRate.bitRate &&
-			txRate.chWidth == other.txRate.chWidth && txRate.mcs
-				.equals(other.txRate.mcs) &&
+			Objects.equals(txRate, other.txRate) &&
 			txRetries == other.txRetries && ackSignal == other.ackSignal &&
-			ackSignalAvg == other.ackSignalAvg && radio.equals(other.radio);
+			ackSignalAvg == other.ackSignalAvg &&
+			Objects.equals(radio, other.radio);
 	}
 
 	/**
@@ -209,10 +206,7 @@ public class AggregatedState {
 	 *         channel_width and tx_power
 	 */
 	public boolean add(AggregatedState state) {
-		if (
-			(bssid == null && station == null && radio == null) ||
-				hashCode() == state.hashCode()
-		) {
+		if (hashCode() == state.hashCode()) {
 			this.bssid = state.bssid;
 			this.station = state.station;
 			this.connected = state.connected;

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -10,40 +10,25 @@ package com.facebook.openwifirrm.ucentral.models;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association;
 import com.facebook.openwifirrm.ucentral.models.State.Interface.SSID.Association.Rate;
 
+/**
+ * Aggregation model for State aggregation. Only contains info useful for analysis.
+ */
 public class AggregatedState {
 
-	public class AggregatedRate {
-		public long bitrate;
-		public int chwidth;
+	public static class AggregatedRate {
+		public long bitRate;
+		public int chWidth;
 		public List<Integer> mcs;
 
 		/** Constructor with no args */
 		public AggregatedRate() {
-			this.mcs = new ArrayList<>();
-		}
-
-		/** Constructor */
-		public AggregatedRate(List<Rate> rates) {
-			int size = rates.size();
-			if (size == 0) {
-				return;
-			}
-			add(rates);
-		}
-
-		/** Add a list of Rates to the AggregatedRate */
-		public void add(List<Rate> rates) {
-			if (rates.isEmpty()) {
-				return;
-			}
-			for (Rate rate : rates) {
-				this.mcs.add(rate.mcs);
-			}
+			mcs = new ArrayList<>();
 		}
 
 		/** Add a Rate to the AggregatedRate */
@@ -52,22 +37,22 @@ public class AggregatedState {
 				return;
 			}
 			if (mcs == null || mcs.isEmpty()) {
-				this.bitrate = rate.bitrate;
-				this.chwidth = rate.chwidth;
+				bitRate = rate.bitrate;
+				chWidth = rate.chwidth;
 			}
-			this.mcs.add(rate.mcs);
+			mcs.add(rate.mcs);
 		}
 
 		/** Add an AggregatedRate with the same channel_width to the AggregatedRate */
 		public void add(AggregatedRate rate) {
-			if (rate.chwidth != chwidth) {
+			if (rate.chWidth != chWidth) {
 				return;
 			}
 			if (mcs == null || mcs.isEmpty()) {
-				this.bitrate = rate.bitrate;
-				this.chwidth = rate.chwidth;
+				bitRate = rate.bitRate;
+				chWidth = rate.chWidth;
 			}
-			this.mcs.addAll(rate.mcs);
+			mcs.addAll(rate.mcs);
 		}
 	}
 
@@ -76,41 +61,41 @@ public class AggregatedState {
 	public long connected;
 	public long inactive;
 	public List<Integer> rssi;
-	public long rx_bytes;
-	public long rx_packets;
-	public AggregatedRate rx_rate;
-	public long tx_bytes;
-	public long tx_duration;
-	public long tx_failed;
-	public long tx_packets;
-	public AggregatedRate tx_rate;
-	public long tx_retries;
-	public int ack_signal;
-	public int ack_signal_avg;
+	public long rxBytes;
+	public long rxPackets;
+	public AggregatedRate rxRate;
+	public long txBytes;
+	public long txDuration;
+	public long txFailed;
+	public long txPackets;
+	public AggregatedRate txRate;
+	public long txRetries;
+	public int ackSignal;
+	public int ackSignalAvg;
 	public Radio radio;
 
-	public class Radio {
+	public static class Radio {
 		public int channel;
-		public int channel_width;
-		public int tx_power;
+		public int channelWidth;
+		public int txPower;
 
 		public Radio() {}
 
-		public Radio(int channel, int channel_width, int tx_power) {
+		public Radio(int channel, int channelWidth, int txPower) {
 			this.channel = channel;
-			this.channel_width = channel_width;
-			this.tx_power = tx_power;
+			this.channelWidth = channelWidth;
+			this.txPower = txPower;
 		}
 
-		public Radio(int[] radios) {
-			this.channel = radios[0];
-			this.channel_width = radios[1];
-			this.tx_power = radios[2];
+		public Radio(Map<String, Integer> radioInfo) {
+			channel = radioInfo.getOrDefault("channel", null);
+			channelWidth = radioInfo.getOrDefault("channel_width", null);
+			txPower = radioInfo.getOrDefault("tx_power", null);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(channel, channel_width, tx_power);
+			return Objects.hash(channel, channelWidth, txPower);
 		}
 
 		@Override
@@ -127,8 +112,8 @@ public class AggregatedState {
 
 			Radio other = (Radio) obj;
 			return channel == other.channel &&
-				channel_width == other.channel_width &&
-				tx_power == other.tx_power;
+				channelWidth == other.channelWidth &&
+				txPower == other.txPower;
 		}
 	}
 
@@ -137,26 +122,60 @@ public class AggregatedState {
 		return Objects.hash(bssid, station, radio);
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+
+		AggregatedState other = (AggregatedState) obj;
+
+		return bssid == other.bssid &&
+			station == other.station &&
+			connected == other.connected && inactive == other.inactive && rssi
+				.equals(other.rssi) &&
+			rxBytes == other.rxBytes && rxBytes == other.rxPackets &&
+			rxRate.bitRate == other.rxRate.bitRate &&
+			rxRate.chWidth == other.rxRate.chWidth && rxRate.mcs
+				.equals(other.rxRate.mcs) &&
+			txBytes == other.txBytes && txDuration == other.txDuration &&
+			txFailed == other.txFailed && txPackets == other.txPackets &&
+			txRate.bitRate == other.txRate.bitRate &&
+			txRate.chWidth == other.txRate.chWidth && txRate.mcs
+				.equals(other.txRate.mcs) &&
+			txRetries == other.txRetries && ackSignal == other.ackSignal &&
+			ackSignalAvg == other.ackSignalAvg && radio.equals(other.radio);
+	}
+
 	/** Constructor with no args */
 	public AggregatedState() {
-		this.rx_rate = new AggregatedRate();
-		this.tx_rate = new AggregatedRate();
+		this.rxRate = new AggregatedRate();
+		this.txRate = new AggregatedRate();
 		this.rssi = new ArrayList<>();
 		this.radio = new Radio();
 	}
 
 	/** Construct from Aggregatedstate */
 	public AggregatedState(AggregatedState state) {
-		this.rx_rate = new AggregatedRate();
-		this.tx_rate = new AggregatedRate();
+		this.rxRate = new AggregatedRate();
+		this.txRate = new AggregatedRate();
 		this.rssi = new ArrayList<>();
 		add(state);
 	}
 
-	/** Construt from Asscociation and radio */
-	public AggregatedState(Association association, int[] radios) {
-		this.rx_rate = new AggregatedRate();
-		this.tx_rate = new AggregatedRate();
+	/** Construct from Association and radio */
+	public AggregatedState(
+		Association association,
+		Map<String, Integer> radioInfo
+	) {
+		this.rxRate = new AggregatedRate();
+		this.txRate = new AggregatedRate();
 		this.rssi = new ArrayList<>();
 
 		this.bssid = association.bssid;
@@ -164,21 +183,22 @@ public class AggregatedState {
 		this.connected = association.connected;
 		this.inactive = association.inactive;
 		this.rssi.add(association.rssi);
-		this.rx_bytes = association.rx_bytes;
-		this.rx_packets = association.rx_packets;
-		this.rx_rate.add(association.rx_rate);
-		this.tx_bytes = association.tx_bytes;
-		this.tx_duration = association.tx_duration;
-		this.tx_failed = association.tx_failed;
-		this.tx_packets = association.tx_packets;
-		this.tx_rate.add(association.tx_rate);
-		this.tx_retries = association.tx_retries;
-		this.ack_signal = association.ack_signal;
-		this.ack_signal_avg = association.ack_signal_avg;
-		this.radio = new Radio(radios);
+		this.rxBytes = association.rx_bytes;
+		this.rxPackets = association.rx_packets;
+		this.rxRate.add(association.rx_rate);
+		this.txBytes = association.tx_bytes;
+		this.txDuration = association.tx_duration;
+		this.txFailed = association.tx_failed;
+		this.txPackets = association.tx_packets;
+		this.txRate.add(association.tx_rate);
+		this.txRetries = association.tx_retries;
+		this.ackSignal = association.ack_signal;
+		this.ackSignalAvg = association.ack_signal_avg;
+		this.radio = new Radio(radioInfo);
 	}
 
-	/** Add an AggregatedState to this AggregatedState. Succeed only when the two
+	/**
+	 * Add an AggregatedState to this AggregatedState. Succeed only when the two
 	 * matches in hashCode.
 	 *
 	 * @param state input AggregatedState
@@ -191,21 +211,21 @@ public class AggregatedState {
 			this.connected = state.connected;
 			this.inactive = state.inactive;
 			this.rssi.addAll(state.rssi);
-			this.rx_bytes = state.rx_bytes;
-			this.rx_packets = state.rx_packets;
-			this.rx_rate.add(state.rx_rate);
-			this.tx_bytes = state.tx_bytes;
-			this.tx_duration = state.tx_duration;
-			this.tx_failed = state.tx_failed;
-			this.tx_packets = state.tx_packets;
-			this.tx_rate.add(state.tx_rate);
-			this.tx_retries = state.tx_retries;
-			this.ack_signal = state.ack_signal;
-			this.ack_signal_avg = state.ack_signal_avg;
+			this.rxBytes = state.rxBytes;
+			this.rxPackets = state.rxPackets;
+			this.rxRate.add(state.rxRate);
+			this.txBytes = state.txBytes;
+			this.txDuration = state.txDuration;
+			this.txFailed = state.txFailed;
+			this.txPackets = state.txPackets;
+			this.txRate.add(state.txRate);
+			this.txRetries = state.txRetries;
+			this.ackSignal = state.ackSignal;
+			this.ackSignalAvg = state.ackSignalAvg;
 			this.radio = new Radio(
 				state.radio.channel,
-				state.radio.channel_width,
-				state.radio.tx_power
+				state.radio.channelWidth,
+				state.radio.txPower
 			);
 			return true;
 		}

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -28,7 +28,6 @@ import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.models.AggregatedState;
 import com.facebook.openwifirrm.ucentral.models.State;
-import com.facebook.openwifirrm.ucentral.models.AggregatedState.Radio;
 
 public class ModelerUtilsTest {
 	@Test
@@ -716,7 +715,7 @@ public class ModelerUtilsTest {
 			TestUtils.DEFAULT_LOCAL_TIME - 800
 		);
 
-		//As State time3ToStateA is obsolescent, it should not be aggregated.
+		//As State time3ToStateA is obsolete, it should not be aggregated.
 		State time3ToStateA = TestUtils.createState(
 			1,
 			80,
@@ -730,7 +729,7 @@ public class ModelerUtilsTest {
 			bssidA,
 			new String[] { "stationA1", "staionA2" },
 			new int[] { 180, 180 },
-			// Set the localtime exactly obsolescent
+			// Set the localtime exactly obsolete
 			TestUtils.DEFAULT_LOCAL_TIME - obsoletionPeriodMs - 1
 		);
 
@@ -750,37 +749,48 @@ public class ModelerUtilsTest {
 				.getAggregatedStates(dataModel, obsoletionPeriodMs, refTimeMs);
 
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(), 2
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(),
+			2
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).radio, new AggregatedState().new Radio(1, 80, 1000)
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).radio,
+			new AggregatedState.Radio(1, 80, 1000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).rssi, new ArrayList<>(Arrays.asList(-84, 27))
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).rssi,
+			Arrays.asList(-84, 27)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).radio, new AggregatedState().new Radio(2, 40, 2000)
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).radio,
+			new AggregatedState.Radio(2, 40, 2000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).rssi, new ArrayList<>(Arrays.asList(-80))
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).rssi,
+			Arrays.asList(-80)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).radio, new AggregatedState().new Radio(1, 80, 1000)
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).radio,
+			new AggregatedState.Radio(1, 80, 1000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).rssi, new ArrayList<>(Arrays.asList(-67, -67))
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).rssi,
+			Arrays.asList(-67, -67)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).radio, new AggregatedState().new Radio(2, 40, 2000)
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).radio,
+			new AggregatedState.Radio(2, 40, 2000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).rssi, new ArrayList<>(Arrays.asList(180, 67))
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).rssi,
+			Arrays.asList(180, 67)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).radio, new AggregatedState().new Radio(1, 80, 1000)
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).radio,
+			new AggregatedState.Radio(1, 80, 1000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).rssi, new ArrayList<>(Arrays.asList(10, 100))
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).rssi,
+			Arrays.asList(10, 100)
 		);
 
 		// Test more clients operate on the same channel (stationB and stationA)
@@ -823,7 +833,8 @@ public class ModelerUtilsTest {
 		);
 
 		assertEquals(
-			aggregatedMap2.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(), aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size()
+			aggregatedMap2.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(),
+			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size()
 		);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -598,20 +598,20 @@ public class ModelerUtilsTest {
 		Map<String, List<AggregatedState>> bssidToAggregatedStates =
 			new HashMap<>();
 		bssidToAggregatedStates.put(
-			TestUtils.getBssidStationKeyPair(bssidA, stationA1),
+			ModelerUtils.getBssidStationKeyPair(bssidA, stationA1),
 			new ArrayList<>(Arrays.asList(aggStateA1))
 		);
 
 		bssidToAggregatedStates.put(
-			TestUtils.getBssidStationKeyPair(bssidA, stationA2),
+			ModelerUtils.getBssidStationKeyPair(bssidA, stationA2),
 			new ArrayList<>(Arrays.asList(aggStateA2))
 		);
 		bssidToAggregatedStates.put(
-			TestUtils.getBssidStationKeyPair(bssidB, stationB),
+			ModelerUtils.getBssidStationKeyPair(bssidB, stationB),
 			new ArrayList<>(Arrays.asList(aggStateB))
 		);
 		bssidToAggregatedStates.put(
-			TestUtils.getBssidStationKeyPair(bssidC, stationC),
+			ModelerUtils.getBssidStationKeyPair(bssidC, stationC),
 			new ArrayList<>(Arrays.asList(aggStateC))
 		);
 
@@ -630,20 +630,20 @@ public class ModelerUtilsTest {
 
 		assertEquals(
 			bssidToAggregatedStates
-				.get(TestUtils.getBssidStationKeyPair(bssidA, stationA1))
+				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1))
 				.get(0).rssi,
 			Arrays.asList(10, 20, 30)
 		);
 
 		assertEquals(
 			bssidToAggregatedStates
-				.get(TestUtils.getBssidStationKeyPair(bssidA, stationA1))
+				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1))
 				.get(1).rssi,
 			Arrays.asList(40, 50)
 		);
 		assertEquals(
 			bssidToAggregatedStates
-				.get(TestUtils.getBssidStationKeyPair(bssidA, stationA2))
+				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2))
 				.get(0).rssi,
 			Arrays.asList(20, 30, 40, 60)
 		);
@@ -661,7 +661,7 @@ public class ModelerUtilsTest {
 			.addStateToAggregation(bssidToAggregatedStates, toBeAggregated2);
 		assertEquals(
 			bssidToAggregatedStates
-				.get(TestUtils.getBssidStationKeyPair(bssidB, stationB))
+				.get(ModelerUtils.getBssidStationKeyPair(bssidB, stationB))
 				.get(0).rssi,
 			Arrays.asList(10, 20, 30, 40)
 		);
@@ -748,47 +748,47 @@ public class ModelerUtilsTest {
 				.getAggregatedStates(dataModel, obsoletionPeriodMs, refTimeMs);
 
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(),
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(),
 			2
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).radio,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).radio,
 			new AggregatedState.Radio(1, 80, 1000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).rssi,
 			Arrays.asList(-84, 27)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).radio,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).radio,
 			new AggregatedState.Radio(2, 40, 2000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).rssi,
 			Arrays.asList(-80)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).radio,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).radio,
 			new AggregatedState.Radio(1, 80, 1000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).rssi,
 			Arrays.asList(-67, -67)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).radio,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).radio,
 			new AggregatedState.Radio(2, 40, 2000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).rssi,
 			Arrays.asList(180, 67)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).radio,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).radio,
 			new AggregatedState.Radio(1, 80, 1000)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).rssi,
 			Arrays.asList(10, 100)
 		);
 
@@ -824,16 +824,16 @@ public class ModelerUtilsTest {
 				.getAggregatedStates(dataModel, obsoletionPeriodMs, refTimeMs);
 
 		assertEquals(
-			aggregatedMap2.get(serialNumberB).get(TestUtils.getBssidStationKeyPair(bssidB, "stationB")).get(0).rssi, Arrays.asList(-30)
+			aggregatedMap2.get(serialNumberB).get(ModelerUtils.getBssidStationKeyPair(bssidB, "stationB")).get(0).rssi, Arrays.asList(-30)
 		);
 
 		assertEquals(
-			aggregatedMap2.get(serialNumberC).get(TestUtils.getBssidStationKeyPair(bssidC, "stationC")).get(0).rssi, Arrays.asList(-100)
+			aggregatedMap2.get(serialNumberC).get(ModelerUtils.getBssidStationKeyPair(bssidC, "stationC")).get(0).rssi, Arrays.asList(-100)
 		);
 
 		assertEquals(
-			aggregatedMap2.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(),
-			aggregatedMap.get(serialNumberA).get(TestUtils.getBssidStationKeyPair(bssidA, "stationA1")).size()
+			aggregatedMap2.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(),
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).size()
 		);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -565,7 +565,7 @@ public class ModelerUtilsTest {
 		AggregatedState aggStateA1 = TestUtils.createAggregatedState(
 			1,
 			20,
-			100,
+			10,
 			bssidA,
 			stationA1,
 			new int[] { 10, 20, 30 }
@@ -573,7 +573,7 @@ public class ModelerUtilsTest {
 		AggregatedState aggStateA2 = TestUtils.createAggregatedState(
 			2,
 			20,
-			100,
+			10,
 			bssidA,
 			stationA2,
 			new int[] { 20, 30, 40 }
@@ -581,7 +581,7 @@ public class ModelerUtilsTest {
 		AggregatedState aggStateB = TestUtils.createAggregatedState(
 			3,
 			20,
-			200,
+			20,
 			bssidB,
 			stationB,
 			new int[] { 10, 20, 30 }
@@ -589,7 +589,7 @@ public class ModelerUtilsTest {
 		AggregatedState aggStateC = TestUtils.createAggregatedState(
 			1,
 			20,
-			100,
+			10,
 			bssidC,
 			stationC,
 			new int[] { 100, 200, 300 }
@@ -618,7 +618,7 @@ public class ModelerUtilsTest {
 		State toBeAggregated1 = TestUtils.createState(
 			2,
 			20,
-			100,
+			10,
 			bssidA,
 			new String[] { stationA1, stationA1, stationA2 },
 			new int[] { 40, 50, 60 },
@@ -651,7 +651,7 @@ public class ModelerUtilsTest {
 		State toBeAggregated2 = TestUtils.createState(
 			3,
 			20,
-			200,
+			20,
 			bssidB,
 			new String[] { stationB },
 			new int[] { 40 },

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -571,7 +571,7 @@ public class ModelerUtilsTest {
 			new int[] { 10, 20, 30 }
 		);
 		AggregatedState aggStateA2 = TestUtils.createAggregatedState(
-			2,
+			6,
 			20,
 			10,
 			bssidA,
@@ -579,7 +579,7 @@ public class ModelerUtilsTest {
 			new int[] { 20, 30, 40 }
 		);
 		AggregatedState aggStateB = TestUtils.createAggregatedState(
-			3,
+			11,
 			20,
 			20,
 			bssidB,
@@ -616,7 +616,7 @@ public class ModelerUtilsTest {
 		);
 
 		State toBeAggregated1 = TestUtils.createState(
-			2,
+			6,
 			20,
 			10,
 			bssidA,
@@ -649,7 +649,7 @@ public class ModelerUtilsTest {
 		);
 
 		State toBeAggregated2 = TestUtils.createState(
-			3,
+			11,
 			20,
 			20,
 			bssidB,

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -564,7 +564,7 @@ public class ModelerUtilsTest {
 
 		AggregatedState aggStateA1 = TestUtils.createAggregatedState(
 			1,
-			10,
+			20,
 			100,
 			bssidA,
 			stationA1,
@@ -572,7 +572,7 @@ public class ModelerUtilsTest {
 		);
 		AggregatedState aggStateA2 = TestUtils.createAggregatedState(
 			2,
-			10,
+			20,
 			100,
 			bssidA,
 			stationA2,
@@ -588,7 +588,7 @@ public class ModelerUtilsTest {
 		);
 		AggregatedState aggStateC = TestUtils.createAggregatedState(
 			1,
-			10,
+			20,
 			100,
 			bssidC,
 			stationC,
@@ -617,7 +617,7 @@ public class ModelerUtilsTest {
 
 		State toBeAggregated1 = TestUtils.createState(
 			2,
-			10,
+			20,
 			100,
 			bssidA,
 			new String[] { stationA1, stationA1, stationA2 },
@@ -676,57 +676,63 @@ public class ModelerUtilsTest {
 		final String bssidB = "bb:bb:bb:bb:bb:bb";
 		final String serialNumberC = "cccccccccccc";
 		final String bssidC = "cc:cc:cc:cc:cc:cc";
+		final String stationA1 = "stationA1";
+		final String stationA2 = "stationA2";
+		final String stationA3 = "stationA3";
+		final String stationA4 = "stationA4";
+		final String stationB = "stationB";
+		final String stationC = "stationC";
 
-		long refTimeMs = TestUtils.DEFAULT_LOCAL_TIME;
+		final long refTimeMs = TestUtils.DEFAULT_LOCAL_TIME;
 
 		DataModel dataModel = new DataModel();
 
 		// This serie of StateA is used to test a valid input states.
-		State time1ToStateA = TestUtils.createState(
+		State time1StateA = TestUtils.createState(
 			1,
 			80,
-			1000,
+			10,
 			bssidA,
-			new String[] { "stationA1", "stationA2", "stationA2", "stationA3" },
+			new String[] { stationA1, stationA2, stationA2, stationA3 },
 			new int[] { -84, -67, -67, 10 },
-			2,
+			6,
 			40,
-			2000,
+			20,
 			bssidA,
-			new String[] { "stationA1" },
+			new String[] { stationA1 },
 			new int[] { -80 },
 			TestUtils.DEFAULT_LOCAL_TIME
 		);
 
-		State time2ToStateA = TestUtils.createState(
+		State time2StateA = TestUtils.createState(
 			1,
 			80,
-			1000,
+			10,
 			bssidA,
-			new String[] { "stationA1", "stationA3" },
+			new String[] { stationA1, stationA3 },
 			new int[] { 27, 100 },
-			2,
+			6,
 			40,
-			2000,
+			20,
 			bssidA,
-			new String[] { "stationA2", "stationA2" },
+			new String[] { stationA2, stationA2 },
 			new int[] { 180, 67 },
 			TestUtils.DEFAULT_LOCAL_TIME - 800
 		);
 
-		//As State time3ToStateA is obsolete, it should not be aggregated.
-		State time3ToStateA = TestUtils.createState(
+		//As State time3StateA is obsolete, it should not be aggregated.
+		State time3StateA = TestUtils.createState(
 			1,
 			80,
-			1000,
+			10,
 			bssidA,
-			new String[] { "stationA1", "stationA2", "stationA4" },
+			new String[] { stationA1, stationA2, stationA4 },
 			new int[] { 24, 27, 1000 },
-			2,
+			6,
 			40,
-			2000,
+			20,
 			bssidA,
-			new String[] { "stationA1", "staionA2" },
+			new String[] { stationA1, stationA2 },
 			new int[] { 180, 180 },
 			// Set the localtime exactly obsolete
 			TestUtils.DEFAULT_LOCAL_TIME - obsoletionPeriodMs - 1
@@ -736,9 +742,9 @@ public class ModelerUtilsTest {
 			serialNumberA,
 			new ArrayList<>(
 				Arrays.asList(
-					time1ToStateA,
-					time2ToStateA,
-					time3ToStateA
+					time1StateA,
+					time2StateA,
+					time3StateA
 				)
 			)
 		);
@@ -748,92 +754,92 @@ public class ModelerUtilsTest {
 				.getAggregatedStates(dataModel, obsoletionPeriodMs, refTimeMs);
 
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(),
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).size(),
 			2
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).radio,
-			new AggregatedState.Radio(1, 80, 1000)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(0).radio,
+			new AggregatedState.Radio(1, 80, 10)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(0).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(0).rssi,
 			Arrays.asList(-84, 27)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).radio,
-			new AggregatedState.Radio(2, 40, 2000)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(1).radio,
+			new AggregatedState.Radio(6, 40, 20)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).get(1).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(1).rssi,
 			Arrays.asList(-80)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).radio,
-			new AggregatedState.Radio(1, 80, 1000)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(0).radio,
+			new AggregatedState.Radio(1, 80, 10)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(0).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(0).rssi,
 			Arrays.asList(-67, -67)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).radio,
-			new AggregatedState.Radio(2, 40, 2000)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(1).radio,
+			new AggregatedState.Radio(6, 40, 20)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA2")).get(1).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(1).rssi,
 			Arrays.asList(180, 67)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).radio,
-			new AggregatedState.Radio(1, 80, 1000)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA3)).get(0).radio,
+			new AggregatedState.Radio(1, 80, 10)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA3")).get(0).rssi,
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA3)).get(0).rssi,
 			Arrays.asList(10, 100)
 		);
 
 		// Test more clients operate on the same channel (stationB and stationA)
-		State time1ToStateB = TestUtils.createState(
+		State time1StateB = TestUtils.createState(
 			1,
 			80,
-			1000,
+			10,
 			bssidB,
-			new String[] { "stationB" },
+			new String[] { stationB },
 			new int[] { -30 },
 			TestUtils.DEFAULT_LOCAL_TIME
 		);
 		dataModel.latestStates
 			.computeIfAbsent(serialNumberB, k -> new ArrayList<>())
-			.add(time1ToStateB);
+			.add(time1StateB);
 
-		State time1ToStateC = TestUtils.createState(
-			2,
+		State time1StateC = TestUtils.createState(
+			6,
 			40,
-			2000,
+			20,
 			bssidC,
-			new String[] { "stationC" },
+			new String[] { stationC },
 			new int[] { -100 },
 			TestUtils.DEFAULT_LOCAL_TIME
 		);
 		dataModel.latestStates
 			.computeIfAbsent(serialNumberC, k -> new ArrayList<>())
-			.add(time1ToStateC);
+			.add(time1StateC);
 
 		Map<String, Map<String, List<AggregatedState>>> aggregatedMap2 =
 			ModelerUtils
 				.getAggregatedStates(dataModel, obsoletionPeriodMs, refTimeMs);
 
 		assertEquals(
-			aggregatedMap2.get(serialNumberB).get(ModelerUtils.getBssidStationKeyPair(bssidB, "stationB")).get(0).rssi, Arrays.asList(-30)
+			aggregatedMap2.get(serialNumberB).get(ModelerUtils.getBssidStationKeyPair(bssidB, stationB)).get(0).rssi, Arrays.asList(-30)
 		);
 
 		assertEquals(
-			aggregatedMap2.get(serialNumberC).get(ModelerUtils.getBssidStationKeyPair(bssidC, "stationC")).get(0).rssi, Arrays.asList(-100)
+			aggregatedMap2.get(serialNumberC).get(ModelerUtils.getBssidStationKeyPair(bssidC, stationC)).get(0).rssi, Arrays.asList(-100)
 		);
 
 		assertEquals(
-			aggregatedMap2.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).size(),
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, "stationA1")).size()
+			aggregatedMap2.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).size(),
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).size()
 		);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -599,20 +599,20 @@ public class ModelerUtilsTest {
 			new HashMap<>();
 		bssidToAggregatedStates.put(
 			TestUtils.getBssidStationKeyPair(bssidA, stationA1),
-			Arrays.asList(aggStateA1)
+			new ArrayList<>(Arrays.asList(aggStateA1))
 		);
 
 		bssidToAggregatedStates.put(
 			TestUtils.getBssidStationKeyPair(bssidA, stationA2),
-			Arrays.asList(aggStateA2)
+			new ArrayList<>(Arrays.asList(aggStateA2))
 		);
 		bssidToAggregatedStates.put(
 			TestUtils.getBssidStationKeyPair(bssidB, stationB),
-			Arrays.asList(aggStateB)
+			new ArrayList<>(Arrays.asList(aggStateB))
 		);
 		bssidToAggregatedStates.put(
 			TestUtils.getBssidStationKeyPair(bssidC, stationC),
-			Arrays.asList(aggStateC)
+			new ArrayList<>(Arrays.asList(aggStateC))
 		);
 
 		State toBeAggregated1 = TestUtils.createState(

--- a/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/ModelerUtilsTest.java
@@ -36,9 +36,9 @@ public class ModelerUtilsTest {
 		double[][][] rxPower = ModelerUtils.generateRxPower(
 			500,
 			4,
-			new ArrayList<>(Arrays.asList(408.0, 507.0, 64.0, 457.0)),
-			new ArrayList<>(Arrays.asList(317.0, 49.0, 140.0, 274.0)),
-			new ArrayList<>(Arrays.asList(20.0, 20.0, 20.0, 20.0))
+			Arrays.asList(408.0, 507.0, 64.0, 457.0),
+			Arrays.asList(317.0, 49.0, 140.0, 274.0),
+			Arrays.asList(20.0, 20.0, 20.0, 20.0)
 		);
 		assertNull(rxPower);
 	}
@@ -48,9 +48,9 @@ public class ModelerUtilsTest {
 		double[][][] rxPower = ModelerUtils.generateRxPower(
 			500,
 			4,
-			new ArrayList<>(Arrays.asList(408.0, 453.0, 64.0, 457.0)),
-			new ArrayList<>(Arrays.asList(317.0, 49.0, 140.0, 274.0)),
-			new ArrayList<>(Arrays.asList(20.0, 20.0, 20.0, 20.0))
+			Arrays.asList(408.0, 453.0, 64.0, 457.0),
+			Arrays.asList(317.0, 49.0, 140.0, 274.0),
+			Arrays.asList(20.0, 20.0, 20.0, 20.0)
 		);
 		assertEquals(-108.529, rxPower[0][0][0], 0.001);
 		double[][] heatMap = ModelerUtils.generateHeatMap(
@@ -78,9 +78,9 @@ public class ModelerUtilsTest {
 		double[][][] rxPower = ModelerUtils.generateRxPower(
 			500,
 			4,
-			new ArrayList<>(Arrays.asList(408.0, 453.0, 64.0, 457.0)),
-			new ArrayList<>(Arrays.asList(317.0, 49.0, 140.0, 274.0)),
-			new ArrayList<>(Arrays.asList(30.0, 30.0, 30.0, 30.0))
+			Arrays.asList(408.0, 453.0, 64.0, 457.0),
+			Arrays.asList(317.0, 49.0, 140.0, 274.0),
+			Arrays.asList(30.0, 30.0, 30.0, 30.0)
 		);
 		assertEquals(-98.529, rxPower[0][0][0], 0.001);
 		double[][] heatMap = ModelerUtils.generateHeatMap(
@@ -599,20 +599,20 @@ public class ModelerUtilsTest {
 			new HashMap<>();
 		bssidToAggregatedStates.put(
 			TestUtils.getBssidStationKeyPair(bssidA, stationA1),
-			new ArrayList<>(Arrays.asList(aggStateA1))
+			Arrays.asList(aggStateA1)
 		);
 
 		bssidToAggregatedStates.put(
 			TestUtils.getBssidStationKeyPair(bssidA, stationA2),
-			new ArrayList<>(Arrays.asList(aggStateA2))
+			Arrays.asList(aggStateA2)
 		);
 		bssidToAggregatedStates.put(
 			TestUtils.getBssidStationKeyPair(bssidB, stationB),
-			new ArrayList<>(Arrays.asList(aggStateB))
+			Arrays.asList(aggStateB)
 		);
 		bssidToAggregatedStates.put(
 			TestUtils.getBssidStationKeyPair(bssidC, stationC),
-			new ArrayList<>(Arrays.asList(aggStateC))
+			Arrays.asList(aggStateC)
 		);
 
 		State toBeAggregated1 = TestUtils.createState(
@@ -632,20 +632,20 @@ public class ModelerUtilsTest {
 			bssidToAggregatedStates
 				.get(TestUtils.getBssidStationKeyPair(bssidA, stationA1))
 				.get(0).rssi,
-			new ArrayList<>(Arrays.asList(10, 20, 30))
+			Arrays.asList(10, 20, 30)
 		);
 
 		assertEquals(
 			bssidToAggregatedStates
 				.get(TestUtils.getBssidStationKeyPair(bssidA, stationA1))
 				.get(1).rssi,
-			new ArrayList<>(Arrays.asList(40, 50))
+			Arrays.asList(40, 50)
 		);
 		assertEquals(
 			bssidToAggregatedStates
 				.get(TestUtils.getBssidStationKeyPair(bssidA, stationA2))
 				.get(0).rssi,
-			new ArrayList<>(Arrays.asList(20, 30, 40, 60))
+			Arrays.asList(20, 30, 40, 60)
 		);
 
 		State toBeAggregated2 = TestUtils.createState(
@@ -663,9 +663,8 @@ public class ModelerUtilsTest {
 			bssidToAggregatedStates
 				.get(TestUtils.getBssidStationKeyPair(bssidB, stationB))
 				.get(0).rssi,
-			new ArrayList<>(Arrays.asList(10, 20, 30, 40))
+			Arrays.asList(10, 20, 30, 40)
 		);
-
 	}
 
 	@Test

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -21,7 +21,9 @@ import com.facebook.openwifirrm.DeviceTopology;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.WifiScanEntry;
+import com.facebook.openwifirrm.ucentral.models.AggregatedState;
 import com.facebook.openwifirrm.ucentral.models.State;
+import com.facebook.openwifirrm.ucentral.models.State.Radio;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -38,6 +40,9 @@ public class TestUtils {
 	public static final int DEFAULT_CHANNEL_WIDTH = 20;
 	/** Default tx power in dBm */
 	public static final int DEFAULT_TX_POWER = 20;
+
+	/** Default local time in sec*/
+	public static final long DEFAULT_LOCAL_TIME = 1632527275;
 
 	/** Create a topology from the given devices in a single zone. */
 	public static DeviceTopology createTopology(
@@ -428,23 +433,25 @@ public class TestUtils {
 		return radio;
 	}
 
-	/** Create a {@code State.Unit}. */
-	private static State.Unit createStateUnit() {
+	/** Create a {@code State.Unit} with specifying localtime. */
+	private static State.Unit createStateUnit(Long localtime) {
 		// @formatter:off
+		String jsonStr = String.format(
+		"  {\n" +
+		"    \"load\": [\n" +
+		"      0,\n" +
+		"      0,\n" +
+		"      0\n" +
+		"    ],\n" +
+		"    \"localtime\": %d,\n" +
+		"    \"memory\": {\n" +
+		"      \"free\": 788930560,\n" +
+		"      \"total\": 973561856\n" +
+		"    },\n" +
+		"    \"uptime\": 684456\n" +
+		"  }\n", localtime);
 		return gson.fromJson(
-			"  {\n" +
-			"    \"load\": [\n" +
-			"      0,\n" +
-			"      0,\n" +
-			"      0\n" +
-			"    ],\n" +
-			"    \"localtime\": 1632527275,\n" +
-			"    \"memory\": {\n" +
-			"      \"free\": 788930560,\n" +
-			"      \"total\": 973561856\n" +
-			"    },\n" +
-			"    \"uptime\": 684456\n" +
-			"  }\n",
+			jsonStr,
 			State.Unit.class
 		);
 		// @formatter:on
@@ -463,7 +470,9 @@ public class TestUtils {
 	 * @param channelWidths array of channel widths (MHz)
 	 * @param txPowers array of tx powers (dBm)
 	 * @param bssids array of BSSIDs
+	 * @param stations 2-D array of client station codes
 	 * @param clientRssis 2-D array of client RSSIs
+	 * @param local time
 	 * @return the state of an AP with radios described by the given parameters
 	 */
 	public static State createState(
@@ -471,7 +480,9 @@ public class TestUtils {
 		int[] channelWidths,
 		int[] txPowers,
 		String[] bssids,
-		int[][] clientRssis
+		String[][] stations,
+		int[][] clientRssis,
+		long localtime
 	) {
 		if (
 			!(channels.length == channelWidths.length &&
@@ -503,10 +514,47 @@ public class TestUtils {
 					new State.Interface.SSID.Association();
 				state.interfaces[i].ssids[0].associations[j].rssi =
 					clientRssis[i][j];
+				state.interfaces[i].ssids[0].associations[j].station =
+					stations[i][j];
+				state.interfaces[i].ssids[0].associations[j].bssid = bssids[i];
+				state.interfaces[i].ssids[0].radio = gson
+					.fromJson(gson.toJson(state.radios[i]), JsonObject.class);
 			}
 		}
-		state.unit = createStateUnit();
+		state.unit = createStateUnit(localtime);
 		return state;
+	}
+
+	/**
+	 * Create a device state object with one radio.
+	 *
+	 * @param channel channel number
+	 * @param channelWidth channel width in MHz
+	 * @param txPower tx power in dBm
+	 * @param bssid bssid
+	 * @param stations array of station codes
+	 * @param clientRssis array of client RSSIs
+	 * @param localtime local time
+	 * @return the state of an AP with one radio
+	 */
+	public static State createState(
+		int channel,
+		int channelWidth,
+		int txPower,
+		String bssid,
+		String[] stations,
+		int[] clientRssis,
+		long localtime
+	) {
+		return createState(
+			new int[] { channel },
+			new int[] { channelWidth },
+			new int[] { txPower },
+			new String[] { bssid },
+			new String[][] { stations },
+			new int[][] { clientRssis },
+			localtime
+		);
 	}
 
 	/**
@@ -571,7 +619,9 @@ public class TestUtils {
 			new int[] { channelWidth },
 			new int[] { txPower },
 			new String[] { bssid },
-			new int[][] { clientRssis }
+			new String[][] { new String[clientRssis.length] },
+			new int[][] { clientRssis },
+			DEFAULT_LOCAL_TIME
 		);
 	}
 
@@ -644,7 +694,77 @@ public class TestUtils {
 			new int[] { channelWidthA, channelWidthB },
 			new int[] { txPowerA, txPowerB },
 			new String[] { bssidA, bssidB },
-			new int[][] { clientRssisA, clientRssisB }
+			new String[][] {},
+			new int[][] { clientRssisA, clientRssisB },
+			DEFAULT_LOCAL_TIME
+		);
+	}
+
+	public static AggregatedState createAggregatedState(
+		int channel,
+		int channelWidth,
+		int txPower,
+		String bssid,
+		String station,
+		int[] clientRssi
+	) {
+		AggregatedState state = new AggregatedState();
+		state.radio = state.new Radio(channel, channelWidth, txPower);
+		state.bssid = bssid;
+		state.station = station;
+		for (int rssi : clientRssi) {
+			state.rssi.add(rssi);
+		}
+		return state;
+	}
+
+	/**
+	* Create a device state object with two radios.
+	*
+	* @param channelA channel number
+	* @param channelWidthA channel width (MHz) of channelA
+	* @param txPowerA tx power for channelA
+	* @param bssidA bssid for radio on channelA
+	* @param clientRssisA array of client RSSIs for channelA
+	* @param channelB channel number
+	* @param channelWidthB channel width (MHz) of channelB
+	* @param txPowerB tx power for channelB
+	* @param bssidB bssid for radio on channelB
+	* @param clientRssisB array of client RSSIs for channelB
+	* @param localtime local time for the State
+	* @return the state of an AP with two radios
+	*/
+	public static State createState(
+		int channelA,
+		int channelWidthA,
+		int txPowerA,
+		String bssidA,
+		String[] stationsA,
+		int[] clientRssisA,
+		int channelB,
+		int channelWidthB,
+		int txPowerB,
+		String bssidB,
+		String[] stationsB,
+		int[] clientRssisB,
+		long localtime
+	) {
+		return createState(
+			new int[] { channelA, channelB },
+			new int[] { channelWidthA, channelWidthB },
+			new int[] { txPowerA, txPowerB },
+			new String[] { bssidA, bssidB },
+			new String[][] { stationsA, stationsB },
+			new int[][] { clientRssisA, clientRssisB },
+			localtime
+		);
+	}
+
+	public static String getBssidStationKeyPair(String bssid, String station) {
+		return String.format(
+			"bssid: %s, station: %s",
+			bssid,
+			station
 		);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -436,7 +436,7 @@ public class TestUtils {
 	}
 
 	/** Create a {@code State.Unit} with specifying localtime in unix timestamp in seconds. */
-	private static State.Unit createStateUnit(Long localtime) {
+	private static State.Unit createStateUnit(long localtime) {
 		// @formatter:off
 		String jsonStr = String.format(
 		"  {\n" +

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -653,54 +653,12 @@ public class TestUtils {
 		String bssidB
 	) {
 		return createState(
-			channelA,
-			channelWidthA,
-			txPowerA,
-			bssidA,
-			new int[] {},
-			channelB,
-			channelWidthB,
-			txPowerB,
-			bssidB,
-			new int[] {}
-		);
-	}
-
-	/**
-	 * Create a device state object with two radios.
-	 *
-	 * @param channelA channel number
-	 * @param channelWidthA channel width (MHz) of channelA
-	 * @param txPowerA tx power for channelA
-	 * @param bssidA bssid for radio on channelA
-	 * @param clientRssisA array of client RSSIs for channelA
-	 * @param channelB channel number
-	 * @param channelWidthB channel width (MHz) of channelB
-	 * @param txPowerB tx power for channelB
-	 * @param bssidB bssid for radio on channelB
-	 * @param clientRssisB array of client RSSIs for channelB
-	 * @return the state of an AP with two radios
-	 */
-	public static State createState(
-		int channelA,
-		int channelWidthA,
-		int txPowerA,
-		String bssidA,
-		int[] clientRssisA,
-		int channelB,
-		int channelWidthB,
-		int txPowerB,
-		String bssidB,
-		int[] clientRssisB
-	) {
-		return createState(
 			new int[] { channelA, channelB },
 			new int[] { channelWidthA, channelWidthB },
 			new int[] { txPowerA, txPowerB },
 			new String[] { bssidA, bssidB },
-			new String[][] { new String[clientRssisA.length],
-				new String[clientRssisB.length] },
-			new int[][] { clientRssisA, clientRssisB },
+			new String[][] {new String[]{}, new String[]{}},
+			new int[][] {new int[]{}, new int[]{}},
 			DEFAULT_LOCAL_TIME
 		);
 	}

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -41,9 +41,9 @@ public class TestUtils {
 	public static final int DEFAULT_TX_POWER = 20;
 
 	/**
-	 *  Default local time in unix time
+	 *  Default local time in unix timestamps in seconds
 	 * 	GMT: Fri Sep 24 2021 23:47:55 GMT+0000
-	*/
+	 */
 	public static final long DEFAULT_LOCAL_TIME = 1632527275;
 
 	/** Create a topology from the given devices in a single zone. */
@@ -435,7 +435,7 @@ public class TestUtils {
 		return radio;
 	}
 
-	/** Create a {@code State.Unit} with specifying localtime in unix timestamp. */
+	/** Create a {@code State.Unit} with specifying localtime in unix timestamp in seconds. */
 	private static State.Unit createStateUnit(Long localtime) {
 		// @formatter:off
 		String jsonStr = String.format(
@@ -536,7 +536,7 @@ public class TestUtils {
 	 * @param bssid bssid
 	 * @param stations array of station codes
 	 * @param clientRssis array of client RSSIs
-	 * @param localtime local time
+	 * @param localtime unix timestamp in seconds.
 	 * @return the state of an AP with one radio
 	 */
 	public static State createState(
@@ -762,11 +762,4 @@ public class TestUtils {
 		);
 	}
 
-	public static String getBssidStationKeyPair(String bssid, String station) {
-		return String.format(
-			"bssid: %s, station: %s",
-			bssid,
-			station
-		);
-	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -23,7 +23,6 @@ import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.WifiScanEntry;
 import com.facebook.openwifirrm.ucentral.models.AggregatedState;
 import com.facebook.openwifirrm.ucentral.models.State;
-import com.facebook.openwifirrm.ucentral.models.State.Radio;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -41,7 +40,10 @@ public class TestUtils {
 	/** Default tx power in dBm */
 	public static final int DEFAULT_TX_POWER = 20;
 
-	/** Default local time in sec*/
+	/**
+	 *  Default local time in unix time
+	 * 	GMT: Fri Sep 24 2021 23:47:55 GMT+0000
+	*/
 	public static final long DEFAULT_LOCAL_TIME = 1632527275;
 
 	/** Create a topology from the given devices in a single zone. */
@@ -433,7 +435,7 @@ public class TestUtils {
 		return radio;
 	}
 
-	/** Create a {@code State.Unit} with specifying localtime. */
+	/** Create a {@code State.Unit} with specifying localtime in unix timestamp. */
 	private static State.Unit createStateUnit(Long localtime) {
 		// @formatter:off
 		String jsonStr = String.format(
@@ -450,11 +452,11 @@ public class TestUtils {
 		"    },\n" +
 		"    \"uptime\": 684456\n" +
 		"  }\n", localtime);
+		// @formatter:on
 		return gson.fromJson(
 			jsonStr,
 			State.Unit.class
 		);
-		// @formatter:on
 	}
 
 	/**
@@ -472,7 +474,7 @@ public class TestUtils {
 	 * @param bssids array of BSSIDs
 	 * @param stations 2-D array of client station codes
 	 * @param clientRssis 2-D array of client RSSIs
-	 * @param local time
+	 * @param localtime
 	 * @return the state of an AP with radios described by the given parameters
 	 */
 	public static State createState(
@@ -709,7 +711,7 @@ public class TestUtils {
 		int[] clientRssi
 	) {
 		AggregatedState state = new AggregatedState();
-		state.radio = state.new Radio(channel, channelWidth, txPower);
+		state.radio = new AggregatedState.Radio(channel, channelWidth, txPower);
 		state.bssid = bssid;
 		state.station = station;
 		for (int rssi : clientRssi) {
@@ -723,12 +725,12 @@ public class TestUtils {
 	*
 	* @param channelA channel number
 	* @param channelWidthA channel width (MHz) of channelA
-	* @param txPowerA tx power for channelA
+	* @param txPowerA tx power (dB) for channelA
 	* @param bssidA bssid for radio on channelA
 	* @param clientRssisA array of client RSSIs for channelA
 	* @param channelB channel number
 	* @param channelWidthB channel width (MHz) of channelB
-	* @param txPowerB tx power for channelB
+	* @param txPowerB tx power (dB) for channelB
 	* @param bssidB bssid for radio on channelB
 	* @param clientRssisB array of client RSSIs for channelB
 	* @param localtime local time for the State

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -494,7 +494,7 @@ public class TestUtils {
 				stations.length == clientRssis.length)
 		) {
 			throw new IllegalArgumentException(
-				"All arguments must have the same length."
+				"All array-type arguments must have the same length."
 			);
 		}
 		final int numRadios = channels.length;
@@ -657,8 +657,8 @@ public class TestUtils {
 			new int[] { channelWidthA, channelWidthB },
 			new int[] { txPowerA, txPowerB },
 			new String[] { bssidA, bssidB },
-			new String[][] {new String[]{}, new String[]{}},
-			new int[][] {new int[]{}, new int[]{}},
+			new String[][] { new String[] {}, new String[] {} },
+			new int[][] { new int[] {}, new int[] {} },
 			DEFAULT_LOCAL_TIME
 		);
 	}
@@ -704,7 +704,7 @@ public class TestUtils {
 			localtime
 		);
 	}
-	
+
 	/**
 	 * Create an AggregatedState from given radio info.
 	 *

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -489,7 +489,9 @@ public class TestUtils {
 		if (
 			!(channels.length == channelWidths.length &&
 				channelWidths.length == txPowers.length &&
-				txPowers.length == bssids.length)
+				txPowers.length == bssids.length &&
+				channels.length == stations.length &&
+				stations.length == clientRssis.length)
 		) {
 			throw new IllegalArgumentException(
 				"All arguments must have the same length."
@@ -696,12 +698,24 @@ public class TestUtils {
 			new int[] { channelWidthA, channelWidthB },
 			new int[] { txPowerA, txPowerB },
 			new String[] { bssidA, bssidB },
-			new String[][] {},
+			new String[][] { new String[clientRssisA.length],
+				new String[clientRssisB.length] },
 			new int[][] { clientRssisA, clientRssisB },
 			DEFAULT_LOCAL_TIME
 		);
 	}
 
+	/**
+	 * Create an AggregatedState from given radio info.
+	 *
+	 * @param channel channel number
+	 * @param channelWidth channel width (MHz) of channelA
+	 * @param txPower tx power (db) for this channel
+	 * @param bssid bssid for radio on this channel
+	 * @param station station string for radio on this channel
+	 * @param clientRssi array of client RSSIs.
+	 * @return AggregatedState creating from the given radio.
+	 */
 	public static AggregatedState createAggregatedState(
 		int channel,
 		int channelWidth,

--- a/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/TestUtils.java
@@ -474,7 +474,7 @@ public class TestUtils {
 	 * @param bssids array of BSSIDs
 	 * @param stations 2-D array of client station codes
 	 * @param clientRssis 2-D array of client RSSIs
-	 * @param localtime
+	 * @param localtime unix timestamp in seconds.
 	 * @return the state of an AP with radios described by the given parameters
 	 */
 	public static State createState(
@@ -490,7 +490,7 @@ public class TestUtils {
 			!(channels.length == channelWidths.length &&
 				channelWidths.length == txPowers.length &&
 				txPowers.length == bssids.length &&
-				channels.length == stations.length &&
+				bssids.length == stations.length &&
 				stations.length == clientRssis.length)
 		) {
 			throw new IllegalArgumentException(
@@ -706,35 +706,6 @@ public class TestUtils {
 	}
 
 	/**
-	 * Create an AggregatedState from given radio info.
-	 *
-	 * @param channel channel number
-	 * @param channelWidth channel width (MHz) of channelA
-	 * @param txPower tx power (db) for this channel
-	 * @param bssid bssid for radio on this channel
-	 * @param station station string for radio on this channel
-	 * @param clientRssi array of client RSSIs.
-	 * @return AggregatedState creating from the given radio.
-	 */
-	public static AggregatedState createAggregatedState(
-		int channel,
-		int channelWidth,
-		int txPower,
-		String bssid,
-		String station,
-		int[] clientRssi
-	) {
-		AggregatedState state = new AggregatedState();
-		state.radio = new AggregatedState.Radio(channel, channelWidth, txPower);
-		state.bssid = bssid;
-		state.station = station;
-		for (int rssi : clientRssi) {
-			state.rssi.add(rssi);
-		}
-		return state;
-	}
-
-	/**
 	* Create a device state object with two radios.
 	*
 	* @param channelA channel number
@@ -775,5 +746,33 @@ public class TestUtils {
 			localtime
 		);
 	}
-
+	
+	/**
+	 * Create an AggregatedState from given radio info.
+	 *
+	 * @param channel channel number
+	 * @param channelWidth channel width (MHz) of channelA
+	 * @param txPower tx power (db) for this channel
+	 * @param bssid bssid for radio on this channel
+	 * @param station station string for radio on this channel
+	 * @param clientRssi array of client RSSIs.
+	 * @return AggregatedState creating from the given radio.
+	 */
+	public static AggregatedState createAggregatedState(
+		int channel,
+		int channelWidth,
+		int txPower,
+		String bssid,
+		String station,
+		int[] clientRssi
+	) {
+		AggregatedState state = new AggregatedState();
+		state.radio = new AggregatedState.Radio(channel, channelWidth, txPower);
+		state.bssid = bssid;
+		state.station = station;
+		for (int rssi : clientRssi) {
+			state.rssi.add(rssi);
+		}
+		return state;
+	}
 }

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizerTest.java
@@ -10,7 +10,6 @@ package com.facebook.openwifirrm.optimizers.channel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -58,11 +57,9 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils
-						.createState(aExpectedChannel, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils
+					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -85,9 +82,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -108,10 +103,8 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(149, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -156,11 +149,9 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils
-						.createState(aExpectedChannel, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils
+					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -183,9 +174,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(6, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(6, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -203,9 +192,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(6, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(6, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -258,11 +245,9 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils
-						.createState(aExpectedChannel, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils
+					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -284,9 +269,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -306,10 +289,8 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(149, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -362,11 +343,9 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils
-						.createState(aExpectedChannel, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils
+					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -390,9 +369,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -413,10 +390,8 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(149, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -463,11 +438,9 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils
-						.createState(aExpectedChannel, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils
+					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -492,9 +465,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -515,10 +486,8 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(149, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -539,9 +508,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceD,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceD,
@@ -594,11 +561,9 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils
-						.createState(aExpectedChannel, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils
+					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -621,9 +586,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(36, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(36, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -644,10 +607,8 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(149, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -670,9 +631,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceD,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(36, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(36, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceD,
@@ -697,11 +656,9 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceE,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils
-						.createState(aExpectedChannel, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils
+					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -748,11 +705,9 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils
-						.createState(aExpectedChannel, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils
+					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(
@@ -774,9 +729,7 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(48, channelWidth, dummyBssid))
-			)
+			Arrays.asList(TestUtils.createState(48, channelWidth, dummyBssid))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -808,10 +761,8 @@ public class LeastUsedChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(149, channelWidth, dummyBssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
 		);
 		dataModel.latestWifiScans.put(

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/LeastUsedChannelOptimizerTest.java
@@ -10,6 +10,7 @@ package com.facebook.openwifirrm.optimizers.channel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -55,9 +56,14 @@ public class LeastUsedChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -77,9 +83,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(40, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -98,9 +106,13 @@ public class LeastUsedChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(149, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(149, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -142,9 +154,14 @@ public class LeastUsedChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -164,9 +181,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 6)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(6, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(6, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -182,9 +201,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 6)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(6, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(6, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -235,9 +256,14 @@ public class LeastUsedChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -256,9 +282,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(40, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -276,9 +304,13 @@ public class LeastUsedChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(149, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(149, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -328,9 +360,14 @@ public class LeastUsedChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -351,9 +388,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(40, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -372,9 +411,13 @@ public class LeastUsedChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(149, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(149, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -418,9 +461,14 @@ public class LeastUsedChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -442,9 +490,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(40, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -463,9 +513,13 @@ public class LeastUsedChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(149, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(149, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -483,9 +537,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceD,
 			TestUtils.createDeviceStatus(band, 40)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceD,
-			TestUtils.createState(40, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceD,
@@ -536,9 +592,14 @@ public class LeastUsedChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -558,9 +619,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 36)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(36, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(36, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -579,9 +642,13 @@ public class LeastUsedChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(149, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(149, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -601,9 +668,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceD,
 			TestUtils.createDeviceStatus(band, 36)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceD,
-			TestUtils.createState(36, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(36, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceD,
@@ -626,9 +695,14 @@ public class LeastUsedChannelOptimizerTest {
 			deviceE,
 			TestUtils.createDeviceStatus(band, eExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceE,
-			TestUtils.createState(eExpectedChannel, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceE,
@@ -672,9 +746,14 @@ public class LeastUsedChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -693,9 +772,11 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 48)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(48, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(48, channelWidth, dummyBssid))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -725,9 +806,13 @@ public class LeastUsedChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(149, channelWidth, dummyBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(149, channelWidth, dummyBssid)
+				)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
@@ -11,7 +11,6 @@ package com.facebook.openwifirrm.optimizers.channel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Random;
@@ -50,18 +49,14 @@ public class RandomChannelInitializerTest {
 		DataModel dataModel = new DataModel();
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(6, channelWidth, deviceABssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(6, channelWidth, deviceABssid)
 			)
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(11, channelWidth, deviceBBssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(11, channelWidth, deviceBBssid)
 			)
 		);
 		dataModel.latestDeviceStatusRadios.put(
@@ -103,18 +98,14 @@ public class RandomChannelInitializerTest {
 		DataModel dataModel = new DataModel();
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(6, channelWidth, deviceABssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(6, channelWidth, deviceABssid)
 			)
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(11, channelWidth, deviceBBssid)
-				)
+			Arrays.asList(
+				TestUtils.createState(11, channelWidth, deviceBBssid)
 			)
 		);
 		dataModel.latestDeviceStatusRadios.put(

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/RandomChannelInitializerTest.java
@@ -11,6 +11,8 @@ package com.facebook.openwifirrm.optimizers.channel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Random;
 
@@ -46,13 +48,21 @@ public class RandomChannelInitializerTest {
 
 		// A and B will be assigned to the same channel
 		DataModel dataModel = new DataModel();
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(6, channelWidth, deviceABssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(6, channelWidth, deviceABssid)
+				)
+			)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(11, channelWidth, deviceBBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(11, channelWidth, deviceBBssid)
+				)
+			)
 		);
 		dataModel.latestDeviceStatusRadios.put(
 			deviceA,
@@ -91,13 +101,21 @@ public class RandomChannelInitializerTest {
 
 		// A and B will be assigned to the same channel
 		DataModel dataModel = new DataModel();
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(6, channelWidth, deviceABssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(6, channelWidth, deviceABssid)
+				)
+			)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(11, channelWidth, deviceBBssid)
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(11, channelWidth, deviceBBssid)
+				)
+			)
 		);
 		dataModel.latestDeviceStatusRadios.put(
 			deviceA,

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/UnmanagedApAwareChannelOptimizerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/UnmanagedApAwareChannelOptimizerTest.java
@@ -10,7 +10,6 @@ package com.facebook.openwifirrm.optimizers.channel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -59,13 +58,11 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays
-					.asList(
-						TestUtils
-							.createState(aExpectedChannel, channelWidth, bssidA)
-					)
-			)
+			Arrays
+				.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, bssidA)
+				)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -89,9 +86,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(40, channelWidth, bssidB))
-			)
+			Arrays.asList(TestUtils.createState(40, channelWidth, bssidB))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -125,9 +120,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(149, channelWidth, bssidC))
-			)
+			Arrays.asList(TestUtils.createState(149, channelWidth, bssidC))
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -173,13 +166,11 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays
-					.asList(
-						TestUtils
-							.createState(aExpectedChannel, channelWidth, bssidA)
-					)
-			)
+			Arrays
+				.asList(
+					TestUtils
+						.createState(aExpectedChannel, channelWidth, bssidA)
+				)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -201,9 +192,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(6, channelWidth, bssidB))
-			)
+			Arrays.asList(TestUtils.createState(6, channelWidth, bssidB))
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -221,9 +210,7 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(TestUtils.createState(6, channelWidth, bssidC))
-			)
+			Arrays.asList(TestUtils.createState(6, channelWidth, bssidC))
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,

--- a/src/test/java/com/facebook/openwifirrm/optimizers/channel/UnmanagedApAwareChannelOptimizerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/channel/UnmanagedApAwareChannelOptimizerTest.java
@@ -10,6 +10,7 @@ package com.facebook.openwifirrm.optimizers.channel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -56,9 +57,15 @@ public class UnmanagedApAwareChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, bssidA)
+			new ArrayList<>(
+				Arrays
+					.asList(
+						TestUtils
+							.createState(aExpectedChannel, channelWidth, bssidA)
+					)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -80,9 +87,11 @@ public class UnmanagedApAwareChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 40)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(40, channelWidth, bssidB)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(40, channelWidth, bssidB))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -114,9 +123,11 @@ public class UnmanagedApAwareChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 149)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(149, channelWidth, bssidC)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(149, channelWidth, bssidC))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -160,9 +171,15 @@ public class UnmanagedApAwareChannelOptimizerTest {
 			deviceA,
 			TestUtils.createDeviceStatus(band, aExpectedChannel)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(aExpectedChannel, channelWidth, bssidA)
+			new ArrayList<>(
+				Arrays
+					.asList(
+						TestUtils
+							.createState(aExpectedChannel, channelWidth, bssidA)
+					)
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceA,
@@ -182,9 +199,11 @@ public class UnmanagedApAwareChannelOptimizerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 6)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(6, channelWidth, bssidB)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(6, channelWidth, bssidB))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -200,9 +219,11 @@ public class UnmanagedApAwareChannelOptimizerTest {
 			deviceC,
 			TestUtils.createDeviceStatus(band, 6)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(6, channelWidth, bssidC)
+			new ArrayList<>(
+				Arrays.asList(TestUtils.createState(6, channelWidth, bssidC))
+			)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -132,17 +132,21 @@ public class LocationBasedOptimalTPCTest {
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
-			dataModel.latestState.put(
+			dataModel.latestStates.put(
 				device,
-				TestUtils.createState(
-					DEFAULT_CHANNEL_2G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid,
-					DEFAULT_CHANNEL_5G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid
+				new ArrayList<>(
+					Arrays.asList(
+						TestUtils.createState(
+							DEFAULT_CHANNEL_2G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid,
+							DEFAULT_CHANNEL_5G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid
+						)
+					)
 				)
 			);
 		}
@@ -199,18 +203,23 @@ public class LocationBasedOptimalTPCTest {
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
-			dataModel2.latestState.put(
+			dataModel2.latestStates.put(
 				device,
-				TestUtils.createState(
-					DEFAULT_CHANNEL_2G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid,
-					DEFAULT_CHANNEL_5G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid
+				new ArrayList<>(
+					Arrays.asList(
+						TestUtils.createState(
+							DEFAULT_CHANNEL_2G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid,
+							DEFAULT_CHANNEL_5G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid
+						)
+					)
 				)
+
 			);
 		}
 		dataModel2.latestDeviceStatusRadios
@@ -220,14 +229,19 @@ public class LocationBasedOptimalTPCTest {
 					Arrays.asList(UCentralConstants.BAND_5G)
 				)
 			);
-		dataModel2.latestState.put(
+		dataModel2.latestStates.put(
 			deviceC,
-			TestUtils.createState(
-				DEFAULT_CHANNEL_5G,
-				DEFAULT_CHANNEL_WIDTH,
-				DEFAULT_TX_POWER,
-				dummyBssid
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(
+						DEFAULT_CHANNEL_5G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid
+					)
+				)
 			)
+
 		);
 
 		Map<String, Map<String, Integer>> expected2 = new HashMap<>();
@@ -308,18 +322,23 @@ public class LocationBasedOptimalTPCTest {
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
-			dataModel2.latestState.put(
+			dataModel2.latestStates.put(
 				device,
-				TestUtils.createState(
-					DEFAULT_CHANNEL_2G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid,
-					DEFAULT_CHANNEL_5G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid
+				new ArrayList<>(
+					Arrays.asList(
+						TestUtils.createState(
+							DEFAULT_CHANNEL_2G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid,
+							DEFAULT_CHANNEL_5G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid
+						)
+					)
 				)
+
 			);
 		}
 
@@ -367,18 +386,23 @@ public class LocationBasedOptimalTPCTest {
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
-			dataModel3.latestState.put(
+			dataModel3.latestStates.put(
 				device,
-				TestUtils.createState(
-					DEFAULT_CHANNEL_2G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid,
-					DEFAULT_CHANNEL_5G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid
+				new ArrayList<>(
+					Arrays.asList(
+						TestUtils.createState(
+							DEFAULT_CHANNEL_2G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid,
+							DEFAULT_CHANNEL_5G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid
+						)
+					)
 				)
+
 			);
 		}
 
@@ -416,17 +440,21 @@ public class LocationBasedOptimalTPCTest {
 				device,
 				TestUtils.createDeviceStatus(UCentralConstants.BANDS)
 			);
-			dataModel4.latestState.put(
+			dataModel4.latestStates.put(
 				device,
-				TestUtils.createState(
-					DEFAULT_CHANNEL_2G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid,
-					DEFAULT_CHANNEL_2G,
-					DEFAULT_CHANNEL_WIDTH,
-					DEFAULT_TX_POWER,
-					dummyBssid
+				new ArrayList<>(
+					Arrays.asList(
+						TestUtils.createState(
+							DEFAULT_CHANNEL_2G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid,
+							DEFAULT_CHANNEL_2G,
+							DEFAULT_CHANNEL_WIDTH,
+							DEFAULT_TX_POWER,
+							dummyBssid
+						)
+					)
 				)
 			);
 		}

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -205,21 +205,18 @@ public class LocationBasedOptimalTPCTest {
 			);
 			dataModel2.latestStates.put(
 				device,
-				new ArrayList<>(
-					Arrays.asList(
-						TestUtils.createState(
-							DEFAULT_CHANNEL_2G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid,
-							DEFAULT_CHANNEL_5G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid
-						)
+				Arrays.asList(
+					TestUtils.createState(
+						DEFAULT_CHANNEL_2G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid,
+						DEFAULT_CHANNEL_5G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid
 					)
 				)
-
 			);
 		}
 		dataModel2.latestDeviceStatusRadios
@@ -231,17 +228,14 @@ public class LocationBasedOptimalTPCTest {
 			);
 		dataModel2.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(
-						DEFAULT_CHANNEL_5G,
-						DEFAULT_CHANNEL_WIDTH,
-						DEFAULT_TX_POWER,
-						dummyBssid
-					)
+			Arrays.asList(
+				TestUtils.createState(
+					DEFAULT_CHANNEL_5G,
+					DEFAULT_CHANNEL_WIDTH,
+					DEFAULT_TX_POWER,
+					dummyBssid
 				)
 			)
-
 		);
 
 		Map<String, Map<String, Integer>> expected2 = new HashMap<>();
@@ -324,21 +318,18 @@ public class LocationBasedOptimalTPCTest {
 			);
 			dataModel2.latestStates.put(
 				device,
-				new ArrayList<>(
-					Arrays.asList(
-						TestUtils.createState(
-							DEFAULT_CHANNEL_2G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid,
-							DEFAULT_CHANNEL_5G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid
-						)
+				Arrays.asList(
+					TestUtils.createState(
+						DEFAULT_CHANNEL_2G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid,
+						DEFAULT_CHANNEL_5G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid
 					)
 				)
-
 			);
 		}
 
@@ -388,21 +379,18 @@ public class LocationBasedOptimalTPCTest {
 			);
 			dataModel3.latestStates.put(
 				device,
-				new ArrayList<>(
-					Arrays.asList(
-						TestUtils.createState(
-							DEFAULT_CHANNEL_2G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid,
-							DEFAULT_CHANNEL_5G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid
-						)
+				Arrays.asList(
+					TestUtils.createState(
+						DEFAULT_CHANNEL_2G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid,
+						DEFAULT_CHANNEL_5G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid
 					)
 				)
-
 			);
 		}
 
@@ -442,18 +430,16 @@ public class LocationBasedOptimalTPCTest {
 			);
 			dataModel4.latestStates.put(
 				device,
-				new ArrayList<>(
-					Arrays.asList(
-						TestUtils.createState(
-							DEFAULT_CHANNEL_2G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid,
-							DEFAULT_CHANNEL_2G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid
-						)
+				Arrays.asList(
+					TestUtils.createState(
+						DEFAULT_CHANNEL_2G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid,
+						DEFAULT_CHANNEL_2G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid
 					)
 				)
 			);

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -134,18 +134,16 @@ public class LocationBasedOptimalTPCTest {
 			);
 			dataModel.latestStates.put(
 				device,
-				new ArrayList<>(
-					Arrays.asList(
-						TestUtils.createState(
-							DEFAULT_CHANNEL_2G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid,
-							DEFAULT_CHANNEL_5G,
-							DEFAULT_CHANNEL_WIDTH,
-							DEFAULT_TX_POWER,
-							dummyBssid
-						)
+				Arrays.asList(
+					TestUtils.createState(
+						DEFAULT_CHANNEL_2G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid,
+						DEFAULT_CHANNEL_5G,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						dummyBssid
 					)
 				)
 			);

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -92,13 +92,15 @@ public class MeasurementBasedApApTPCTest {
 		for (int i = 0; i < devices.size(); i++) {
 			String device = devices.get(i);
 			String bssid = bssids.get(i);
-			model.latestState.put(
+			model.latestStates.put(
 				device,
-				TestUtils.createState(
-					channel,
-					DEFAULT_CHANNEL_WIDTH,
-					MAX_TX_POWER,
-					bssid
+				Arrays.asList(
+					TestUtils.createState(
+						channel,
+						DEFAULT_CHANNEL_WIDTH,
+						MAX_TX_POWER,
+						bssid
+					)
 				)
 			);
 			model.latestDeviceStatusRadios.put(
@@ -130,17 +132,21 @@ public class MeasurementBasedApApTPCTest {
 		for (int i = 0; i < devices.size(); i++) {
 			String device = devices.get(i);
 			String bssid = bssids.get(i);
-			model.latestState.put(
+			model.latestStates.put(
 				device,
-				TestUtils.createState(
-					channel2G,
-					DEFAULT_CHANNEL_WIDTH,
-					MAX_TX_POWER,
-					bssid,
-					channel5G,
-					DEFAULT_CHANNEL_WIDTH,
-					MAX_TX_POWER,
-					bssid
+				new ArrayList<>(
+					Arrays.asList(
+						TestUtils.createState(
+							channel2G,
+							DEFAULT_CHANNEL_WIDTH,
+							MAX_TX_POWER,
+							bssid,
+							channel5G,
+							DEFAULT_CHANNEL_WIDTH,
+							MAX_TX_POWER,
+							bssid
+						)
+					)
 				)
 			);
 			model.latestDeviceStatusRadios.put(
@@ -569,13 +575,17 @@ public class MeasurementBasedApApTPCTest {
 		);
 
 		// now test when device C does not have a 5G radio
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			DEVICE_C,
-			TestUtils.createState(
-				1,
-				DEFAULT_CHANNEL_WIDTH,
-				MAX_TX_POWER,
-				BSSID_C
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(
+						1,
+						DEFAULT_CHANNEL_WIDTH,
+						MAX_TX_POWER,
+						BSSID_C
+					)
+				)
 			)
 		);
 		dataModel.latestDeviceStatusRadios.put(

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -134,18 +134,16 @@ public class MeasurementBasedApApTPCTest {
 			String bssid = bssids.get(i);
 			model.latestStates.put(
 				device,
-				new ArrayList<>(
-					Arrays.asList(
-						TestUtils.createState(
-							channel2G,
-							DEFAULT_CHANNEL_WIDTH,
-							MAX_TX_POWER,
-							bssid,
-							channel5G,
-							DEFAULT_CHANNEL_WIDTH,
-							MAX_TX_POWER,
-							bssid
-						)
+				Arrays.asList(
+					TestUtils.createState(
+						channel2G,
+						DEFAULT_CHANNEL_WIDTH,
+						MAX_TX_POWER,
+						bssid,
+						channel5G,
+						DEFAULT_CHANNEL_WIDTH,
+						MAX_TX_POWER,
+						bssid
 					)
 				)
 			);
@@ -577,14 +575,12 @@ public class MeasurementBasedApApTPCTest {
 		// now test when device C does not have a 5G radio
 		dataModel.latestStates.put(
 			DEVICE_C,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(
-						1,
-						DEFAULT_CHANNEL_WIDTH,
-						MAX_TX_POWER,
-						BSSID_C
-					)
+			Arrays.asList(
+				TestUtils.createState(
+					1,
+					DEFAULT_CHANNEL_WIDTH,
+					MAX_TX_POWER,
+					BSSID_C
 				)
 			)
 		);

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
@@ -174,12 +174,10 @@ public class MeasurementBasedApClientTPCTest {
 					20,
 					20,
 					null,
-					new int[] {},
 					36,
 					20,
 					20,
-					null,
-					new int[] {}
+					null
 				)
 			)
 		);

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
@@ -10,6 +10,7 @@ package com.facebook.openwifirrm.optimizers.tpc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -55,25 +56,52 @@ public class MeasurementBasedApClientTPCTest {
 		);
 
 		DataModel dataModel = new DataModel();
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(36, 20, 20, null, new int[] {})
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(36, 20, 20, null, new int[] {})
+				)
+			)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(36, 20, 20, "", new int[] { -65 })
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(36, 20, 20, "", new int[] { -65 })
+				)
+			)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(36, 40, 21, null, new int[] { -65, -73, -58 })
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(
+						36,
+						40,
+						21,
+						null,
+						new int[] { -65, -73, -58 }
+					)
+				)
+			)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceD,
-			TestUtils.createState(36, 20, 22, null, new int[] { -80 })
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(36, 20, 22, null, new int[] { -80 })
+				)
+			)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceE,
-			TestUtils.createState(36, 20, 23, null, new int[] { -45 })
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(36, 20, 23, null, new int[] { -45 })
+				)
+			)
+
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(
@@ -136,35 +164,53 @@ public class MeasurementBasedApClientTPCTest {
 
 		DataModel dataModel = new DataModel();
 		// 2G only
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(1, 20, 20, null, new int[] {})
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(1, 20, 20, null, new int[] {})
+				)
+			)
+
 		);
 		// 5G only
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(36, 20, 20, null, new int[] {})
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(36, 20, 20, null, new int[] {})
+				)
+			)
+
 		);
 		// 2G and 5G
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(
-				1,
-				20,
-				20,
-				null,
-				new int[] {},
-				36,
-				20,
-				20,
-				null,
-				new int[] {}
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(
+						1,
+						20,
+						20,
+						null,
+						new int[] {},
+						36,
+						20,
+						20,
+						null,
+						new int[] {}
+					)
+				)
 			)
 		);
 		// No valid bands in 2G or 5G
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceD,
-			TestUtils.createState(25, 20, 20, null, new int[] {})
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(25, 20, 20, null, new int[] {})
+				)
+			)
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(
@@ -220,17 +266,37 @@ public class MeasurementBasedApClientTPCTest {
 		deviceDataManager.setDeviceLayeredConfig(deviceLayeredConfig);
 
 		DataModel dataModel = new DataModel();
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceA,
-			TestUtils.createState(36, 20, 20, null, new int[] {})
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(36, 20, 20, null, new int[] {})
+				)
+			)
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceB,
-			TestUtils.createState(36, 20, 20, "", new int[] { -65 })
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(36, 20, 20, "", new int[] { -65 })
+				)
+			)
+
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			deviceC,
-			TestUtils.createState(36, 40, 21, null, new int[] { -65, -73, -58 })
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(
+						36,
+						40,
+						21,
+						null,
+						new int[] { -65, -73, -58 }
+					)
+				)
+			)
+
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
@@ -10,7 +10,6 @@ package com.facebook.openwifirrm.optimizers.tpc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -58,50 +57,39 @@ public class MeasurementBasedApClientTPCTest {
 		DataModel dataModel = new DataModel();
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(36, 20, 20, null, new int[] {})
-				)
+			Arrays.asList(
+				TestUtils.createState(36, 20, 20, null, new int[] {})
 			)
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(36, 20, 20, "", new int[] { -65 })
-				)
+			Arrays.asList(
+				TestUtils.createState(36, 20, 20, "", new int[] { -65 })
 			)
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(
-						36,
-						40,
-						21,
-						null,
-						new int[] { -65, -73, -58 }
-					)
+			Arrays.asList(
+				TestUtils.createState(
+					36,
+					40,
+					21,
+					null,
+					new int[] { -65, -73, -58 }
 				)
 			)
 		);
 		dataModel.latestStates.put(
 			deviceD,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(36, 20, 22, null, new int[] { -80 })
-				)
+			Arrays.asList(
+				TestUtils.createState(36, 20, 22, null, new int[] { -80 })
 			)
 		);
 		dataModel.latestStates.put(
 			deviceE,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(36, 20, 23, null, new int[] { -45 })
-				)
+			Arrays.asList(
+				TestUtils.createState(36, 20, 23, null, new int[] { -45 })
 			)
-
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(
@@ -166,50 +154,40 @@ public class MeasurementBasedApClientTPCTest {
 		// 2G only
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(1, 20, 20, null, new int[] {})
-				)
+			Arrays.asList(
+				TestUtils.createState(1, 20, 20, null, new int[] {})
 			)
-
 		);
 		// 5G only
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(36, 20, 20, null, new int[] {})
-				)
+			Arrays.asList(
+				TestUtils.createState(36, 20, 20, null, new int[] {})
 			)
-
 		);
 		// 2G and 5G
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(
-						1,
-						20,
-						20,
-						null,
-						new int[] {},
-						36,
-						20,
-						20,
-						null,
-						new int[] {}
-					)
+			Arrays.asList(
+				TestUtils.createState(
+					1,
+					20,
+					20,
+					null,
+					new int[] {},
+					36,
+					20,
+					20,
+					null,
+					new int[] {}
 				)
 			)
 		);
 		// No valid bands in 2G or 5G
 		dataModel.latestStates.put(
 			deviceD,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(25, 20, 20, null, new int[] {})
-				)
+			Arrays.asList(
+				TestUtils.createState(25, 20, 20, null, new int[] {})
 			)
 		);
 
@@ -268,35 +246,27 @@ public class MeasurementBasedApClientTPCTest {
 		DataModel dataModel = new DataModel();
 		dataModel.latestStates.put(
 			deviceA,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(36, 20, 20, null, new int[] {})
-				)
+			Arrays.asList(
+				TestUtils.createState(36, 20, 20, null, new int[] {})
 			)
 		);
 		dataModel.latestStates.put(
 			deviceB,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(36, 20, 20, "", new int[] { -65 })
-				)
+			Arrays.asList(
+				TestUtils.createState(36, 20, 20, "", new int[] { -65 })
 			)
-
 		);
 		dataModel.latestStates.put(
 			deviceC,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(
-						36,
-						40,
-						21,
-						null,
-						new int[] { -65, -73, -58 }
-					)
+			Arrays.asList(
+				TestUtils.createState(
+					36,
+					40,
+					21,
+					null,
+					new int[] { -65, -73, -58 }
 				)
 			)
-
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -20,6 +20,7 @@ import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Random;
@@ -63,26 +64,35 @@ public class RandomTxPowerInitializerTest {
 	 */
 	private static DataModel createModel() {
 		DataModel dataModel = new DataModel();
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			DEVICE_A,
-			TestUtils.createState(
-				36,
-				DEFAULT_CHANNEL_WIDTH,
-				DEFAULT_TX_POWER,
-				BSSID_A,
-				2,
-				DEFAULT_CHANNEL_WIDTH,
-				DEFAULT_TX_POWER,
-				BSSID_A
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(
+						36,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						BSSID_A,
+						2,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						BSSID_A
+					)
+				)
 			)
+
 		);
-		dataModel.latestState.put(
+		dataModel.latestStates.put(
 			DEVICE_B,
-			TestUtils.createState(
-				2,
-				DEFAULT_CHANNEL_WIDTH,
-				DEFAULT_TX_POWER,
-				BSSID_B
+			new ArrayList<>(
+				Arrays.asList(
+					TestUtils.createState(
+						2,
+						DEFAULT_CHANNEL_WIDTH,
+						DEFAULT_TX_POWER,
+						BSSID_B
+					)
+				)
 			)
 		);
 		return dataModel;

--- a/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -20,7 +20,6 @@ import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.optimizers.TestUtils;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Random;
@@ -66,32 +65,27 @@ public class RandomTxPowerInitializerTest {
 		DataModel dataModel = new DataModel();
 		dataModel.latestStates.put(
 			DEVICE_A,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(
-						36,
-						DEFAULT_CHANNEL_WIDTH,
-						DEFAULT_TX_POWER,
-						BSSID_A,
-						2,
-						DEFAULT_CHANNEL_WIDTH,
-						DEFAULT_TX_POWER,
-						BSSID_A
-					)
+			Arrays.asList(
+				TestUtils.createState(
+					36,
+					DEFAULT_CHANNEL_WIDTH,
+					DEFAULT_TX_POWER,
+					BSSID_A,
+					2,
+					DEFAULT_CHANNEL_WIDTH,
+					DEFAULT_TX_POWER,
+					BSSID_A
 				)
 			)
-
 		);
 		dataModel.latestStates.put(
 			DEVICE_B,
-			new ArrayList<>(
-				Arrays.asList(
-					TestUtils.createState(
-						2,
-						DEFAULT_CHANNEL_WIDTH,
-						DEFAULT_TX_POWER,
-						BSSID_B
-					)
+			Arrays.asList(
+				TestUtils.createState(
+					2,
+					DEFAULT_CHANNEL_WIDTH,
+					DEFAULT_TX_POWER,
+					BSSID_B
 				)
 			)
 		);


### PR DESCRIPTION
Signed-off-by: zhiqiand <zhiqian@fb.com>
### Summary
This PR aggregates State by bssid&station String and Radio. If two State matches in bssid, station, channel, channel_width and tx_power. Then the two need to be aggregated to an `AggregatedState`. In `AggregatedState`, rssi and mcs list all the values over the time.

The return aggregated map is a map from serial number to a map from bssid&station String to a list of `AggregatedState`.
`Map(Serial Number -> Map(bssid&station string -> List<AggregatedState>))`

Also keep only `latestStates` under `DataModel` instead of `latesState`. This PR fixes some bugs causing by this change.

### Implementation
For easy review, focus on `AggregatedState.java`, `ModelerUtils.java`, `ModelerUtilsTest.java` and `UtilsTest.java`.

- Create `AggregatedState` class, `AggregatedRate` and `Radio` are inner classes of `AggregatedState`. Override hashCode() under `AggregatedState` for checking if two `AggregatedStates` matches the aggregation rule. Method `AggregatedState.add()` is for easily aggregating two States of the same hashCode. 

- Mainly functional method is `ModelerUtils.getAggregatedStates()`, which aggregates all the non-obsolete State. `ModelerUtils.addStateToAggregation` is serves as a helper which aggregate one State to a list of AggregatedState.

### Follow up
- Will convert the aggregation result to json.
