### PR TITLE
Fix vendorReferenceUrl in RRMConfig broken in #99

### DIFF
--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/RRMConfig.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/RRMConfig.java
@@ -60,7 +60,7 @@ public class RRMConfig {
 		 * ({@code SERVICECONFIG_VENDORREFERENCEURL})
 		 */
 		public String vendorReferenceUrl =
-			"https://github.com/Telecominfraproject/wlan-cloud-rrm/blob/main/ALGORITHMS.md";
+			"https://github.com/Telecominfraproject/wlan-cloud-rrm/blob/main/owrrm/ALGORITHMS.md";
 	}
 
 	/** Service configuration. */


### PR DESCRIPTION
Fix default value of `RRMConfig.ServiceConfig.vendorReferenceUrl` after paths changed in #99.