### PR TITLE
JVM options for strings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY runner.sh /
 COPY --from=build /usr/src/java/owrrm/target/openwifi-rrm.jar /usr/local/bin/
 EXPOSE 16789 16790
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["/runner.sh", "/usr/local/bin/openwifi-rrm.jar", \
+CMD ["/runner.sh", "java", "/usr/local/bin/openwifi-rrm.jar", \
     "run", \
     "--config-env", \
     "-t", "/owrrm-data/topology.json", \

--- a/runner.sh
+++ b/runner.sh
@@ -7,7 +7,9 @@ JVM=$1
 BIN=$2
 shift 2
 
-COMMON_PARAMETERS=()
+COMMON_PARAMETERS=(
+-XX:+CompactStrings
+)
 
 if [ -n "$JVM_HOTSPOT" ]; then
 # for hotspot

--- a/runner.sh
+++ b/runner.sh
@@ -1,11 +1,29 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-BIN=$1
-shift 1
+# script to help run the binary with specific jvm and jvm options
+# Defaults to openj9. Turn on hotspot by setting env JVM_HOTSPOT
 
-echo $@
+JVM=$1
+BIN=$2
+shift 2
 
-java \
-	-XX:+IdleTuningGcOnIdle -Xtune:virtualized \
+COMMON_PARAMETERS=()
+
+if [ -n "$JVM_HOTSPOT" ]; then
+# for hotspot
+PARAMETERS=(
+"${COMMON_PARAMETERS[@]}"
+)
+else
+# for openj9
+PARAMETERS=(
+"${COMMON_PARAMETERS[@]}"
+-XX:+IdleTuningGcOnIdle
+-Xtune:virtualized
+)
+fi
+
+"$JVM" \
+	"${PARAMETERS[@]}" \
 	-jar "$BIN" \
 	"$@"

--- a/runner.sh
+++ b/runner.sh
@@ -15,6 +15,8 @@ if [ -n "$JVM_HOTSPOT" ]; then
 # for hotspot
 PARAMETERS=(
 "${COMMON_PARAMETERS[@]}"
+-XX:+UseG1GC
+-XX:+UseStringDeduplication
 )
 else
 # for openj9

--- a/runner.sh
+++ b/runner.sh
@@ -1,33 +1,38 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # script to help run the binary with specific jvm and jvm options
-# Defaults to openj9. Turn on hotspot by setting env JVM_HOTSPOT
+# Defaults to openj9. Switch by setting JVM_IMPL environment variable
 
-JVM=$1
-BIN=$2
+JAVA_BIN=$1
+JAR=$2
 shift 2
 
-COMMON_PARAMETERS=(
--XX:+CompactStrings
-)
+COMMON_PARAMETERS=" \
+-XX:+CompactStrings \
+"
 
-if [ -n "$JVM_HOTSPOT" ]; then
+JVM_IMPL="${JVM_IMPL:-openj9}"
+
+if [ "$JVM_IMPL" = "hotspot" ]; then
 # for hotspot
-PARAMETERS=(
-"${COMMON_PARAMETERS[@]}"
--XX:+UseG1GC
--XX:+UseStringDeduplication
-)
-else
+PARAMETERS="\
+$COMMON_PARAMETERS \
+-XX:+UseG1GC \
+-XX:+UseStringDeduplication \
+"
+elif [ "$JVM_IMPL" = "openj9" ]; then
 # for openj9
-PARAMETERS=(
-"${COMMON_PARAMETERS[@]}"
--XX:+IdleTuningGcOnIdle
+PARAMETERS=" \
+$COMMON_PARAMETERS \
+-XX:+IdleTuningGcOnIdle \
 -Xtune:virtualized
-)
+"
+else
+echo "Invalid JVM_IMPL option"
+exit 1
 fi
 
-"$JVM" \
-	"${PARAMETERS[@]}" \
-	-jar "$BIN" \
-	"$@"
+"$JAVA_BIN" \
+	$PARAMETERS \
+	-jar "$JAR" \
+	$@


### PR DESCRIPTION
Modify runner script to support different java binaries.

- Compact strings for both (default on openj9, but make it explicit)
- string deduplication for hotspot (seems to reduce a tiny amount of memory and g1 was already default gc so just make it explicity)