### PR TITLE
Use device capabilities to identify radio band

### DIFF
--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralConstants.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralConstants.java
@@ -22,7 +22,7 @@ public final class UCentralConstants {
 	public static final String BAND_2G = "2G";
 	/** String of the 5 GHz band */
 	public static final String BAND_5G = "5G";
-	/** List of all bands */
+	/** List of all bands ordered from lowest to highest */
 	public static final List<String> BANDS = Collections
 		.unmodifiableList(Arrays.asList(BAND_2G, BAND_5G));
 

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
@@ -63,6 +63,8 @@ public class UCentralUtils {
 				Arrays.asList(36, 40, 44, 48, 149, 153, 157, 161, 165)
 			)
 		);
+		// NOTE: later, we may want to support channels 12, 13, and/or 14, if
+		// the AP supports it and OWF vendors will use them
 		bandToChannelsMap.put(
 			UCentralConstants.BAND_2G,
 			Collections.unmodifiableList(
@@ -417,18 +419,23 @@ public class UCentralUtils {
 	}
 
 	/**
-	 * Converts channel number to that channel's center frequency in MHz.
+	 * Converts channel number to that channel's center frequency in MHz. If,
+	 * due to channel numbering schemes, the channel number appears in multiple
+	 * bands, use the lowest such band.
 	 *
 	 * @param channel channel number
 	 * @return the center frequency of the given channel in MHz
 	 */
-	public static int channelToFrequencyMHz(int channel) {
-		// TODO fixme
-		if (channel <= 14) {
-			// 2.4 GHz
-			return 2407 + 5 * channel;
+	public static int channelToFrequencyMHzInLowestMatchingBand(int channel) {
+		if (isChannelInBand(channel, UCentralConstants.BAND_2G)) {
+			if (channel <= 13) {
+				return 2407 + 5 * channel;
+			} else {
+				// special case
+				return 2484;
+			}
 		} else {
-			// 5 GHz
+			// 5G
 			return 5000 + channel;
 		}
 	}

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
@@ -452,13 +452,14 @@ public class UCentralUtils {
 	}
 
 	/**
-	 * Given the channel, gets the band by checking lower bound and upper bound
-	 * of each band
+	 * Given the channel, gets the lowest band that contains that channel (there
+	 * may be multiple bands that contain the same channel number due to channel
+	 * numbering schemes).
 	 *
 	 * @param channel channel number
-	 * @return band if the channel can be mapped to a valid band; null otherwise
+	 * @return band lowest band containing the channel; null if no such band
 	 */
-	public static String getBandFromChannel(int channel) {
+	public static String channelToLowestMatchingBand(int channel) {
 		for (String band : UCentralConstants.BANDS) {
 			if (isChannelInBand(channel, band)) {
 				return band;

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
@@ -419,28 +419,6 @@ public class UCentralUtils {
 	}
 
 	/**
-	 * Converts channel number to that channel's center frequency in MHz. If,
-	 * due to channel numbering schemes, the channel number appears in multiple
-	 * bands, use the lowest such band.
-	 *
-	 * @param channel channel number
-	 * @return the center frequency of the given channel in MHz
-	 */
-	public static int channelToFrequencyMHzInLowestMatchingBand(int channel) {
-		if (isChannelInBand(channel, UCentralConstants.BAND_2G)) {
-			if (channel <= 13) {
-				return 2407 + 5 * channel;
-			} else {
-				// special case
-				return 2484;
-			}
-		} else {
-			// 5G
-			return 5000 + channel;
-		}
-	}
-
-	/**
 	 * Determines if the given channel is in the given band.
 	 *
 	 * @param channel channel number
@@ -451,21 +429,13 @@ public class UCentralUtils {
 		return AVAILABLE_CHANNELS_BAND.get(band).contains(channel);
 	}
 
-	/**
-	 * Given the channel, gets the lowest band that contains that channel (there
-	 * may be multiple bands that contain the same channel number due to channel
-	 * numbering schemes).
-	 *
-	 * @param channel channel number
-	 * @return band lowest band containing the channel; null if no such band
-	 */
-	public static String channelToLowestMatchingBand(int channel) {
-		for (String band : UCentralConstants.BANDS) {
-			if (isChannelInBand(channel, band)) {
-				return band;
-			}
+	/** Return which band contains the given frequency (MHz). */
+	public static String freqToBand(int freqMHz) {
+		if (2412 <= freqMHz && freqMHz <= 2484) {
+			return "2G";
+		} else {
+			return "5G";
 		}
-		return null;
 	}
 
 	/**

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ModelerUtils.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ModelerUtils.java
@@ -30,6 +30,8 @@ import com.facebook.openwifi.cloudsdk.models.ap.State.Interface.SSID.Association
 import com.facebook.openwifi.rrm.aggregators.Aggregator;
 import com.facebook.openwifi.rrm.aggregators.MeanAggregator;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 /**
  * Modeler utilities.
@@ -554,5 +556,22 @@ public class ModelerUtils {
 			bssid,
 			station
 		);
+	}
+
+	/** Return the radio's band, or null if band cannot be found */
+	public static String getBand(
+		State.Radio radio,
+		JsonObject deviceCapability
+	) {
+		JsonElement radioCapabilityElement = deviceCapability.get(radio.phy);
+		if (radioCapabilityElement == null) {
+			return null;
+		}
+		JsonObject radioCapability = radioCapabilityElement.getAsJsonObject();
+		JsonElement bandsElement = radioCapability.get("band");
+		if (bandsElement == null) {
+			return null;
+		}
+		return bandsElement.getAsJsonArray().get(0).getAsString();
 	}
 }

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ModelerUtils.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ModelerUtils.java
@@ -30,6 +30,7 @@ import com.facebook.openwifi.cloudsdk.models.ap.State.Interface.SSID.Association
 import com.facebook.openwifi.rrm.aggregators.Aggregator;
 import com.facebook.openwifi.rrm.aggregators.MeanAggregator;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -563,6 +564,9 @@ public class ModelerUtils {
 		State.Radio radio,
 		JsonObject deviceCapability
 	) {
+		if (radio.phy == null) {
+			return null;
+		}
 		JsonElement radioCapabilityElement = deviceCapability.get(radio.phy);
 		if (radioCapabilityElement == null) {
 			return null;
@@ -572,6 +576,10 @@ public class ModelerUtils {
 		if (bandsElement == null) {
 			return null;
 		}
-		return bandsElement.getAsJsonArray().get(0).getAsString();
+		JsonArray bands = bandsElement.getAsJsonArray();
+		if (bands.isEmpty()) {
+			return null;
+		}
+		return bands.get(0).getAsString();
 	}
 }

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizer.java
@@ -393,7 +393,12 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 					continue;
 				}
 				int[] currentChannelInfo =
-					getCurrentChannel(band, serialNumber, state);
+					getCurrentChannel(
+						band,
+						serialNumber,
+						state,
+						model.latestDeviceCapabilities
+					);
 				int currentChannel = currentChannelInfo[0];
 				// Filter out APs if the radios in the state do not contain a
 				// channel in a band given by the state. This can happen when

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/RandomChannelInitializer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/RandomChannelInitializer.java
@@ -23,8 +23,8 @@ import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
-import com.facebook.openwifi.rrm.modules.ModelerUtils;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
+import com.facebook.openwifi.rrm.modules.ModelerUtils;
 
 /**
  * Random channel initializer.
@@ -204,7 +204,12 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 					continue;
 				}
 				int[] currentChannelInfo =
-					getCurrentChannel(band, serialNumber, state);
+					getCurrentChannel(
+						band,
+						serialNumber,
+						state,
+						model.latestDeviceCapabilities
+					);
 				int currentChannel = currentChannelInfo[0];
 				int currentChannelWidth = currentChannelInfo[1];
 				if (currentChannel == 0) {

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -166,7 +166,7 @@ public class LocationBasedOptimalTPC extends TPC {
 	) {
 		int numOfAPs = 0;
 		int boundary = 100;
-		String band = UCentralUtils.getBandFromChannel(channel);
+		String band = UCentralUtils.channelToLowestMatchingBand(channel);
 		Map<String, Integer> validAPs = new TreeMap<>();
 		List<Double> apLocX = new ArrayList<>();
 		List<Double> apLocY = new ArrayList<>();

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -18,12 +18,11 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceConfig;
 import com.facebook.openwifi.rrm.DeviceDataManager;
-import com.facebook.openwifi.rrm.modules.ModelerUtils;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
+import com.facebook.openwifi.rrm.modules.ModelerUtils;
 
 /**
  * Location-based optimal TPC algorithm.
@@ -153,6 +152,7 @@ public class LocationBasedOptimalTPC extends TPC {
 	/**
 	 * Calculate new tx powers for the given band.
 	 *
+	 * @param band band (e.g., "2G")
 	 * @param channel channel
 	 * @param serialNumbers The serial numbers of the APs with the channel
 	 * @param txPowerMap this map from serial number to band to new tx power
@@ -160,13 +160,13 @@ public class LocationBasedOptimalTPC extends TPC {
 	 *                   this method with the new tx powers.
 	 */
 	private void buildTxPowerMapForChannel(
+		String band,
 		int channel,
 		List<String> serialNumbers,
 		Map<String, Map<String, Integer>> txPowerMap
 	) {
 		int numOfAPs = 0;
 		int boundary = 100;
-		String band = UCentralUtils.channelToLowestMatchingBand(channel);
 		Map<String, Integer> validAPs = new TreeMap<>();
 		List<Double> apLocX = new ArrayList<>();
 		List<Double> apLocY = new ArrayList<>();
@@ -283,9 +283,27 @@ public class LocationBasedOptimalTPC extends TPC {
 	@Override
 	public Map<String, Map<String, Integer>> computeTxPowerMap() {
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
-		Map<Integer, List<String>> apsPerChannel = getApsPerChannel();
-		for (Map.Entry<Integer, List<String>> e : apsPerChannel.entrySet()) {
-			buildTxPowerMapForChannel(e.getKey(), e.getValue(), txPowerMap);
+		Map<String, Map<Integer, List<String>>> bandToChannelToAps =
+			getApsPerChannel();
+		for (
+			Map.Entry<String, Map<Integer, List<String>>> bandEntry : bandToChannelToAps
+				.entrySet()
+		) {
+			final String band = bandEntry.getKey();
+			Map<Integer, List<String>> channelToAps = bandEntry.getValue();
+			for (
+				Map.Entry<Integer, List<String>> channelEntry : channelToAps
+					.entrySet()
+			) {
+				final int channel = channelEntry.getKey();
+				List<String> serialNumbers = channelEntry.getValue();
+				buildTxPowerMapForChannel(
+					band,
+					channel,
+					serialNumbers,
+					txPowerMap
+				);
+			}
 		}
 		return txPowerMap;
 	}

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -306,7 +306,7 @@ public class MeasurementBasedApApTPC extends TPC {
 		List<String> serialNumbers,
 		Map<String, Map<String, Integer>> txPowerMap
 	) {
-		String band = UCentralUtils.getBandFromChannel(channel);
+		String band = UCentralUtils.channelToLowestMatchingBand(channel);
 		Set<String> managedBSSIDs = getManagedBSSIDs(model);
 		Map<String, List<Integer>> bssidToRssiValues =
 			buildRssiMap(managedBSSIDs, model.latestWifiScans, band);

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -220,11 +220,12 @@ public class MeasurementBasedApApTPC extends TPC {
 			// At a given AP, if we receive a signal from ap_2, then it gets added to the rssi list for ap_2
 			latestScan.stream()
 				.filter((entry) -> {
-					boolean isManaged = managedBSSIDs.contains(entry.bssid);
+					if (!managedBSSIDs.contains(entry.bssid)) {
+						return false;
+					}
 					String entryBand = UCentralUtils
 						.freqToBand(entry.frequency);
-					return isManaged && entryBand != null &&
-						entryBand.equals(band);
+					return entryBand != null && entryBand.equals(band);
 				})
 				.forEach(
 					entry -> {

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -25,6 +25,8 @@ import com.facebook.openwifi.cloudsdk.WifiScanEntry;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
+import com.facebook.openwifi.rrm.modules.ModelerUtils;
+import com.google.gson.JsonObject;
 
 /**
  * Measurement-based AP-AP TPC algorithm.
@@ -217,7 +219,13 @@ public class MeasurementBasedApApTPC extends TPC {
 
 			// At a given AP, if we receive a signal from ap_2, then it gets added to the rssi list for ap_2
 			latestScan.stream()
-				.filter(entry -> (managedBSSIDs.contains(entry.bssid) && UCentralUtils.isChannelInBand(entry.channel, band)))
+				.filter((entry) -> {
+					boolean isManaged = managedBSSIDs.contains(entry.bssid);
+					String entryBand = UCentralUtils
+						.freqToBand(entry.frequency);
+					return isManaged && entryBand != null &&
+						entryBand.equals(band);
+				})
 				.forEach(
 					entry -> {
 						bssidToRssiValues.get(entry.bssid).add(entry.signal);
@@ -296,17 +304,18 @@ public class MeasurementBasedApApTPC extends TPC {
 	/**
 	 * Calculate new tx powers for the given channel on the given APs .
 	 *
+	 * @param band band (e.g., "2G")
 	 * @param channel channel
 	 * @param serialNumbers the serial numbers of the APs with the channel
 	 * @param txPowerMap this maps from serial number to band to new tx power (dBm)
 	 *                   and is updated by this method with the new tx powers.
 	 */
 	protected void buildTxPowerMapForChannel(
+		String band,
 		int channel,
 		List<String> serialNumbers,
 		Map<String, Map<String, Integer>> txPowerMap
 	) {
-		String band = UCentralUtils.channelToLowestMatchingBand(channel);
 		Set<String> managedBSSIDs = getManagedBSSIDs(model);
 		Map<String, List<Integer>> bssidToRssiValues =
 			buildRssiMap(managedBSSIDs, model.latestWifiScans, band);
@@ -363,9 +372,16 @@ public class MeasurementBasedApApTPC extends TPC {
 					State.Radio radio = state.radios[idx];
 
 					// this specific SSID is not on the band of interest
-					if (
-						!UCentralUtils.isChannelInBand(radio.channel, band)
-					) {
+					JsonObject deviceCapability = model.latestDeviceCapabilities
+						.get(serialNumber);
+					if (deviceCapability == null) {
+						continue;
+					}
+					final String radioBand = ModelerUtils.getBand(
+						radio,
+						deviceCapability
+					);
+					if (radioBand == null || !radioBand.equals(band)) {
 						continue;
 					}
 
@@ -409,9 +425,27 @@ public class MeasurementBasedApApTPC extends TPC {
 	@Override
 	public Map<String, Map<String, Integer>> computeTxPowerMap() {
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
-		Map<Integer, List<String>> apsPerChannel = getApsPerChannel();
-		for (Map.Entry<Integer, List<String>> e : apsPerChannel.entrySet()) {
-			buildTxPowerMapForChannel(e.getKey(), e.getValue(), txPowerMap);
+		Map<String, Map<Integer, List<String>>> bandToChannelToAps =
+			getApsPerChannel();
+		for (
+			Map.Entry<String, Map<Integer, List<String>>> bandEntry : bandToChannelToAps
+				.entrySet()
+		) {
+			final String band = bandEntry.getKey();
+			Map<Integer, List<String>> channelToAps = bandEntry.getValue();
+			for (
+				Map.Entry<Integer, List<String>> channelEntry : channelToAps
+					.entrySet()
+			) {
+				final int channel = channelEntry.getKey();
+				List<String> serialNumbers = channelEntry.getValue();
+				buildTxPowerMapForChannel(
+					band,
+					channel,
+					serialNumbers,
+					txPowerMap
+				);
+			}
 		}
 		return txPowerMap;
 	}

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -306,7 +306,7 @@ public class MeasurementBasedApClientTPC extends TPC {
 			Map<String, Integer> radioMap = new TreeMap<>();
 			for (State.Radio radio : state.radios) {
 				int currentChannel = radio.channel;
-				String band = UCentralUtils.getBandFromChannel(currentChannel);
+				String band = UCentralUtils.channelToLowestMatchingBand(currentChannel);
 				if (band == null) {
 					continue;
 				}

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -15,13 +15,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.facebook.openwifi.rrm.modules.ModelerUtils;
+import com.google.gson.JsonObject;
 
 /**
  * Measurement-based AP-client algorithm.
@@ -305,8 +307,15 @@ public class MeasurementBasedApClientTPC extends TPC {
 
 			Map<String, Integer> radioMap = new TreeMap<>();
 			for (State.Radio radio : state.radios) {
-				int currentChannel = radio.channel;
-				String band = UCentralUtils.channelToLowestMatchingBand(currentChannel);
+				JsonObject deviceCapability = model.latestDeviceCapabilities
+					.get(serialNumber);
+				if (deviceCapability == null) {
+					continue;
+				}
+				final String band = ModelerUtils.getBand(
+					radio,
+					deviceCapability
+				);
 				if (band == null) {
 					continue;
 				}

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -144,7 +144,7 @@ public class RandomTxPowerInitializer extends TPC {
 			int channel = e.getKey();
 			List<String> serialNumbers = e.getValue();
 
-			String band = UCentralUtils.getBandFromChannel(channel);
+			String band = UCentralUtils.channelToLowestMatchingBand(channel);
 			for (String serialNumber : serialNumbers) {
 				int txPower = defaultTxPower;
 				if (setDifferentTxPowerPerAp) {

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/RandomTxPowerInitializer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/RandomTxPowerInitializer.java
@@ -18,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifi.cloudsdk.UCentralConstants;
-import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
 
@@ -137,36 +136,44 @@ public class RandomTxPowerInitializer extends TPC {
 			logger.info("Default power: {}", defaultTxPower);
 		}
 
-		Map<Integer, List<String>> apsPerChannel = getApsPerChannel();
+		Map<String, Map<Integer, List<String>>> bandToChannelToAps =
+			getApsPerChannel();
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
 
-		for (Map.Entry<Integer, List<String>> e : apsPerChannel.entrySet()) {
-			int channel = e.getKey();
-			List<String> serialNumbers = e.getValue();
-
-			String band = UCentralUtils.channelToLowestMatchingBand(channel);
-			for (String serialNumber : serialNumbers) {
-				int txPower = defaultTxPower;
-				if (setDifferentTxPowerPerAp) {
-					List<Integer> curTxPowerChoices = updateTxPowerChoices(
-						band,
+		for (
+			Map.Entry<String, Map<Integer, List<String>>> bandEntry : bandToChannelToAps
+				.entrySet()
+		) {
+			final String band = bandEntry.getKey();
+			Map<Integer, List<String>> channelToAps = bandEntry.getValue();
+			for (
+				Map.Entry<Integer, List<String>> channelEntry : channelToAps
+					.entrySet()
+			) {
+				List<String> serialNumbers = channelEntry.getValue();
+				for (String serialNumber : serialNumbers) {
+					int txPower = defaultTxPower;
+					if (setDifferentTxPowerPerAp) {
+						List<Integer> curTxPowerChoices = updateTxPowerChoices(
+							band,
+							serialNumber,
+							DEFAULT_TX_POWER_CHOICES
+						);
+						txPower = curTxPowerChoices
+							.get(rng.nextInt(curTxPowerChoices.size()));
+					}
+					txPowerMap
+						.computeIfAbsent(serialNumber, k -> new TreeMap<>())
+						.put(band, txPower);
+					logger.info(
+						"Device {} band {}: Assigning tx power = {}",
 						serialNumber,
-						DEFAULT_TX_POWER_CHOICES
+						band,
+						txPower
 					);
-					txPower = curTxPowerChoices
-						.get(rng.nextInt(curTxPowerChoices.size()));
 				}
-				txPowerMap.computeIfAbsent(serialNumber, k -> new TreeMap<>())
-					.put(band, txPower);
-				logger.info(
-					"Device {} band {}: Assigning tx power = {}",
-					serialNumber,
-					band,
-					txPower
-				);
 			}
 		}
-
 		return txPowerMap;
 	}
 }

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
@@ -201,7 +201,7 @@ public class TestUtils {
 	public static WifiScanEntry createWifiScanEntry(int channel) {
 		WifiScanEntry entry = new WifiScanEntry();
 		entry.channel = channel;
-		entry.frequency = UCentralUtils.channelToFrequencyMHz(channel);
+		entry.frequency = UCentralUtils.channelToFrequencyMHzInLowestMatchingBand(channel);
 		entry.signal = -60;
 		entry.unixTimeMs = TestUtils.DEFAULT_WIFISCANENTRY_TIME.toEpochMilli();
 		return entry;
@@ -262,7 +262,7 @@ public class TestUtils {
 		WifiScanEntry entry = new WifiScanEntry();
 		entry.bssid = bssid;
 		entry.channel = channel;
-		entry.frequency = UCentralUtils.channelToFrequencyMHz(channel);
+		entry.frequency = UCentralUtils.channelToFrequencyMHzInLowestMatchingBand(channel);
 		entry.signal = -60;
 		entry.ht_oper = htOper;
 		entry.vht_oper = vhtOper;

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
@@ -158,7 +158,7 @@ public class TestUtils {
 		JsonArray jsonList = new JsonArray();
 		jsonList.add(
 			createDeviceStatusRadioObject(
-				UCentralUtils.getBandFromChannel(channel),
+				UCentralUtils.channelToLowestMatchingBand(channel),
 				channel,
 				DEFAULT_CHANNEL_WIDTH,
 				txPower2G

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizerTest.java
@@ -63,6 +63,10 @@ public class LeastUsedChannelOptimizerTest {
 					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -84,6 +88,10 @@ public class LeastUsedChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceB,
 			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -107,6 +115,10 @@ public class LeastUsedChannelOptimizerTest {
 			Arrays.asList(
 				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -155,6 +167,10 @@ public class LeastUsedChannelOptimizerTest {
 					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -177,6 +193,10 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			Arrays.asList(TestUtils.createState(6, channelWidth, dummyBssid))
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceB,
 			Arrays.asList(TestUtils.createWifiScanList(channelsB))
@@ -194,6 +214,10 @@ public class LeastUsedChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceC,
 			Arrays.asList(TestUtils.createState(6, channelWidth, dummyBssid))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -251,6 +275,10 @@ public class LeastUsedChannelOptimizerTest {
 					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -271,6 +299,10 @@ public class LeastUsedChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceB,
 			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -293,6 +325,10 @@ public class LeastUsedChannelOptimizerTest {
 			Arrays.asList(
 				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -349,6 +385,10 @@ public class LeastUsedChannelOptimizerTest {
 					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -372,6 +412,10 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceB,
 			Arrays.asList(TestUtils.createWifiScanList(channelsB))
@@ -394,6 +438,10 @@ public class LeastUsedChannelOptimizerTest {
 			Arrays.asList(
 				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -444,6 +492,10 @@ public class LeastUsedChannelOptimizerTest {
 					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -468,6 +520,10 @@ public class LeastUsedChannelOptimizerTest {
 			deviceB,
 			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceB,
 			Arrays.asList(TestUtils.createWifiScanList(channelsB))
@@ -491,6 +547,10 @@ public class LeastUsedChannelOptimizerTest {
 				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceC,
 			Arrays.asList(TestUtils.createWifiScanList(channelsC))
@@ -510,6 +570,10 @@ public class LeastUsedChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceD,
 			Arrays.asList(TestUtils.createState(40, channelWidth, dummyBssid))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceD,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceD,
@@ -567,6 +631,10 @@ public class LeastUsedChannelOptimizerTest {
 					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -588,6 +656,10 @@ public class LeastUsedChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceB,
 			Arrays.asList(TestUtils.createState(36, channelWidth, dummyBssid))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -612,6 +684,10 @@ public class LeastUsedChannelOptimizerTest {
 				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceC,
 			Arrays.asList(TestUtils.createWifiScanList(channelsC))
@@ -633,6 +709,10 @@ public class LeastUsedChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceD,
 			Arrays.asList(TestUtils.createState(36, channelWidth, dummyBssid))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceD,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceD,
@@ -661,6 +741,10 @@ public class LeastUsedChannelOptimizerTest {
 				TestUtils
 					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceE,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceE,
@@ -711,6 +795,10 @@ public class LeastUsedChannelOptimizerTest {
 					.createState(aExpectedChannel, channelWidth, dummyBssid)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -731,6 +819,10 @@ public class LeastUsedChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceB,
 			Arrays.asList(TestUtils.createState(48, channelWidth, dummyBssid))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -765,6 +857,10 @@ public class LeastUsedChannelOptimizerTest {
 			Arrays.asList(
 				TestUtils.createState(149, channelWidth, dummyBssid)
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/channel/RandomChannelInitializerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/channel/RandomChannelInitializerTest.java
@@ -67,6 +67,14 @@ public class RandomChannelInitializerTest {
 			deviceB,
 			TestUtils.createDeviceStatus(band, 8)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
+		);
 
 		ChannelOptimizer optimizer = new RandomChannelInitializer(
 			dataModel,
@@ -115,6 +123,22 @@ public class RandomChannelInitializerTest {
 		dataModel.latestDeviceStatusRadios.put(
 			deviceB,
 			TestUtils.createDeviceStatus(band, 8)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(
+				new String[] {
+					UCentralConstants.BAND_2G,
+					UCentralConstants.BAND_2G }
+			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(
+				new String[] {
+					UCentralConstants.BAND_2G,
+					UCentralConstants.BAND_2G }
+			)
 		);
 
 		ChannelOptimizer optimizer = new RandomChannelInitializer(

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/channel/UnmanagedApAwareChannelOptimizerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/channel/UnmanagedApAwareChannelOptimizerTest.java
@@ -65,6 +65,10 @@ public class UnmanagedApAwareChannelOptimizerTest {
 						.createState(aExpectedChannel, channelWidth, bssidA)
 				)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -88,6 +92,10 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceB,
 			Arrays.asList(TestUtils.createState(40, channelWidth, bssidB))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceB,
@@ -122,6 +130,10 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceC,
 			Arrays.asList(TestUtils.createState(149, channelWidth, bssidC))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,
@@ -173,6 +185,10 @@ public class UnmanagedApAwareChannelOptimizerTest {
 						.createState(aExpectedChannel, channelWidth, bssidA)
 				)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceA,
 			Arrays.asList(
@@ -195,6 +211,10 @@ public class UnmanagedApAwareChannelOptimizerTest {
 			deviceB,
 			Arrays.asList(TestUtils.createState(6, channelWidth, bssidB))
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(band)
+		);
 		dataModel.latestWifiScans.put(
 			deviceB,
 			Arrays.asList(TestUtils.createWifiScanList(channelsB))
@@ -212,6 +232,10 @@ public class UnmanagedApAwareChannelOptimizerTest {
 		dataModel.latestStates.put(
 			deviceC,
 			Arrays.asList(TestUtils.createState(6, channelWidth, bssidC))
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(band)
 		);
 		dataModel.latestWifiScans.put(
 			deviceC,

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPCTest.java
@@ -145,6 +145,14 @@ public class LocationBasedOptimalTPCTest {
 					)
 				)
 			);
+			dataModel.latestDeviceCapabilities.put(
+				device,
+				TestUtils.createDeviceCapability(
+					new String[] {
+						UCentralConstants.BAND_2G,
+						UCentralConstants.BAND_5G }
+				)
+			);
 		}
 
 		Map<String, Map<String, Integer>> expected = new HashMap<>();
@@ -214,6 +222,14 @@ public class LocationBasedOptimalTPCTest {
 					)
 				)
 			);
+			dataModel2.latestDeviceCapabilities.put(
+				device,
+				TestUtils.createDeviceCapability(
+					new String[] {
+						UCentralConstants.BAND_2G,
+						UCentralConstants.BAND_5G }
+				)
+			);
 		}
 		dataModel2.latestDeviceStatusRadios
 			.put(
@@ -232,6 +248,10 @@ public class LocationBasedOptimalTPCTest {
 					dummyBssid
 				)
 			)
+		);
+		dataModel2.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
 		);
 
 		Map<String, Map<String, Integer>> expected2 = new HashMap<>();
@@ -327,6 +347,14 @@ public class LocationBasedOptimalTPCTest {
 					)
 				)
 			);
+			dataModel2.latestDeviceCapabilities.put(
+				device,
+				TestUtils.createDeviceCapability(
+					new String[] {
+						UCentralConstants.BAND_2G,
+						UCentralConstants.BAND_5G }
+				)
+			);
 		}
 
 		Map<String, Map<String, Integer>> expected2 = new HashMap<>();
@@ -388,6 +416,14 @@ public class LocationBasedOptimalTPCTest {
 					)
 				)
 			);
+			dataModel3.latestDeviceCapabilities.put(
+				device,
+				TestUtils.createDeviceCapability(
+					new String[] {
+						UCentralConstants.BAND_2G,
+						UCentralConstants.BAND_5G }
+				)
+			);
 		}
 
 		Map<String, Map<String, Integer>> expected3 = new HashMap<>();
@@ -437,6 +473,14 @@ public class LocationBasedOptimalTPCTest {
 						DEFAULT_TX_POWER,
 						dummyBssid
 					)
+				)
+			);
+			dataModel4.latestDeviceCapabilities.put(
+				device,
+				TestUtils.createDeviceCapability(
+					new String[] {
+						UCentralConstants.BAND_2G,
+						UCentralConstants.BAND_2G }
 				)
 			);
 		}

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPCTest.java
@@ -108,6 +108,10 @@ public class MeasurementBasedApApTPCTest {
 				TestUtils
 					.createDeviceStatusSingleBand(channel, MAX_TX_POWER)
 			);
+			model.latestDeviceCapabilities.put(
+				device,
+				TestUtils.createDeviceCapability(band)
+			);
 		}
 
 		return model;
@@ -156,6 +160,14 @@ public class MeasurementBasedApApTPCTest {
 						channel5G,
 						MAX_TX_POWER
 					)
+			);
+			model.latestDeviceCapabilities.put(
+				device,
+				TestUtils.createDeviceCapability(
+					new String[] {
+						UCentralConstants.BAND_2G,
+						UCentralConstants.BAND_5G }
+				)
 			);
 		}
 
@@ -591,6 +603,10 @@ public class MeasurementBasedApApTPCTest {
 				1,
 				MAX_TX_POWER
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			DEVICE_C,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_2G)
 		);
 		optimizer = new MeasurementBasedApApTPC(
 			dataModel,

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPCTest.java
@@ -61,11 +61,19 @@ public class MeasurementBasedApClientTPCTest {
 				TestUtils.createState(36, 20, 20, null, new int[] {})
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
+		);
 		dataModel.latestStates.put(
 			deviceB,
 			Arrays.asList(
 				TestUtils.createState(36, 20, 20, "", new int[] { -65 })
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
 		);
 		dataModel.latestStates.put(
 			deviceC,
@@ -79,17 +87,29 @@ public class MeasurementBasedApClientTPCTest {
 				)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
+		);
 		dataModel.latestStates.put(
 			deviceD,
 			Arrays.asList(
 				TestUtils.createState(36, 20, 22, null, new int[] { -80 })
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceD,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
+		);
 		dataModel.latestStates.put(
 			deviceE,
 			Arrays.asList(
 				TestUtils.createState(36, 20, 23, null, new int[] { -45 })
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceE,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(
@@ -158,12 +178,20 @@ public class MeasurementBasedApClientTPCTest {
 				TestUtils.createState(1, 20, 20, null, new int[] {})
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_2G)
+		);
 		// 5G only
 		dataModel.latestStates.put(
 			deviceB,
 			Arrays.asList(
 				TestUtils.createState(36, 20, 20, null, new int[] {})
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
 		);
 		// 2G and 5G
 		dataModel.latestStates.put(
@@ -179,6 +207,14 @@ public class MeasurementBasedApClientTPCTest {
 					20,
 					null
 				)
+			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(
+				new String[] {
+					UCentralConstants.BAND_2G,
+					UCentralConstants.BAND_5G }
 			)
 		);
 		// No valid bands in 2G or 5G
@@ -248,11 +284,19 @@ public class MeasurementBasedApClientTPCTest {
 				TestUtils.createState(36, 20, 20, null, new int[] {})
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceA,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
+		);
 		dataModel.latestStates.put(
 			deviceB,
 			Arrays.asList(
 				TestUtils.createState(36, 20, 20, "", new int[] { -65 })
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceB,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
 		);
 		dataModel.latestStates.put(
 			deviceC,
@@ -265,6 +309,10 @@ public class MeasurementBasedApClientTPCTest {
 					new int[] { -65, -73, -58 }
 				)
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			deviceC,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_5G)
 		);
 
 		TPC optimizer = new MeasurementBasedApClientTPC(

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/RandomTxPowerInitializerTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/tpc/RandomTxPowerInitializerTest.java
@@ -78,6 +78,14 @@ public class RandomTxPowerInitializerTest {
 				)
 			)
 		);
+		dataModel.latestDeviceCapabilities.put(
+			DEVICE_A,
+			TestUtils.createDeviceCapability(
+				new String[] {
+					UCentralConstants.BAND_5G,
+					UCentralConstants.BAND_2G }
+			)
+		);
 		dataModel.latestStates.put(
 			DEVICE_B,
 			Arrays.asList(
@@ -88,6 +96,10 @@ public class RandomTxPowerInitializerTest {
 					BSSID_B
 				)
 			)
+		);
+		dataModel.latestDeviceCapabilities.put(
+			DEVICE_B,
+			TestUtils.createDeviceCapability(UCentralConstants.BAND_2G)
 		);
 		return dataModel;
 	}


### PR DESCRIPTION
This is done in anticipation of adding 6G support. 6G uses the same channel numbers as other bands. E.g., channel 1 could refer to 2G channel 1 or 6G channel 1. Therefore, we cannot just infer band form channel anymore.

This PR makes sure we use device capabilities to identify a radio's band separately from its channel number, and that when we categorize radios based on channel, we also take band into account (i.e., we should categorize on the (band, channel) tuple instead).