### PR TITLE
Update comments about validating tokens

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -302,12 +302,13 @@ public class ApiServer implements Runnable {
 	}
 
 	/**
-	 * Validate an OpenWiFi token (external), caching successful lookups.
+	 * Validate an OpenWiFi token (external), caching successful lookups. Both normal
+	 * token and subtoken is checked in the validateToken call already so there is
+	 * no need to call validateSubToken separately.
 	 * @return true if token is valid
 	 */
 	private boolean validateOpenWifiToken(String token) {
 		// The below only checks /api/v1/validateToken and caches it as necessary.
-		// TODO - /api/v1/validateSubToken still has to be implemented.
 		Long expiry = tokenCache.get(token);
 		if (expiry == null) {
 			TokenValidationResult result = client.validateToken(token);


### PR DESCRIPTION
`validateToken` already tries to validate normal tokens and subscriber tokens so there is no need to call `validateSubToken` separately: https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/adce4a823856c60a4a88980cfaa4e76ece432e2d/src/AuthService.cpp#L726-L745

Signed-off-by: Jun Woo Shin <jwoos@fb.com>