### PR TITLE
[WIFI-10819] parse cron into valid quartz cron

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -478,7 +478,7 @@ components:
     RRMSchedule:
       type: object
       properties:
-        cron:
+        crons:
           type: array
           items:
             type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -479,7 +479,9 @@ components:
       type: object
       properties:
         cron:
-          type: string
+          type: array
+          items:
+            type: string
         algorithms:
           type: array
           items:

--- a/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
@@ -19,9 +19,9 @@ public class RRMSchedule {
 	 *
 	 * This field expects a cron-like format as defined by the Quartz Job
 	 * Scheduler (CronTrigger):
-	 * https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html
+	 * https://www.quartz-scheduler.org/documentation/quartz-2.4.0/tutorials/crontrigger.html
 	 */
-	public String cron;
+	public String[] cron;
 
 	/**
 	 * The list of RRM algorithms to run.

--- a/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
@@ -21,7 +21,7 @@ public class RRMSchedule {
 	 * Scheduler (CronTrigger):
 	 * https://www.quartz-scheduler.org/documentation/quartz-2.4.0/tutorials/crontrigger.html
 	 */
-	public String[] cron;
+	public List<String> cron;
 
 	/**
 	 * The list of RRM algorithms to run.

--- a/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
+++ b/src/main/java/com/facebook/openwifirrm/RRMSchedule.java
@@ -21,7 +21,7 @@ public class RRMSchedule {
 	 * Scheduler (CronTrigger):
 	 * https://www.quartz-scheduler.org/documentation/quartz-2.4.0/tutorials/crontrigger.html
 	 */
-	public List<String> cron;
+	public List<String> crons;
 
 	/**
 	 * The list of RRM algorithms to run.

--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -159,12 +159,22 @@ public class ProvMonitor implements Runnable {
 			return null;
 		}
 
-		RRMSchedule schedule = new RRMSchedule();
-		schedule.cron = RRMScheduler
+		// RRMScheduler.parseIntoQuartzCron will only return an array of length 1 or 2
+		String[] crons = RRMScheduler
 			.parseIntoQuartzCron(details.rrm.schedule);
-		if (schedule.cron == null || schedule.cron.isEmpty()) {
+		if (crons == null || crons.length == 0) {
 			return null;
 		}
+		// if ANY crons are invalid throw it out since it doesn't make sense to
+		// schedule partial jobs
+		for (String cron : crons) {
+			if (cron == null || cron.isEmpty()) {
+				return null;
+			}
+		}
+
+		RRMSchedule schedule = new RRMSchedule();
+		schedule.cron = crons;
 
 		if (details.rrm.algorithms != null) {
 			schedule.algorithms =
@@ -175,6 +185,7 @@ public class ProvMonitor implements Runnable {
 					)
 					.collect(Collectors.toList());
 		}
+
 		return schedule;
 	}
 

--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -8,6 +8,7 @@
 
 package com.facebook.openwifirrm.modules;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -159,7 +160,6 @@ public class ProvMonitor implements Runnable {
 			return null;
 		}
 
-		// RRMScheduler.parseIntoQuartzCron will only return an array of length 1 or 2
 		String[] crons = RRMScheduler
 			.parseIntoQuartzCron(details.rrm.schedule);
 		if (crons == null || crons.length == 0) {
@@ -174,7 +174,7 @@ public class ProvMonitor implements Runnable {
 		}
 
 		RRMSchedule schedule = new RRMSchedule();
-		schedule.cron = crons;
+		schedule.cron = Arrays.asList(crons);
 
 		if (details.rrm.algorithms != null) {
 			schedule.algorithms =

--- a/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ProvMonitor.java
@@ -174,7 +174,7 @@ public class ProvMonitor implements Runnable {
 		}
 
 		RRMSchedule schedule = new RRMSchedule();
-		schedule.cron = Arrays.asList(crons);
+		schedule.crons = Arrays.asList(crons);
 
 		if (details.rrm.algorithms != null) {
 			schedule.algorithms =

--- a/src/main/java/com/facebook/openwifirrm/modules/RRMScheduler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/RRMScheduler.java
@@ -261,14 +261,14 @@ public class RRMScheduler {
 			DeviceConfig config = deviceDataManager.getZoneConfig(zone);
 			RRMSchedule schedule = config.schedule;
 			if (
-				schedule == null || schedule.cron == null ||
-					schedule.cron.isEmpty()
+				schedule == null || schedule.crons == null ||
+					schedule.crons.isEmpty()
 			) {
 				continue; // RRM not scheduled
 			}
 
-			for (int i = 0; i < schedule.cron.size(); i++) {
-				String cron = schedule.cron.get(i);
+			for (int i = 0; i < schedule.crons.size(); i++) {
+				String cron = schedule.crons.get(i);
 				// if even one schedule has invalid cron, the whole thing is probably wrong
 				if (cron == null || cron.isEmpty()) {
 					logger.error("There was an invalid cron in the schedule");
@@ -281,7 +281,7 @@ public class RRMScheduler {
 					logger.error(
 						String.format(
 							"Invalid cron expression (%s) for zone %s",
-							schedule.cron,
+							cron,
 							zone
 						),
 						e

--- a/src/main/java/com/facebook/openwifirrm/modules/RRMScheduler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/RRMScheduler.java
@@ -77,10 +77,9 @@ public class RRMScheduler {
 
 	/**
 	 * The job keys with active triggers scheduled. Job keys take the format of
-	 * <zone>:<index>, where index applies only if there are multiple schedules for
-	 * one zone
+	 * {@code <zone>:<index>}
 	 *
-	 * @see RRMScheduler.parseIntoQuartzCron
+	 * @see #parseIntoQuartzCron(String)
 	 * */
 	private Set<String> scheduledJobKeys;
 
@@ -134,8 +133,7 @@ public class RRMScheduler {
 		final int DAY_OF_MONTH_INDEX = 3;
 		final int DAY_OF_WEEK_INDEX = 5;
 
-		// make a copy since it's possible it'll be used below
-		String dayOfMonth = new String(split[DAY_OF_MONTH_INDEX]);
+		String dayOfMonth = split[DAY_OF_MONTH_INDEX];
 		String dayOfWeek = split[DAY_OF_WEEK_INDEX];
 
 		// Quartz uses 1-7, while standard cron expects 0-6 so replace all
@@ -168,6 +166,10 @@ public class RRMScheduler {
 				!CronExpression.isValidExpression(dayOfWeekCron) ||
 					!CronExpression.isValidExpression(dayOfMonthCron)
 			) {
+				logger.error(
+					"Unable to parse cron {} into valid crons",
+					linuxCron
+				);
 				return null;
 			}
 
@@ -260,23 +262,16 @@ public class RRMScheduler {
 			RRMSchedule schedule = config.schedule;
 			if (
 				schedule == null || schedule.cron == null ||
-					schedule.cron.length == 0
+					schedule.cron.isEmpty()
 			) {
 				continue; // RRM not scheduled
 			}
 
-			if (
-				schedule.cron == null ||
-					schedule.cron.length == 0
-			) {
-				continue;
-			}
-
-			for (int i = 0; i < schedule.cron.length; i++) {
-				String cron = schedule.cron[i];
-
+			for (int i = 0; i < schedule.cron.size(); i++) {
+				String cron = schedule.cron.get(i);
 				// if even one schedule has invalid cron, the whole thing is probably wrong
 				if (cron == null || cron.isEmpty()) {
+					logger.error("There was an invalid cron in the schedule");
 					break;
 				}
 

--- a/src/test/java/com/facebook/openwifirrm/modules/RRMSchedulerTest.java
+++ b/src/test/java/com/facebook/openwifirrm/modules/RRMSchedulerTest.java
@@ -9,7 +9,7 @@
 package com.facebook.openwifirrm.modules;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,48 +23,48 @@ public class RRMSchedulerTest {
 		assertNull(RRMScheduler.parseIntoQuartzCron("* * * * * * * *"));
 
 		// correct (6 fields)
-		assertEquals(
-			"* * * ? * *",
+		assertArrayEquals(
+			new String[] { "* * * ? * *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * *")
 		);
 
 		// correct (7 fields)
-		assertEquals(
-			"* * * ? * * *",
+		assertArrayEquals(
+			new String[] { "* * * ? * * *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * * *")
 		);
 
 		// correct value other than * for day of month
-		assertEquals(
-			"* * * 1 * ?",
+		assertArrayEquals(
+			new String[] { "* * * 1 * ?" },
 			RRMScheduler.parseIntoQuartzCron("* * * 1 * *")
 		);
-		assertEquals(
-			"* * * 1 * ? *",
+		assertArrayEquals(
+			new String[] { "* * * 1 * ? *" },
 			RRMScheduler.parseIntoQuartzCron("* * * 1 * * *")
 		);
-		assertEquals(
-			"* * * 1/2 * ?",
+		assertArrayEquals(
+			new String[] { "* * * 1/2 * ?" },
 			RRMScheduler.parseIntoQuartzCron("* * * 1/2 * *")
 		);
-		assertEquals(
-			"* * * 1/2 * ? *",
+		assertArrayEquals(
+			new String[] { "* * * 1/2 * ? *" },
 			RRMScheduler.parseIntoQuartzCron("* * * 1/2 * * *")
 		);
-		assertEquals(
-			"* * * 1-2 * ?",
+		assertArrayEquals(
+			new String[] { "* * * 1-2 * ?" },
 			RRMScheduler.parseIntoQuartzCron("* * * 1-2 * *")
 		);
-		assertEquals(
-			"* * * 1-2 * ? *",
+		assertArrayEquals(
+			new String[] { "* * * 1-2 * ? *" },
 			RRMScheduler.parseIntoQuartzCron("* * * 1-2 * * *")
 		);
-		assertEquals(
-			"* * * 1,2 * ?",
+		assertArrayEquals(
+			new String[] { "* * * 1,2 * ?" },
 			RRMScheduler.parseIntoQuartzCron("* * * 1,2 * *")
 		);
-		assertEquals(
-			"* * * 1,2 * ? *",
+		assertArrayEquals(
+			new String[] { "* * * 1,2 * ? *" },
 			RRMScheduler.parseIntoQuartzCron("* * * 1,2 * * *")
 		);
 
@@ -79,70 +79,70 @@ public class RRMSchedulerTest {
 		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * * *"));
 
 		// correct value other than * for day of month
-		assertEquals(
-			"* * * ? * 1",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1")
 		);
-		assertEquals(
-			"* * * ? * 1 *",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1 *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1 *")
 		);
-		assertEquals(
-			"* * * ? * 1/3",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/3" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1/3")
 		);
-		assertEquals(
-			"* * * ? * 1/3 *",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/3 *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1/3 *")
 		);
-		assertEquals(
-			"* * * ? * 1-3",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-3" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1-3")
 		);
-		assertEquals(
-			"* * * ? * 1-3 *",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-3 *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1-3 *")
 		);
-		assertEquals(
-			"* * * ? * 1,3",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1,3" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1,3")
 		);
-		assertEquals(
-			"* * * ? * 1,3 *",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1,3 *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1,3 *")
 		);
 
 		// correct value other than * for day of month, make sure 0 turns into 7
-		assertEquals(
-			"* * * ? * 7",
+		assertArrayEquals(
+			new String[] { "* * * ? * 7" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 0")
 		);
-		assertEquals(
-			"* * * ? * 7 *",
+		assertArrayEquals(
+			new String[] { "* * * ? * 7 *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 0 *")
 		);
-		assertEquals(
-			"* * * ? * 1/7",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/7" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1/0")
 		);
-		assertEquals(
-			"* * * ? * 1/7 *",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/7 *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1/0 *")
 		);
-		assertEquals(
-			"* * * ? * 1-7",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-7" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1-0")
 		);
-		assertEquals(
-			"* * * ? * 1-7 *",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-7 *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1-0 *")
 		);
-		assertEquals(
-			"* * * ? * 1,7",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1,7" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1,0")
 		);
-		assertEquals(
-			"* * * ? * 1,7 *",
+		assertArrayEquals(
+			new String[] { "* * * ? * 1,7 *" },
 			RRMScheduler.parseIntoQuartzCron("* * * * * 1,0 *")
 		);
 
@@ -155,5 +155,119 @@ public class RRMSchedulerTest {
 		assertNull(RRMScheduler.parseIntoQuartzCron("* * * * * 7-8 *"));
 		assertNull(RRMScheduler.parseIntoQuartzCron("* * * * * 7,8"));
 		assertNull(RRMScheduler.parseIntoQuartzCron("* * * * * 7,8 *"));
+
+		// correct value for both day of week and day of month
+		assertArrayEquals(
+			new String[] { "* * * ? * 7", "* * * 1 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1 * 0")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 7 *", "* * * 1 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1 * 0 *")
+		);
+
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/7", "* * * 1 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1 * 1/0")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1", "* * * 1/2 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1/2 * 1")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/7", "* * * 1/2 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1/2 * 1/0")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/7 *", "* * * 1 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1 * 1/0 *")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1 *", "* * * 1/2 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1/2 * 1 *")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/7 *", "* * * 1/2 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1/2 * 1/0 *")
+		);
+
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-7", "* * * 1 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1 * 1-0")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1", "* * * 1-3 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1-3 * 1")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-7", "* * * 1-3 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1-3 * 1-0")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-7 *", "* * * 1 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1 * 1-0 *")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1 *", "* * * 1-3 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1-3 * 1 *")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-7 *", "* * * 1-3 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1-3 * 1-0 *")
+		);
+
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-7", "* * * 1/3 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1/3 * 1-0")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/7", "* * * 1-3 * ?" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1-3 * 1/0")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1-7 *", "* * * 1/3 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1/3 * 1-0 *")
+		);
+		assertArrayEquals(
+			new String[] { "* * * ? * 1/7 *", "* * * 1-3 * ? *" },
+			RRMScheduler.parseIntoQuartzCron("* * * 1-3 * 1/0 *")
+		);
+
+		// wrong value for either day of week or day of month
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0 * 8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0 * 8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0 * 7/8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0 * 7/8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0 * 7-8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0 * 7-8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0 * 7,8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0 * 7,8 *"));
+
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0/1 * 8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0/1 * 8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0/1 * 7/8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0/1 * 7/8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0/1 * 7-8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0/1 * 7-8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0/1 * 7,8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0/1 * 7,8 *"));
+
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0-1 * 8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0-1 * 8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0-1 * 7/8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0-1 * 7/8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0-1 * 7-8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0-1 * 7-8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0-1 * 7,8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0-1 * 7,8 *"));
+
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * 8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * 8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * 7/8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * 7/8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * 7-8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * 7-8 *"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * 7,8"));
+		assertNull(RRMScheduler.parseIntoQuartzCron("* * * 0,1 * 7,8 *"));
 	}
 }


### PR DESCRIPTION
Linux cron is weird and ORs the day of month and day of week values are both not `*`. Quartz is even weirder in that it can't support crons with both values specified.

>  Note: The day of a command's execution can be specified in the
       following two fields — 'day of month', and 'day of week'.  If
       both fields are restricted (i.e., do not contain the "*"
       character), the command will be run when either field matches the
       current time.  For example,
       "30 4 1,15 * 5" would cause a command to be run at 4:30 am on the
       1st and 15th of each month, plus every Friday.

From https://man7.org/linux/man-pages/man5/crontab.5.html

Since it's simply matching either of them, split them out into two different crons and register them both. I had to change the type of a field, which may or may not cause problems depending on if there is a configuration file to read or not.

Signed-off-by: Jun Woo Shin <jwoos@fb.com>