### PR TITLE
[WIFI-10943] Deal with "auto" value for channel and fix 80p80 representation

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
+++ b/src/main/java/com/facebook/openwifirrm/optimizers/channel/ChannelOptimizer.java
@@ -234,8 +234,9 @@ public abstract class ChannelOptimizer {
 				// the difference of 8 means it is consecutive
 				int channelDiff =
 					Math.abs(vhtOperObj.channel1 - vhtOperObj.channel2);
-				// the "8080" below does not mean 8080 MHz wide, it refers to 80+80 MHz channel
-				return channelDiff == 8 ? 160 : 8080;
+				// TODO it will currently return just 80 for 80p80 - it should be dealt
+				// with properly.
+				return channelDiff == 8 ? 160 : 80;
 			} else {
 				return MIN_CHANNEL_WIDTH;
 			}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -193,8 +193,8 @@ public class UCentralUtils {
 			) {
 				currentValue = fieldValue.getAsInt();
 			} else {
-				logger.error(
-					"Unable to get field {} as int, value was {}",
+				logger.debug(
+					"Unable to get field '{}' as int, value was {}",
 					fieldName,
 					fieldValue.toString()
 				);

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -187,18 +187,19 @@ public class UCentralUtils {
 			// not all values are int so override those values
 			Integer currentValue = null;
 			JsonElement fieldValue = radioConfig.get(fieldName);
-			try {
+			if (
+				fieldValue.isJsonPrimitive() &&
+					fieldValue.getAsJsonPrimitive().isNumber()
+			) {
 				currentValue = fieldValue.getAsInt();
-			} catch (NumberFormatException e) {
+			} else {
 				logger.error(
-					String.format(
-						"Unable to get field %s as int, value was %s",
-						fieldName,
-						fieldValue.toString()
-					),
-					e
+					"Unable to get field {} as int, value was {}",
+					fieldName,
+					fieldValue.toString()
 				);
 			}
+
 			if (currentValue != null && currentValue == newValue) {
 				logger.info(
 					"Device {}: {} {} is already {}",

--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -183,9 +183,23 @@ public class UCentralUtils {
 				continue;
 			}
 
-			// Compare vs. existing value
-			int currentValue = radioConfig.get(fieldName).getAsInt();
-			if (currentValue == newValue) {
+			// Compare vs. existing value.
+			// not all values are int so override those values
+			Integer currentValue = null;
+			JsonElement fieldValue = radioConfig.get(fieldName);
+			try {
+				currentValue = fieldValue.getAsInt();
+			} catch (NumberFormatException e) {
+				logger.error(
+					String.format(
+						"Unable to get field %s as int, value was %s",
+						fieldName,
+						fieldValue.toString()
+					),
+					e
+				);
+			}
+			if (currentValue != null && currentValue == newValue) {
 				logger.info(
 					"Device {}: {} {} is already {}",
 					serialNumber,
@@ -203,7 +217,7 @@ public class UCentralUtils {
 					operationalBand,
 					fieldName,
 					newValue,
-					currentValue
+					currentValue != null ? currentValue : fieldValue.toString()
 				);
 				wasModified = true;
 			}

--- a/src/test/java/com/facebook/openwifirrm/ucentral/UCentralUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/ucentral/UCentralUtilsTest.java
@@ -8,7 +8,12 @@
 
 package com.facebook.openwifirrm.ucentral;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,5 +21,61 @@ public class UCentralUtilsTest {
 	@Test
 	void test_placeholder() throws Exception {
 		assertEquals(3, 1 + 2);
+	}
+
+	@Test
+	void test_setRadioConfigFieldChannel() throws Exception {
+		final String serialNumber = "aaaaaaaaaaaa";
+		final int expectedChannel = 10;
+		final Map<String, Integer> newValueList = Collections
+			.singletonMap(UCentralConstants.BAND_5G, expectedChannel);
+
+		// test case where channel value is a string and not an integer
+		UCentralApConfiguration config = new UCentralApConfiguration(
+			"{\"interfaces\": [], \"radios\": [{\"band\": \"5G\", \"channel\": \"auto\"}]}"
+		);
+		boolean modified = UCentralUtils
+			.setRadioConfigField(serialNumber, config, "channel", newValueList);
+		assertTrue(modified);
+		assertEquals(
+			config.getRadioConfig(0).get("channel").getAsInt(),
+			expectedChannel
+		);
+
+		// field doesn't exist
+		config = new UCentralApConfiguration(
+			"{\"interfaces\": [], \"radios\": [{\"band\": \"5G\"}]}"
+		);
+		modified = UCentralUtils
+			.setRadioConfigField(serialNumber, config, "channel", newValueList);
+		assertTrue(modified);
+		assertEquals(
+			config.getRadioConfig(0).get("channel").getAsInt(),
+			expectedChannel
+		);
+
+		// normal field, not modified
+		config = new UCentralApConfiguration(
+			"{\"interfaces\": [], \"radios\": [{\"band\": \"5G\", \"channel\": 10}]}"
+		);
+		modified = UCentralUtils
+			.setRadioConfigField(serialNumber, config, "channel", newValueList);
+		assertFalse(modified);
+		assertEquals(
+			config.getRadioConfig(0).get("channel").getAsInt(),
+			expectedChannel
+		);
+
+		// normal field, modified
+		config = new UCentralApConfiguration(
+			"{\"interfaces\": [], \"radios\": [{\"band\": \"5G\", \"channel\": 15}]}"
+		);
+		modified = UCentralUtils
+			.setRadioConfigField(serialNumber, config, "channel", newValueList);
+		assertTrue(modified);
+		assertEquals(
+			config.getRadioConfig(0).get("channel").getAsInt(),
+			expectedChannel
+		);
 	}
 }

--- a/src/test/java/com/facebook/openwifirrm/ucentral/UCentralUtilsTest.java
+++ b/src/test/java/com/facebook/openwifirrm/ucentral/UCentralUtilsTest.java
@@ -26,7 +26,7 @@ public class UCentralUtilsTest {
 	@Test
 	void test_setRadioConfigFieldChannel() throws Exception {
 		final String serialNumber = "aaaaaaaaaaaa";
-		final int expectedChannel = 10;
+		final int expectedChannel = 1;
 		final Map<String, Integer> newValueList = Collections
 			.singletonMap(UCentralConstants.BAND_5G, expectedChannel);
 
@@ -56,7 +56,7 @@ public class UCentralUtilsTest {
 
 		// normal field, not modified
 		config = new UCentralApConfiguration(
-			"{\"interfaces\": [], \"radios\": [{\"band\": \"5G\", \"channel\": 10}]}"
+			"{\"interfaces\": [], \"radios\": [{\"band\": \"5G\", \"channel\": 1}]}"
 		);
 		modified = UCentralUtils
 			.setRadioConfigField(serialNumber, config, "channel", newValueList);


### PR DESCRIPTION
1. "auto" is a valid value in configuration - there was an assumption that it was only an int and it tried to call `getAsInt()` without any safeguards. This caused the exception to propagate up (not caught anywhere) and crash the system.
    1. https://github.com/Telecominfraproject/wlan-ucentral-schema/blob/bfcb0e8c6e6c07195ba964f696c562aae3723fa3/schema/radio.yml#L27-L36
3. 80p80 was represented as 8080, which is problematic as the value is taken at face value i.e. it's used directly in computations. So it was seen has 8080MHz instead of the proper 80p80 it is. @pohanhf can speak more to this.