### PR TITLE
Move running image to ibm-semeru and introduce runner script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,18 @@ WORKDIR /usr/src/java
 COPY . .
 RUN mvn clean package -pl owrrm -am -DappendVersionString="$(./scripts/get_build_version.sh)"
 
-FROM adoptopenjdk/openjdk11-openj9:latest
-RUN apt-get update && apt-get install -y gettext-base wget
-RUN wget https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-ucentral-deploy/main/docker-compose/certs/restapi-ca.pem \
-    -O /usr/local/share/ca-certificates/restapi-ca-selfsigned.pem
+FROM ibm-semeru-runtimes:open-11-jre
+RUN apt-get update && apt-get install -y gettext-base
+ADD https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-ucentral-deploy/main/docker-compose/certs/restapi-ca.pem \
+  /usr/local/share/ca-certificates/restapi-ca-selfsigned.pem
 RUN mkdir /owrrm-data
 WORKDIR /usr/src/java
 COPY docker-entrypoint.sh /
+COPY runner.sh /
 COPY --from=build /usr/src/java/owrrm/target/openwifi-rrm.jar /usr/local/bin/
 EXPOSE 16789 16790
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["java", "-XX:+IdleTuningGcOnIdle", "-Xtune:virtualized", \
-     "-jar", "/usr/local/bin/openwifi-rrm.jar", \
-     "run", "--config-env", \
-     "-t", "/owrrm-data/topology.json", \
-     "-d", "/owrrm-data/device_config.json"]
+CMD ["/runner.sh", "/usr/local/bin/openwifi-rrm.jar", \
+    "--config-env", \
+    "-t", "/owrrm-data/topology.json", \
+    "-d", "/owrrm-data/device_config.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY --from=build /usr/src/java/owrrm/target/openwifi-rrm.jar /usr/local/bin/
 EXPOSE 16789 16790
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/runner.sh", "/usr/local/bin/openwifi-rrm.jar", \
+    "run", \
     "--config-env", \
     "-t", "/owrrm-data/topology.json", \
     "-d", "/owrrm-data/device_config.json"]

--- a/runner.sh
+++ b/runner.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+BIN=$1
+shift 1
+
+echo $@
+
+java \
+	-XX:+IdleTuningGcOnIdle -Xtune:virtualized \
+	-jar "$BIN" \
+	run "$@"

--- a/runner.sh
+++ b/runner.sh
@@ -8,4 +8,4 @@ echo $@
 java \
 	-XX:+IdleTuningGcOnIdle -Xtune:virtualized \
 	-jar "$BIN" \
-	run "$@"
+	"$@"


### PR DESCRIPTION
- adoptopenjdk is being dissolved, so users should move to eclipse temurin or ibm semeru. Since the former is hotspot based and we want openj9, use ibm semeru JUST FOR RUNTIME. We will still use eclipse temurin for building (although i think we can technically use semeru for building as well - don't have as much context here)
  - a benefit of this is that there's aarch64 build so we can build/run native docker images on the ARM macbooks
- Add `runner.sh` to mirror running both in docker and locally. This will help speed up performance tuning