### PR TITLE
Fix IE parsing

### DIFF
--- a/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/UCentralUtils.java
@@ -149,7 +149,7 @@ public class UCentralUtils {
 					break;
 				}
 			} catch (Exception e) {
-				logger.debug("Skipping invalid IE {}", ie);
+				logger.error(String.format("Skipping invalid IE %s", ie), e);
 				continue;
 			}
 		}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/informationelement/Country.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/informationelement/Country.java
@@ -125,8 +125,9 @@ public class Country {
 		JsonElement constraintsObject = contents.get("constraints");
 		if (constraintsObject != null) {
 			for (JsonElement jsonElement : constraintsObject.getAsJsonArray()) {
+				JsonObject innerElem = jsonElement.getAsJsonObject();
 				CountryInfo countryInfo =
-					CountryInfo.parse(jsonElement.getAsJsonObject());
+					CountryInfo.parse(innerElem.get("Country Info").getAsJsonObject());
 				constraints.add(countryInfo);
 			}
 		}

--- a/src/main/java/com/facebook/openwifirrm/ucentral/informationelement/TxPwrInfo.java
+++ b/src/main/java/com/facebook/openwifirrm/ucentral/informationelement/TxPwrInfo.java
@@ -25,7 +25,7 @@ public class TxPwrInfo {
 	public static final int TYPE = 195;
 
 	/** Local maximum transmit power for 20 MHz. Required field. */
-	public final Integer localMaxTxPwrConstraint20MHz;
+	public final int localMaxTxPwrConstraint20MHz;
 	/** Local maximum transmit power for 40 MHz. Optional field. */
 	public final Integer localMaxTxPwrConstraint40MHz;
 	/** Local maximum transmit power for 80 MHz. Optional field. */
@@ -36,9 +36,9 @@ public class TxPwrInfo {
 	/** Constructor */
 	public TxPwrInfo(
 		int localMaxTxPwrConstraint20MHz,
-		int localMaxTxPwrConstraint40MHz,
-		int localMaxTxPwrConstraint80MHz,
-		int localMaxTxPwrConstraint160MHz
+		Integer localMaxTxPwrConstraint40MHz,
+		Integer localMaxTxPwrConstraint80MHz,
+		Integer localMaxTxPwrConstraint160MHz
 	) {
 		this.localMaxTxPwrConstraint20MHz = localMaxTxPwrConstraint20MHz;
 		this.localMaxTxPwrConstraint40MHz = localMaxTxPwrConstraint40MHz;
@@ -48,16 +48,17 @@ public class TxPwrInfo {
 
 	/** Parse TxPwrInfo IE from appropriate Json object. */
 	public static TxPwrInfo parse(JsonObject contents) {
+		JsonObject innerObj = contents.get("Tx Pwr Info").getAsJsonObject();
 		// required field
 		int localMaxTxPwrConstraint20MHz =
-			contents.get("Local Max Tx Pwr Constraint 20MHz").getAsInt();
+			innerObj.get("Local Max Tx Pwr Constraint 20MHz").getAsInt();
 		// optional field
 		Integer localMaxTxPwrConstraint40MHz =
-			parseOptionalField(contents, "Local Max Tx Pwr Constraint 40MHz");
+			parseOptionalField(innerObj, "Local Max Tx Pwr Constraint 40MHz");
 		Integer localMaxTxPwrConstraint80MHz =
-			parseOptionalField(contents, "Local Max Tx Pwr Constraint 40MHz");
+			parseOptionalField(innerObj, "Local Max Tx Pwr Constraint 80MHz");
 		Integer localMaxTxPwrConstraint160MHz =
-			parseOptionalField(contents, "Local Max Tx Pwr Constraint 40MHz");
+			parseOptionalField(innerObj, "Local Max Tx Pwr Constraint 160MHz");
 		return new TxPwrInfo(
 			localMaxTxPwrConstraint20MHz,
 			localMaxTxPwrConstraint40MHz,


### PR DESCRIPTION
Parsing for Country and Tx Power Info was wrong - they didn't take the actual inner element and tried to use the content value.

Tx Power Info also had type errors (Integer and int didn't line up between parsing and constructor) as well as wrong field names.