### PR TITLE
Rename HTOperationElement, HTOperationElementTest, VHTOperationElement, and VHTOperationElementTest

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/ModelerUtils.java
@@ -22,8 +22,8 @@ import com.facebook.openwifirrm.aggregators.Aggregator;
 import com.facebook.openwifirrm.aggregators.MeanAggregator;
 import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.ucentral.WifiScanEntry;
-import com.facebook.openwifirrm.ucentral.informationelement.HTOperationElement;
-import com.facebook.openwifirrm.ucentral.informationelement.VHTOperationElement;
+import com.facebook.openwifirrm.ucentral.informationelement.HTOperation;
+import com.facebook.openwifirrm.ucentral.informationelement.VHTOperation;
 
 /**
  * Modeler utilities.
@@ -239,9 +239,9 @@ public class ModelerUtils {
 		return Objects.equals(entry1.bssid, entry2.bssid) &&
 			entry1.frequency == entry2.frequency &&
 			entry1.channel == entry2.channel &&
-			HTOperationElement
+			HTOperation
 				.matchesHtForAggregation(entry1.ht_oper, entry2.ht_oper) &&
-			VHTOperationElement
+			VHTOperation
 				.matchesVhtForAggregation(entry1.vht_oper, entry2.vht_oper);
 	}
 

--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
@@ -25,8 +25,8 @@ import com.facebook.openwifirrm.modules.Modeler.DataModel;
 import com.facebook.openwifirrm.ucentral.UCentralConstants;
 import com.facebook.openwifirrm.ucentral.UCentralUtils;
 import com.facebook.openwifirrm.ucentral.WifiScanEntry;
-import com.facebook.openwifirrm.ucentral.informationelement.HTOperationElement;
-import com.facebook.openwifirrm.ucentral.informationelement.VHTOperationElement;
+import com.facebook.openwifirrm.ucentral.informationelement.HTOperation;
+import com.facebook.openwifirrm.ucentral.informationelement.VHTOperation;
 import com.facebook.openwifirrm.ucentral.models.State;
 
 /**
@@ -208,13 +208,13 @@ public abstract class ChannelOptimizer {
 			return MIN_CHANNEL_WIDTH;
 		}
 
-		HTOperationElement htOperObj = new HTOperationElement(htOper);
+		HTOperation htOperObj = new HTOperation(htOper);
 		if (vhtOper == null) {
 			// HT mode only supports 20/40 MHz
 			return htOperObj.staChannelWidth ? 40 : 20;
 		} else {
 			// VHT/HE mode supports 20/40/160/80+80 MHz
-			VHTOperationElement vhtOperObj = new VHTOperationElement(vhtOper);
+			VHTOperation vhtOperObj = new VHTOperation(vhtOper);
 			if (!htOperObj.staChannelWidth && vhtOperObj.channelWidth == 0) {
 				return 20;
 			} else if (

--- a/src/main/java/com/facebook/openwifirrm/ucentral/informationelement/HTOperation.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/informationelement/HTOperation.java
@@ -17,7 +17,7 @@ import org.apache.commons.codec.binary.Base64;
  * High Throughput (HT) Operation Element, which is potentially present in
  * wifiscan entries. Introduced in 802.11n (2009).
  */
