### PR TITLE
Refresh token when expired

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/ConfigManager.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ConfigManager.java
@@ -172,7 +172,7 @@ public class ConfigManager implements Runnable {
 			}
 		}
 		client.refreshAccessToken();
-		
+
 		// Fetch device list
 		List<DeviceWithStatus> devices = client.getDevices();
 		if (devices == null) {

--- a/src/main/java/com/facebook/openwifirrm/modules/ConfigManager.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ConfigManager.java
@@ -171,7 +171,8 @@ public class ConfigManager implements Runnable {
 				return;
 			}
 		}
-
+		client.refreshAccessToken();
+		
 		// Fetch device list
 		List<DeviceWithStatus> devices = client.getDevices();
 		if (devices == null) {

--- a/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
@@ -219,7 +219,7 @@ public class DataCollector implements Runnable {
 			}
 		}
 		client.refreshAccessToken();
-		
+
 		// Fetch device list
 		List<DeviceWithStatus> devices = client.getDevices();
 		if (devices == null) {

--- a/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/DataCollector.java
@@ -218,7 +218,8 @@ public class DataCollector implements Runnable {
 				return;
 			}
 		}
-
+		client.refreshAccessToken();
+		
 		// Fetch device list
 		List<DeviceWithStatus> devices = client.getDevices();
 		if (devices == null) {

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -239,7 +239,7 @@ public class Modeler implements Runnable {
 			}
 		}
 		client.refreshAccessToken();
-		
+
 		// TODO: backfill data from database?
 
 		// Fetch state from uCentralGw

--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -238,7 +238,8 @@ public class Modeler implements Runnable {
 				return;
 			}
 		}
-
+		client.refreshAccessToken();
+		
 		// TODO: backfill data from database?
 
 		// Fetch state from uCentralGw

--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -103,6 +103,7 @@ public class ProvMonitor implements Runnable {
 				return;
 			}
 		}
+		client.refreshAccessToken();
 
 		// Fetch data from owprov
 		// TODO: this may change later - for now, we only fetch inventory and

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralClient.java
@@ -143,6 +143,17 @@ public class UCentralClient {
 	private WebTokenResult accessToken;
 
 	/**
+	 * The unix timestamp (in seconds) keeps track of when the accessToken is created.
+	 */
+	private long created;
+
+	/**
+	 * The unix timestamp (in seconds) keeps track of last time when the accessToken 
+	 * is accessed.
+	 */
+	private long lastAccess;
+
+	/**
 	 * Constructor.
 	 * @param rrmEndpoint advertise this RRM endpoint to the SDK
 	 * @param usePublicEndpoints whether to use public or private endpoints
@@ -216,6 +227,8 @@ public class UCentralClient {
 			return false;
 		}
 		this.accessToken = token;
+		this.created = accessToken.created;
+		this.lastAccess = accessToken.created;
 		logger.info("Login successful as user: {}", username);
 		logger.debug("Access token: {}", accessToken.access_token);
 		logger.debug("Refresh token: {}", accessToken.refresh_token);
@@ -243,7 +256,7 @@ public class UCentralClient {
 		if (accessToken == null) {
 			return true;
 		}
-		return accessToken.created + accessToken.expires_in <
+		return created + accessToken.expires_in <
 			Instant.now().getEpochSecond();
 	}
 
@@ -256,7 +269,7 @@ public class UCentralClient {
 		if (accessToken == null) {
 			return true;
 		}
-		return accessToken.created + accessToken.idle_timeout <
+		return lastAccess + accessToken.idle_timeout <
 			Instant.now().getEpochSecond();
 	}
 
@@ -280,6 +293,8 @@ public class UCentralClient {
 				if (isAccessTokenTimedOut()) {
 					logger.debug("Access token timed out, refreshing the token");
 					accessToken = refreshToken();
+					created = Instant.now().getEpochSecond();
+					lastAccess = created;
 					if (accessToken != null) {
 						logger.debug("Successfully refresh token.");
 					}else{
@@ -448,6 +463,7 @@ public class UCentralClient {
 					"Authorization",
 					"Bearer " + accessToken.access_token
 				);
+				lastAccess = Instant.now().getEpochSecond();
 			}
 		} else {
 			req
@@ -501,6 +517,7 @@ public class UCentralClient {
 					"Authorization",
 					"Bearer " + accessToken.access_token
 				);
+				lastAccess = Instant.now().getEpochSecond();
 			}
 		} else {
 			req

--- a/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/WebTokenRefreshRequest.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/gw/models/WebTokenRefreshRequest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifirrm.ucentral.gw.models;
+
+public class WebTokenRefreshRequest {
+	public String userId;
+	public String refreshToken;
+}


### PR DESCRIPTION
Summary:
See Task: [T127668163](https://www.internalfb.com/intern/tasks/?t=127668163)
log: 
<img width="1391" alt="Screen Shot 2022-09-27 at 12 23 32 PM" src="https://user-images.githubusercontent.com/60716841/192618848-9db9e22b-5de2-402c-8cce-4b040d7b7dfd.png">

set `TOKEN_REFRESH_WINDOW_S` to very slow: will never hit the log to refresh access token. But print out this log in every `TOKEN_REFRESH_WINDOW_S`
<img width="1384" alt="Screen Shot 2022-09-27 at 12 22 27 PM" src="https://user-images.githubusercontent.com/60716841/192619426-6a050e06-4646-497b-a529-66552bd3a8c8.png">
