### PR TITLE
Use eclipse temurin distribution of openjdk for docker maven builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-jdk-11 as build
+FROM maven:3-eclipse-temurin-11 as build
 WORKDIR /usr/src/java
 COPY . .
 RUN mvn clean package -pl owrrm -am -DappendVersionString="$(./scripts/get_build_version.sh)"


### PR DESCRIPTION
`maven:3-jdk-11` uses `openjdk:11-jdk` which is an adoptjdk distro which is deprecated and not being updated anymore: https://adoptopenjdk.net/upstream.html

tested on m1 mbp:
```
$ docker buildx build --platform=linux/amd64 .
```