-public class HTOperationElement {
+public class HTOperation {
 
 	/** Channel number of the primary channel. */
 	public final byte primaryChannel;
@@ -78,7 +78,7 @@ public class HTOperationElement {
 	 * For details about the parameters, see the javadocs for the corresponding
 	 * member variables.
 	 */
-	public HTOperationElement(
+	public HTOperation(
 		byte primaryChannel,
 		byte secondaryChannelOffset,
 		boolean staChannelWidth,
@@ -114,7 +114,7 @@ public class HTOperationElement {
 	}
 
 	/** Constructor with the most used parameters. */
-	public HTOperationElement(
+	public HTOperation(
 		byte primaryChannel,
 		byte secondaryChannelOffset,
 		boolean staChannelWidth,
@@ -141,7 +141,7 @@ public class HTOperationElement {
 	 * @param htOper a base64 encoded properly formatted HT operation element (see
 	 *               802.11)
 	 */
-	public HTOperationElement(String htOper) {
+	public HTOperation(String htOper) {
 		byte[] bytes = Base64.decodeBase64(htOper);
 		/*
 		 * Note that the code here may seem to read "reversed" compared to 802.11. This
@@ -182,7 +182,7 @@ public class HTOperationElement {
 	 * @return true if the the operation elements "match" for the purpose of
 	 *         aggregating statistics; false otherwise.
 	 */
-	public boolean matchesForAggregation(HTOperationElement other) {
+	public boolean matchesForAggregation(HTOperation other) {
 		return other != null && primaryChannel == other.primaryChannel &&
 			secondaryChannelOffset == other.secondaryChannelOffset &&
 			staChannelWidth == other.staChannelWidth &&
@@ -211,8 +211,8 @@ public class HTOperationElement {
 		if (htOper1 == null || htOper2 == null) {
 			return false; // false if exactly one is null
 		}
-		HTOperationElement htOperObj1 = new HTOperationElement(htOper1);
-		HTOperationElement htOperObj2 = new HTOperationElement(htOper2);
+		HTOperation htOperObj1 = new HTOperation(htOper1);
+		HTOperation htOperObj2 = new HTOperation(htOper2);
 		return htOperObj1.matchesForAggregation(htOperObj2);
 	}
 
@@ -248,7 +248,7 @@ public class HTOperationElement {
 		if (getClass() != obj.getClass()) {
 			return false;
 		}
-		HTOperationElement other = (HTOperationElement) obj;
+		HTOperation other = (HTOperation) obj;
 		return Arrays.equals(basicHtMcsSet, other.basicHtMcsSet) &&
 			channelCenterFrequencySegment2 ==
 				other.channelCenterFrequencySegment2 &&

--- a/src/main/java/com/facebook/openwifirrm/ucentral/informationelement/VHTOperation.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/informationelement/VHTOperation.java
@@ -17,7 +17,7 @@ import org.apache.commons.codec.binary.Base64;
  * Very High Throughput (VHT) Operation Element, which is potentially present in
  * wifiscan entries. Introduced in 802.11ac (2013).
  */
-public class VHTOperationElement {
+public class VHTOperation {
 
 	/**
 	 * This field is 0 if the channel width is 20 MHz or 40 MHz, and 1 otherwise.
@@ -65,7 +65,7 @@ public class VHTOperationElement {
 	 * @param vhtOper a base64 encoded properly formatted VHT operation element (see
 	 *                802.11 standard)
 	 */
-	public VHTOperationElement(String vhtOper) {
+	public VHTOperation(String vhtOper) {
 		byte[] bytes = Base64.decodeBase64(vhtOper);
 		this.channelWidth = bytes[0];
 		this.channel1 = (short) (bytes[1] & 0xff); // read as unsigned value
@@ -89,7 +89,7 @@ public class VHTOperationElement {
 	 * For details about the parameters, see the javadocs for the corresponding
 	 * member variables.
 	 */
-	public VHTOperationElement(
+	public VHTOperation(
 		byte channelWidth,
 		short channel1,
 		short channel2,
@@ -114,7 +114,7 @@ public class VHTOperationElement {
 	 * @return true if the the operation elements "match" for the purpose of
 	 *         aggregating statistics; false otherwise.
 	 */
-	public boolean matchesForAggregation(VHTOperationElement other) {
+	public boolean matchesForAggregation(VHTOperation other) {
 		// check everything except vhtMcsForNss
 		return other != null && channel1 == other.channel1 &&
 			channel2 == other.channel2 && channelWidth == other.channelWidth;
@@ -142,8 +142,8 @@ public class VHTOperationElement {
 		if (vhtOper1 == null || vhtOper2 == null) {
 			return false; // false if exactly one is null
 		}
-		VHTOperationElement vhtOperObj1 = new VHTOperationElement(vhtOper1);
-		VHTOperationElement vhtOperObj2 = new VHTOperationElement(vhtOper2);
+		VHTOperation vhtOperObj1 = new VHTOperation(vhtOper1);
+		VHTOperation vhtOperObj2 = new VHTOperation(vhtOper2);
 		return vhtOperObj1.matchesForAggregation(vhtOperObj2);
 	}
 
@@ -168,7 +168,7 @@ public class VHTOperationElement {
 		if (getClass() != obj.getClass()) {
 			return false;
 		}
-		VHTOperationElement other = (VHTOperationElement) obj;
+		VHTOperation other = (VHTOperation) obj;
 		return channel1 == other.channel1 && channel2 == other.channel2 &&
 			channelWidth == other.channelWidth &&
 			Arrays.equals(vhtMcsForNss, other.vhtMcsForNss);

--- a/src/test/java/com/facebook/openwifirrm/ucentral/informationelement/HTOperationTest.java
+++ b/src/test/java/com/facebook/openwifirrm/ucentral/informationelement/HTOperationTest.java
@@ -12,11 +12,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class HTOperationElementTest {
+public class HTOperationTest {
 	@Test
 	void testGetHtOper() {
 		String htOper = "AQAEAAAAAAAAAAAAAAAAAAAAAAAAAA==";
-		HTOperationElement htOperObj = new HTOperationElement(htOper);
+		HTOperation htOperObj = new HTOperation(htOper);
 		byte expectedPrimaryChannel = 1;
 		byte expectedSecondaryChannelOffset = 0;
 		boolean expectedStaChannelWidth = false;
@@ -28,7 +28,7 @@ public class HTOperationElementTest {
 		boolean expectedDualBeacon = false;
 		boolean expectedDualCtsProtection = false;
 		boolean expectedStbcBeacon = false;
-		HTOperationElement expectedHtOperObj = new HTOperationElement(
+		HTOperation expectedHtOperObj = new HTOperation(
 			expectedPrimaryChannel,
 			expectedSecondaryChannelOffset,
 			expectedStaChannelWidth,
@@ -44,11 +44,11 @@ public class HTOperationElementTest {
 		assertEquals(expectedHtOperObj, htOperObj);
 
 		htOper = "JAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
-		htOperObj = new HTOperationElement(htOper);
+		htOperObj = new HTOperation(htOper);
 		// all fields except the primary channel and nongreenfield field are the same
 		expectedPrimaryChannel = 36;
 		expectedNongreenfieldHtStasPresent = false;
-		expectedHtOperObj = new HTOperationElement(
+		expectedHtOperObj = new HTOperation(
 			expectedPrimaryChannel,
 			expectedSecondaryChannelOffset,
 			expectedStaChannelWidth,

--- a/src/test/java/com/facebook/openwifirrm/ucentral/informationelement/VHTOperationTest.java
+++ b/src/test/java/com/facebook/openwifirrm/ucentral/informationelement/VHTOperationTest.java
@@ -12,17 +12,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class VHTOperationElementTest {
+public class VHTOperationTest {
 
 	@Test
 	void testGetVhtOper() {
 		String vhtOper = "ACQAAAA=";
-		VHTOperationElement vhtOperObj = new VHTOperationElement(vhtOper);
+		VHTOperation vhtOperObj = new VHTOperation(vhtOper);
 		byte expectedChannelWidthIndicator = 0; // 20 MHz channel width
 		short expectedChannel1 = 36;
 		short expectedChannel2 = 0;
 		byte[] expectedVhtMcsForNss = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
-		VHTOperationElement expectedVhtOperObj = new VHTOperationElement(
+		VHTOperation expectedVhtOperObj = new VHTOperation(
 			expectedChannelWidthIndicator,
 			expectedChannel1,
 			expectedChannel2,
@@ -31,12 +31,12 @@ public class VHTOperationElementTest {
 		assertEquals(expectedVhtOperObj, vhtOperObj);
 
 		vhtOper = "AToAUAE=";
-		vhtOperObj = new VHTOperationElement(vhtOper);
+		vhtOperObj = new VHTOperation(vhtOper);
 		expectedChannelWidthIndicator = 1; // 80 MHz channel width
 		expectedChannel1 = 58;
 		// same channel2
 		expectedVhtMcsForNss = new byte[] { 1, 1, 0, 0, 0, 0, 0, 1 };
-		expectedVhtOperObj = new VHTOperationElement(
+		expectedVhtOperObj = new VHTOperation(
 			expectedChannelWidthIndicator,
 			expectedChannel1,
 			expectedChannel2,
@@ -45,12 +45,12 @@ public class VHTOperationElementTest {
 		assertEquals(expectedVhtOperObj, vhtOperObj);
 
 		vhtOper = "ASoyUAE=";
-		vhtOperObj = new VHTOperationElement(vhtOper);
+		vhtOperObj = new VHTOperation(vhtOper);
 		// same channel width indicator (160 MHz channel width)
 		expectedChannel1 = 42;
 		expectedChannel2 = 50;
 		// same vhtMcsForNss
-		expectedVhtOperObj = new VHTOperationElement(
+		expectedVhtOperObj = new VHTOperation(
 			expectedChannelWidthIndicator,
 			expectedChannel1,
 			expectedChannel2,
@@ -60,12 +60,12 @@ public class VHTOperationElementTest {
 
 		// test with channel number >= 128 (channel fields should be unsigned)
 		vhtOper = "AJUAAAA=";
-		vhtOperObj = new VHTOperationElement(vhtOper);
+		vhtOperObj = new VHTOperation(vhtOper);
 		expectedChannelWidthIndicator = 0;
 		expectedChannel1 = 149;
 		expectedChannel2 = 0;
 		expectedVhtMcsForNss = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 };
-		expectedVhtOperObj = new VHTOperationElement(
+		expectedVhtOperObj = new VHTOperation(
 			expectedChannelWidthIndicator,
 			expectedChannel1,
 			expectedChannel2,


### PR DESCRIPTION
Rename HTOperationElement, HTOperationElementTest, VHTOperationElement, and VHTOperationElementTest for consistency (all other classes in the package do not include the "Element" suffix)