### PR TITLE
[WIFI-10911] Use short instead of byte to store unsigned byte values in VHTOperationElement

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/ucentral/operationelement/VHTOperationElement.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/operationelement/VHTOperationElement.java
@@ -30,15 +30,23 @@ public class VHTOperationElement {
 	 * 160 MHz wide channel, this parameter is the channel number of the 80MHz
 	 * channel that contains the primary channel. For a 80+80 MHz wide channel, this
 	 * parameter is the channel number of the primary channel.
+	 * <p>
+	 * This field is an unsigned byte in the specification (i.e., with values
+	 * between 0 and 255). But because Java only supports signed bytes, a short
+	 * data type is used to store the value.
 	 */
-	public final byte channel1;
+	public final short channel1;
 	/**
 	 * This should be zero unless the channel is 160MHz or 80+80 MHz wide. If the
 	 * channel is 160 MHz wide, this parameter is the channel number of the 160 MHz
 	 * wide channel. If the channel is 80+80 MHz wide, this parameter is the channel
 	 * index of the secondary 80 MHz wide channel.
+	 * <p>
+	 * This field is an unsigned byte in the specification (i.e., with values
+	 * between 0 and 255). But because Java only supports signed bytes, a short
+	 * data type is used to store the value.
 	 */
-	public final byte channel2;
+	public final short channel2;
 	/**
 	 * An 8-element array where each element is between 0 and 4 inclusive. MCS means
 	 * Modulation and Coding Scheme. NSS means Number of Spatial Streams. There can
@@ -60,8 +68,8 @@ public class VHTOperationElement {
 	public VHTOperationElement(String vhtOper) {
 		byte[] bytes = Base64.decodeBase64(vhtOper);
 		this.channelWidth = bytes[0];
-		this.channel1 = bytes[1];
-		this.channel2 = bytes[2];
+		this.channel1 = (short) (bytes[1] & 0xff); // read as unsigned value
+		this.channel2 = (short) (bytes[2] & 0xff); // read as unsigned value
 		byte[] vhtMcsForNss = new byte[8];
 		vhtMcsForNss[0] = (byte) (bytes[3] >>> 6);
 		vhtMcsForNss[1] = (byte) ((bytes[3] & 0b00110000) >>> 4);
@@ -83,8 +91,8 @@ public class VHTOperationElement {
 	 */
 	public VHTOperationElement(
 		byte channelWidth,
-		byte channel1,
-		byte channel2,
+		short channel1,
+		short channel2,
 		byte[] vhtMcsForNss
 	) {
 		/*

--- a/src/test/java/com/facebook/openwifirrm/ucentral/operationelement/VHTOperationElementTest.java
+++ b/src/test/java/com/facebook/openwifirrm/ucentral/operationelement/VHTOperationElementTest.java
@@ -19,8 +19,8 @@ public class VHTOperationElementTest {
 		String vhtOper = "ACQAAAA=";
 		VHTOperationElement vhtOperObj = new VHTOperationElement(vhtOper);
 		byte expectedChannelWidthIndicator = 0; // 20 MHz channel width
-		byte expectedChannel1 = 36;
-		byte expectedChannel2 = 0;
+		short expectedChannel1 = 36;
+		short expectedChannel2 = 0;
 		byte[] expectedVhtMcsForNss = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
 		VHTOperationElement expectedVhtOperObj = new VHTOperationElement(
 			expectedChannelWidthIndicator,
@@ -50,6 +50,21 @@ public class VHTOperationElementTest {
 		expectedChannel1 = 42;
 		expectedChannel2 = 50;
 		// same vhtMcsForNss
+		expectedVhtOperObj = new VHTOperationElement(
+			expectedChannelWidthIndicator,
+			expectedChannel1,
+			expectedChannel2,
+			expectedVhtMcsForNss
+		);
+		assertEquals(expectedVhtOperObj, vhtOperObj);
+
+		// test with channel number >= 128 (channel fields should be unsigned)
+		vhtOper = "AJUAAAA=";
+		vhtOperObj = new VHTOperationElement(vhtOper);
+		expectedChannelWidthIndicator = 0;
+		expectedChannel1 = 149;
+		expectedChannel2 = 0;
+		expectedVhtMcsForNss = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
 		expectedVhtOperObj = new VHTOperationElement(
 			expectedChannelWidthIndicator,
 			expectedChannel1,


### PR DESCRIPTION
Cherry-pick #81 into release/v2.7.0 to address allow `VHTOperationElement` to store channel numbers greater than 127.

https://telecominfraproject.atlassian.net/browse/WIFI-10911