### PR TITLE
Remove lower and upper channel limit maps

### DIFF
--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
@@ -44,29 +44,17 @@ public class UCentralUtils {
 	/** The Gson instance. */
 	private static final Gson gson = new Gson();
 
-	/** Map of band to the band-specific lowest available channel*/
-	public static final Map<String, Integer> LOWER_CHANNEL_LIMIT =
-		new HashMap<>();
-	static {
-		UCentralUtils.LOWER_CHANNEL_LIMIT.put(UCentralConstants.BAND_2G, 1);
-		UCentralUtils.LOWER_CHANNEL_LIMIT.put(UCentralConstants.BAND_5G, 36);
-	}
-
-	/** Map of band to the band-specific highest available channel*/
-	public static final Map<String, Integer> UPPER_CHANNEL_LIMIT =
-		new HashMap<>();
-	static {
-		UCentralUtils.UPPER_CHANNEL_LIMIT.put(UCentralConstants.BAND_2G, 11);
-		UCentralUtils.UPPER_CHANNEL_LIMIT.put(UCentralConstants.BAND_5G, 165);
-	}
-
-	/** List of available channels per band for use. */
-	public static final Map<String, List<Integer>> AVAILABLE_CHANNELS_BAND = Collections
-		.unmodifiableMap(buildBandToChannelsMap());
+	/** Map from band to ordered (increasing) list of available channels */
+	public static final Map<String, List<Integer>> AVAILABLE_CHANNELS_BAND =
+		Collections
+			.unmodifiableMap(buildBandToChannelsMap());
 
 	// This class should not be instantiated.
 	private UCentralUtils() {}
-	
+
+	/**
+	 * Builds map from band to ordered (increasing) list of available channels.
+	 */
 	private static Map<String, List<Integer>> buildBandToChannelsMap() {
 		Map<String, List<Integer>> bandToChannelsMap = new HashMap<>();
 		bandToChannelsMap.put(
@@ -82,6 +70,17 @@ public class UCentralUtils {
 			)
 		);
 		return bandToChannelsMap;
+	}
+
+	/** Return the lowest available channel for the given band */
+	public static int getLowerChannelLimit(String band) {
+		return AVAILABLE_CHANNELS_BAND.get(band).get(0);
+	}
+
+	/** Return the lowest available channel for the given band */
+	public static int getUpperChannelLimit(String band) {
+		List<Integer> channels = AVAILABLE_CHANNELS_BAND.get(band);
+		return channels.get(channels.size() - 1);
 	}
 
 	/**
@@ -442,8 +441,7 @@ public class UCentralUtils {
 	 * @return true if the given channel is in the given band; false otherwise
 	 */
 	public static boolean isChannelInBand(int channel, String band) {
-		return LOWER_CHANNEL_LIMIT.get(band) <= channel &&
-			channel <= UPPER_CHANNEL_LIMIT.get(band);
+		return AVAILABLE_CHANNELS_BAND.get(band).contains(channel);
 	}
 
 	/**

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizer.java
@@ -25,8 +25,8 @@ import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
-import com.facebook.openwifi.rrm.modules.ModelerUtils;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
+import com.facebook.openwifi.rrm.modules.ModelerUtils;
 
 /**
  * Least used channel optimizer.
@@ -90,10 +90,10 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 	protected static Map<Integer, Integer> getOccupiedOverlapChannels(
 		Map<Integer, Integer> occupiedChannels
 	) {
-		int maxChannel =
-			UCentralUtils.UPPER_CHANNEL_LIMIT.get(UCentralConstants.BAND_2G);
-		int minChannel =
-			UCentralUtils.LOWER_CHANNEL_LIMIT.get(UCentralConstants.BAND_2G);
+		final int maxChannel =
+			UCentralUtils.getUpperChannelLimit(UCentralConstants.BAND_2G);
+		final int minChannel =
+			UCentralUtils.getLowerChannelLimit(UCentralConstants.BAND_2G);
 		Map<Integer, Integer> occupiedOverlapChannels = new TreeMap<>();
 		for (
 			int overlapChannel : UCentralUtils.AVAILABLE_CHANNELS_BAND

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
@@ -134,7 +134,7 @@ public class TestUtils {
 	public static JsonArray createDeviceStatus(List<String> bands) {
 		JsonArray jsonList = new JsonArray();
 		for (String band : bands) {
-			int channel = UCentralUtils.LOWER_CHANNEL_LIMIT.get(band);
+			int channel = UCentralUtils.getLowerChannelLimit(band);
 			jsonList.add(
 				createDeviceStatusRadioObject(
 					band,

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -39,12 +39,10 @@ public class LocationBasedOptimalTPCTest {
 	private static final int DEFAULT_TX_POWER = 20;
 	/** Default 2G channel. */
 	private static final int DEFAULT_CHANNEL_2G =
-		UCentralUtils.LOWER_CHANNEL_LIMIT
-			.get(UCentralConstants.BAND_2G);
+		UCentralUtils.getLowerChannelLimit(UCentralConstants.BAND_2G);
 	/** Default 5G channel. */
 	private static final int DEFAULT_CHANNEL_5G =
-		UCentralUtils.LOWER_CHANNEL_LIMIT
-			.get(UCentralConstants.BAND_5G);
+		UCentralUtils.getLowerChannelLimit(UCentralConstants.BAND_5G);
 
 	@Test
 	@Order(1)

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -85,7 +85,7 @@ public class MeasurementBasedApApTPCTest {
 	private static DataModel createModelSingleBand(String band) {
 		DataModel model = new DataModel();
 
-		final int channel = UCentralUtils.LOWER_CHANNEL_LIMIT.get(band);
+		final int channel = UCentralUtils.getLowerChannelLimit(band);
 
 		List<String> bssids = Arrays.asList(BSSID_A, BSSID_B, BSSID_C);
 		List<String> devices = Arrays.asList(DEVICE_A, DEVICE_B, DEVICE_C);
@@ -123,9 +123,9 @@ public class MeasurementBasedApApTPCTest {
 		DataModel model = new DataModel();
 
 		final int channel2G =
-			UCentralUtils.LOWER_CHANNEL_LIMIT.get(UCentralConstants.BAND_2G);
+			UCentralUtils.getLowerChannelLimit(UCentralConstants.BAND_2G);
 		final int channel5G =
-			UCentralUtils.LOWER_CHANNEL_LIMIT.get(UCentralConstants.BAND_5G);
+			UCentralUtils.getLowerChannelLimit(UCentralConstants.BAND_5G);
 
 		List<String> bssids = Arrays.asList(BSSID_A, BSSID_B, BSSID_C);
 		List<String> devices = Arrays.asList(DEVICE_A, DEVICE_B, DEVICE_C);
@@ -414,7 +414,7 @@ public class MeasurementBasedApApTPCTest {
 	 * @param band band (e.g., "2G")
 	 */
 	private static void testComputeTxPowerMapSimpleInOneBand(String band) {
-		int channel = UCentralUtils.LOWER_CHANNEL_LIMIT.get(band);
+		final int channel = UCentralUtils.getLowerChannelLimit(band);
 		DataModel dataModel = createModelSingleBand(band);
 		dataModel.latestWifiScans = createLatestWifiScansB(channel);
 		DeviceDataManager deviceDataManager = createDeviceDataManager();
@@ -439,7 +439,7 @@ public class MeasurementBasedApApTPCTest {
 	private static void testComputeTxPowerMapNonzeroNthSmallestRssi(
 		String band
 	) {
-		int channel = UCentralUtils.LOWER_CHANNEL_LIMIT.get(band);
+		final int channel = UCentralUtils.getLowerChannelLimit(band);
 		DataModel dataModel = createModelSingleBand(band);
 		dataModel.latestWifiScans = createLatestWifiScansC(channel);
 		DeviceDataManager deviceDataManager = createDeviceDataManager();
@@ -466,7 +466,7 @@ public class MeasurementBasedApApTPCTest {
 	 * @param band band (e.g., "2G")
 	 */
 	private static void testComputeTxPowerMapMissingDataInOneBand(String band) {
-		int channel = UCentralUtils.LOWER_CHANNEL_LIMIT.get(band);
+		final int channel = UCentralUtils.getLowerChannelLimit(band);
 		DataModel dataModel = createModelSingleBand(band);
 		dataModel.latestWifiScans =
 			createLatestWifiScansWithMissingEntries(channel);
@@ -508,11 +508,11 @@ public class MeasurementBasedApApTPCTest {
 		DeviceDataManager deviceDataManager = createDeviceDataManager();
 		// 2G: use testComputeTxPowerMapSimpleInOneBand setup
 		final int channel2G =
-			UCentralUtils.LOWER_CHANNEL_LIMIT.get(UCentralConstants.BAND_2G);
+			UCentralUtils.getLowerChannelLimit(UCentralConstants.BAND_2G);
 		dataModel.latestWifiScans = createLatestWifiScansB(channel2G);
 		// 5G: use testComputeTxPowerMapMissingDataInOneBand setup
 		final int channel5G =
-			UCentralUtils.LOWER_CHANNEL_LIMIT.get(UCentralConstants.BAND_5G);
+			UCentralUtils.getLowerChannelLimit(UCentralConstants.BAND_5G);
 		// add 5G wifiscan results to dataModel.latestWifiScans
 		Map<String, List<List<WifiScanEntry>>> toMerge =
 			createLatestWifiScansWithMissingEntries(channel5G);


### PR DESCRIPTION
Remove lower and upper channel limit maps. This PR is just consolidating some logic/refactoring in separate PRs so the PR for supporting 6G isn't as large.

The lower and upper channel limit maps were removed since the information stored in them was already present in CHANNEL_AVAILABLE_BAND. It is easier to maintain fewer "sources of truth".