### PR TITLE
Follow-up on stats aggregation

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
+++ b/src/main/java/com/facebook/openwifirrm/modules/Modeler.java
@@ -8,7 +8,6 @@
 
 package com.facebook.openwifirrm.modules;
 
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -271,7 +270,7 @@ public class Modeler implements Runnable {
 					State stateModel = gson.fromJson(state, State.class);
 					dataModel.latestStates.computeIfAbsent(
 						device.serialNumber,
-						k -> Collections.synchronizedList(new LinkedList<>())
+						k -> new LinkedList<>()
 					).add(stateModel);
 					logger.debug(
 						"Device {}: added initial state from uCentralGw",
@@ -307,10 +306,11 @@ public class Modeler implements Runnable {
 						List<State> latestStatesList = dataModel.latestStates
 							.computeIfAbsent(
 								record.serialNumber,
-								k -> Collections
-									.synchronizedList(new LinkedList<>())
+								k -> new LinkedList<>()
 							);
-						if (latestStatesList.size() >= params.stateBufferSize) {
+						while (
+							latestStatesList.size() >= params.stateBufferSize
+						) {
 							latestStatesList.remove(0);
 						}
 						latestStatesList.add(stateModel);

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -170,11 +170,6 @@ public class AggregatedState {
 	}
 
 	@Override
-	public int hashCode() {
-		return Objects.hash(bssid, station, radio);
-	}
-
-	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
 			return true;
@@ -202,15 +197,27 @@ public class AggregatedState {
 	}
 
 	/**
+	 * Check whether some other AggregatedState and this one are matached for aggregation.
+	 * If the two match in bssid, station and radio. Then they could be aggregated to one.
+	 *
+	 * @param state
+	 * @return boolean
+	 */
+	public boolean ifMatchForAggregation(AggregatedState state) {
+		return bssid == state.bssid && station == state.station &&
+			Objects.equals(radio, state.radio);
+	}
+
+	/**
 	 * Add an AggregatedState to this AggregatedState. Succeed only when the two
-	 * matches in hashCode.
+	 * match for aggregation.
 	 *
 	 * @param state input AggregatedState
-	 * @return boolean true if the two matches in bssid, station, channel,
+	 * @return boolean true if the two match in bssid, station, channel,
 	 *         channel_width and tx_power
 	 */
 	public boolean add(AggregatedState state) {
-		if (hashCode() == state.hashCode()) {
+		if (ifMatchForAggregation(state)) {
 			this.rssi.addAll(state.rssi);
 			this.rxRate.add(state.rxRate);
 			this.txRate.add(state.txRate);

--- a/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/models/AggregatedState.java
@@ -169,41 +169,14 @@ public class AggregatedState {
 		this.radio = new Radio(radioInfo);
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-
-		AggregatedState other = (AggregatedState) obj;
-
-		return bssid == other.bssid && station == other.station &&
-			connected == other.connected && inactive == other.inactive && rssi
-				.equals(other.rssi) &&
-			rxBytes == other.rxBytes && rxBytes == other.rxPackets &&
-			Objects.equals(rxRate, other.rxRate) &&
-			txBytes == other.txBytes && txDuration == other.txDuration &&
-			txFailed == other.txFailed && txPackets == other.txPackets &&
-			Objects.equals(txRate, other.txRate) &&
-			txRetries == other.txRetries && ackSignal == other.ackSignal &&
-			ackSignalAvg == other.ackSignalAvg &&
-			Objects.equals(radio, other.radio);
-	}
-
 	/**
-	 * Check whether some other AggregatedState and this one are matached for aggregation.
-	 * If the two match in bssid, station and radio. Then they could be aggregated to one.
+	 * Check whether the passed-in AggregatedState and this one match for aggregation.
+	 * If the two match in bssid, station and radio. Then they could be aggregated.
 	 *
-	 * @param state
-	 * @return boolean
+	 * @param state the reference AggregatedState with which to check with.
+	 * @return boolean return true if the two matches for aggregation.
 	 */
-	public boolean ifMatchForAggregation(AggregatedState state) {
+	public boolean matchesForAggregation(AggregatedState state) {
 		return bssid == state.bssid && station == state.station &&
 			Objects.equals(radio, state.radio);
 	}
@@ -217,7 +190,7 @@ public class AggregatedState {
 	 *         channel_width and tx_power
 	 */
 	public boolean add(AggregatedState state) {
-		if (ifMatchForAggregation(state)) {
+		if (matchesForAggregation(state)) {
 			this.rssi.addAll(state.rssi);
 			this.rxRate.add(state.rxRate);
 			this.txRate.add(state.txRate);


### PR DESCRIPTION
Signed-off-by: zhiqiand <zhiqian@fb.com>

This PR should resolve some conversation from Jerrey in https://github.com/Telecominfraproject/wlan-cloud-rrm/pull/82

- Didn't use `sychronizedList` as it is thread-safe already. 

> In RRM algorithms, the whole DataModel is copied.

- Didn't override `hashCode()` in `AggregatedState`, use a check method instead. Remove `hashCode()` and `equals()`
-  use `while` loop to truncate the State buffer to the correct size.

