### PR TITLE
Add script API and some related utilities

### DIFF
--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
@@ -8,8 +8,10 @@
 
 package com.facebook.openwifi.cloudsdk;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +30,7 @@ import com.facebook.openwifi.cloudsdk.ies.LocalPowerConstraint;
 import com.facebook.openwifi.cloudsdk.ies.QbssLoad;
 import com.facebook.openwifi.cloudsdk.ies.TxPwrInfo;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
+import com.facebook.openwifi.cloudsdk.models.gw.CommandInfo;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -484,5 +489,112 @@ public class UCentralUtils {
 		} catch (NumberFormatException e) {
 			return null;
 		}
+	}
+
+	/**
+	 * Return a map of Wi-Fi client (STA) MAC addresses to the Client structure
+	 * found for that interface. This does NOT support clients connected on
+	 * multiple interfaces simultaneously.
+	 */
+	public static Map<String, State.Interface.Client> getWifiClientInfo(
+		State state
+	) {
+		Map<String, State.Interface.Client> ret = new HashMap<>();
+
+		// Aggregate over all interfaces
+		for (State.Interface iface : state.interfaces) {
+			if (iface.ssids == null || iface.clients == null) {
+				continue;
+			}
+
+			// Convert client array to map (for faster lookups)
+			Map<String, State.Interface.Client> ifaceMap = new HashMap<>();
+			for (State.Interface.Client client : iface.clients) {
+				ifaceMap.put(client.mac, client);
+			}
+
+			// Loop over all SSIDs and connected clients
+			for (State.Interface.SSID ssid : iface.ssids) {
+				if (ssid.associations == null) {
+					continue;
+				}
+				for (
+					State.Interface.SSID.Association association : ssid.associations
+				) {
+					State.Interface.Client client =
+						ifaceMap.get(association.station);
+					if (client != null) {
+						ret.put(association.station, client);
+					}
+				}
+			}
+		}
+
+		return ret;
+	}
+
+	/**
+	 * Decompress (inflate) a UTF-8 string using ZLIB.
+	 *
+	 * @param compressed the compressed string
+	 * @param uncompressedSize the uncompressed size (must be known)
+	 */
+	private static String inflate(String compressed, int uncompressedSize)
+		throws DataFormatException {
+		if (compressed == null) {
+			throw new NullPointerException("Null compressed string");
+		}
+		if (uncompressedSize < 0) {
+			throw new IllegalArgumentException("Invalid size");
+		}
+
+		byte[] input = compressed.getBytes(StandardCharsets.UTF_8);
+		byte[] output = new byte[uncompressedSize];
+
+		Inflater inflater = new Inflater();
+		inflater.setInput(input, 0, input.length);
+		inflater.inflate(output);
+		inflater.end();
+
+		return new String(output, StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Given the result of the "script" API, return the actual script output
+	 * (decoded/decompressed if needed), or null if the script returned an
+	 * error.
+	 *
+	 * @see UCentralClient#runScript(String, String, int, String)
+	 */
+	public static String getScriptOutput(CommandInfo info) {
+		if (info == null || info.results == null) {
+			return null;
+		}
+		if (!info.results.has("status")) {
+			return null;
+		}
+		JsonObject status = info.results.get("status").getAsJsonObject();
+		if (!status.has("error") || status.get("error").getAsInt() != 0) {
+			return null;
+		}
+		if (status.has("result")) {
+			// Raw result
+			return status.get("result").getAsString();
+		} else if (status.has("result_64") && status.has("result_sz")) {
+			// Base64+compressed result
+			// NOTE: untested, not actually implemented on ucentral-client?
+			try {
+				String encoded = status.get("result_64").getAsString();
+				int uncompressedSize = status.get("result_sz").getAsInt();
+				String decoded = new String(
+					Base64.getDecoder().decode(encoded),
+					StandardCharsets.UTF_8
+				);
+				return inflate(decoded, uncompressedSize);
+			} catch (Exception e) {
+				logger.error("Failed to decode or inflate script result", e);
+			}
+		}
+		return null;
 	}
 }

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
@@ -54,6 +54,8 @@ public class State {
 				public int ack_signal;
 				public int ack_signal_avg;
 				public JsonObject[] tid_stats; // TODO: see cfg80211_tid_stats
+
+				// TODO ipaddr_v4 - either string or object (ip4leases), but duplicated in "clients"
 			}
 
 			public Association[] associations;

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/gw/ScriptRequest.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/gw/ScriptRequest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifi.cloudsdk.models.gw;
+
+public class ScriptRequest {
+	public String serialNumber;
+	public long timeout = 30; // in seconds
+	public String type; // "shell", "ucode", "uci"
+	public String script;
+	public String scriptId; // required but unused?
+	public long when = 0;
+}


### PR DESCRIPTION
Add the following new methods:
- `UCentralClient.runScript()` - run script on AP via ucentralgw (with new model `ScriptRequest`)
- `UCentralClient.pingFromDevice()` - run ping from AP (example/stub function using `runScript()`)
- `UCentralUtils.getScriptOutput()` - postprocess result of `UCentralClient.runScript()`
- `UCentralUtils.getWifiClientInfo()` - return STA MAC -> IP mapping from a State object

----

Test code using these new methods to ping all clients of OWF APs (in owrrm `ApiServer`):
```java
modeler.getDataModel().latestStates.forEach((serialNumber, states) -> {
	State state = states.get(states.size() - 1);
	Map<String, State.Interface.Client> clientMap = UCentralUtils.getWifiClientInfo(state);
	if (clientMap.isEmpty()) {
		return;
	}
	logger.info(
		"**** Pinging clients for {} (total {})...",
		serialNumber,
		clientMap.size()
	);
	for (Map.Entry<String, State.Interface.Client> entry : clientMap.entrySet()) {
		State.Interface.Client c = entry.getValue();
		String host;
		if (c.ipv4_addresses.length > 0) {
			host = c.ipv4_addresses[0];
		} else if (c.ipv6_addresses.length > 0) {
			host = c.ipv6_addresses[0];
		} else {
			continue;
		}
		String result = client.pingFromDevice(serialNumber, host);
		logger.info("**** --> PING TO {}:\n{}", host, result);
	}
});
```

Output:
```
**** Pinging clients for (redacted) (total 1)...
**** --> PING TO 192.168.1.61:
PING 192.168.1.61 (192.168.1.61): 56 data bytes
64 bytes from 192.168.1.61: seq=0 ttl=64 time=62.153 ms
64 bytes from 192.168.1.61: seq=1 ttl=64 time=86.589 ms
64 bytes from 192.168.1.61: seq=2 ttl=64 time=110.468 ms
64 bytes from 192.168.1.61: seq=3 ttl=64 time=31.203 ms
64 bytes from 192.168.1.61: seq=4 ttl=64 time=55.595 ms

--- 192.168.1.61 ping statistics ---
5 packets transmitted, 5 packets received, 0% packet loss
round-trip min/avg/max = 31.203/69.201/110.468 ms

**** Pinging clients for (redacted) (total 1)...
**** --> PING TO 192.168.1.60:
PING 192.168.1.60 (192.168.1.60): 56 data bytes
64 bytes from 192.168.1.60: seq=0 ttl=64 time=3.323 ms
64 bytes from 192.168.1.60: seq=1 ttl=64 time=2.759 ms

--- 192.168.1.60 ping statistics ---
5 packets transmitted, 2 packets received, 60% packet loss
round-trip min/avg/max = 2.759/3.041/3.323 ms
```
