### PR TITLE
Update comment around token validation to clarify behavior

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ApiServer.java
@@ -302,9 +302,9 @@ public class ApiServer implements Runnable {
 	}
 
 	/**
-	 * Validate an OpenWiFi token (external), caching successful lookups. Both normal
-	 * token and subtoken is checked in the validateToken call already so there is
-	 * no need to call validateSubToken separately.
+	 * Validate an OpenWiFi token (external), caching successful lookups. This will
+	 * validate a USER token - subscriber token won't work and will fail (plus only
+	 * users should be dealing with RRM).
 	 * @return true if token is valid
 	 */
 	private boolean validateOpenWifiToken(String token) {


### PR DESCRIPTION
Clarified with Stephane that the validation of subtokens within the `validateToken` is a bug. This has been addressed so update the comment on RRM's end: https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/pull/75

Signed-off-by: Jun Woo Shin <jwoos@fb.com>