### PR TITLE
Refactor AggregatedState and add timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 /target/
 */target/
 
+# owrrm specific
+*.log*
+device_config.json
+settings.json
+topology.json
+
 # Eclipse
 .settings/
 bin/

--- a/Dockerfile-hotspot
+++ b/Dockerfile-hotspot
@@ -3,7 +3,7 @@ WORKDIR /usr/src/java
 COPY . .
 RUN mvn clean package -pl owrrm -am -DappendVersionString="$(./scripts/get_build_version.sh)"
 
-FROM ibm-semeru-runtimes:open-11-jre
+FROM eclipse-temurin:11-jre-jammy
 RUN apt-get update && apt-get install -y gettext-base
 ADD https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-ucentral-deploy/main/docker-compose/certs/restapi-ca.pem \
   /usr/local/share/ca-certificates/restapi-ca-selfsigned.pem
@@ -12,9 +12,15 @@ WORKDIR /usr/src/java
 COPY docker-entrypoint.sh /
 COPY runner.sh /
 COPY --from=build /usr/src/java/owrrm/target/openwifi-rrm.jar /usr/local/bin/
+
+# generate Application CDS
+RUN java -Xshare:off -XX:DumpLoadedClassList=static-cds.lst -jar /usr/local/bin/openwifi-rrm.jar --help  && \
+    java -Xshare:dump -XX:SharedClassListFile=static-cds.lst -XX:SharedArchiveFile=static-cds.jsa -jar /usr/local/bin/openwifi-rrm.jar
+
 EXPOSE 16789 16790
 ENTRYPOINT ["/docker-entrypoint.sh"]
-ENV JVM_IMPL=openj9
+ENV JVM_IMPL=hotspot
+ENV EXTRA_JVM_FLAGS="-XX:SharedArchiveFile=static-cds.jsa -Xshare:auto"
 CMD ["/runner.sh", "java", "/usr/local/bin/openwifi-rrm.jar", \
     "run", \
     "--config-env", \

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/AggregatedState.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/AggregatedState.java
@@ -22,34 +22,6 @@ import com.google.gson.JsonObject;
  */
 public class AggregatedState {
 
-	/** Rate information with aggregated fields. */
-	public static class Rate {
-		/**
-		 * Aggregated fields bitRate
-		 */
-		public long bitRate;
-
-		/**
-		 * Aggregated fields chWidth
-		 */
-		public int chWidth;
-
-		/**
-		 * Aggregated fields mcs
-		 */
-		public int mcs;
-
-		/** Constructor with no args */
-		private Rate() {}
-
-		/** Constructor with args */
-		private Rate(long bitRate, int chWidth, int mcs) {
-			this.bitRate = bitRate;
-			this.chWidth = chWidth;
-			this.mcs = mcs;
-		}
-	}
-
 	/**
 	 * Radio information with channel, channel_width and tx_power.
 	 */
@@ -99,11 +71,39 @@ public class AggregatedState {
 		}
 	}
 
-	/** 
-	 * Data model to keep raw data from {@link State.Interface.SSID.Association}, 
+	/**
+	 * Data model to keep raw data from {@link State.Interface.SSID.Association},
 	 * {@link State.Radio} and {@link State.Interface.Counters}.
 	 */
 	public static class AssociationInfo {
+		/** Rate information with aggregated fields. */
+		public static class Rate {
+			/**
+			 * Aggregated fields bitRate
+			 */
+			public long bitRate;
+
+			/**
+			 * Aggregated fields chWidth
+			 */
+			public int chWidth;
+
+			/**
+			 * Aggregated fields mcs
+			 */
+			public int mcs;
+
+			/** Constructor with no args */
+			private Rate() {}
+
+			/** Constructor with args */
+			private Rate(long bitRate, int chWidth, int mcs) {
+				this.bitRate = bitRate;
+				this.chWidth = chWidth;
+				this.mcs = mcs;
+			}
+		}
+
 		public long connected;
 		public long inactive;
 		public int rssi;
@@ -126,7 +126,9 @@ public class AggregatedState {
 		public long noiseRadio;
 		public long receiveMsRadio;
 		public long transmitMsRadio;
-		public long timeStamp;
+
+		/** unix time in ms */
+		public long timestamp;
 
 		/** Default Constructor. */
 		public AssociationInfo() {}
@@ -141,7 +143,7 @@ public class AggregatedState {
 			Association association,
 			Counters counters,
 			JsonObject radio,
-			long timeStamp
+			long timestamp
 		) {
 			// Association info
 			connected = association.connected;
@@ -187,16 +189,19 @@ public class AggregatedState {
 			receiveMsRadio = radio.get("receive_ms").getAsLong();
 			noiseRadio = radio.get("noise").getAsLong();
 
-			this.timeStamp = timeStamp;
+			this.timestamp = timestamp;
 		}
 	}
 
+	/** Aggregate AssociationInfo over bssid, station and RadioConfig */
 	public String bssid;
 	public String station;
 	public RadioConfig radioConfig;
+
+	/** Store a list of AssociationInfo of the same link and radio configuration. */
 	public List<AssociationInfo> associationInfoList;
 
-	/** Constructor with no args */
+	/** Constructor with no args. For test purpose. */
 	public AggregatedState() {
 		this.associationInfoList = new ArrayList<>();
 		this.radioConfig = new RadioConfig();
@@ -207,13 +212,13 @@ public class AggregatedState {
 		Association association,
 		Counters counters,
 		JsonObject radio,
-		long timeStamp
+		long timestamp
 	) {
 		this.bssid = association.bssid;
 		this.station = association.station;
 		this.associationInfoList = new ArrayList<>();
 		associationInfoList
-			.add(new AssociationInfo(association, counters, radio, timeStamp));
+			.add(new AssociationInfo(association, counters, radio, timestamp));
 		this.radioConfig = new RadioConfig(radio);
 	}
 

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/AggregatedState.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/AggregatedState.java
@@ -193,12 +193,12 @@ public class AggregatedState {
 		}
 	}
 
-	/** Aggregate AssociationInfo over bssid, station and RadioConfig */
+	//Aggregate AssociationInfo over bssid, station and RadioConfig.
 	public String bssid;
 	public String station;
 	public RadioConfig radioConfig;
 
-	/** Store a list of AssociationInfo of the same link and radio configuration. */
+	//Store a list of AssociationInfo of the same link and radio configuration. */
 	public List<AssociationInfo> associationInfoList;
 
 	/** Constructor with no args. For test purpose. */

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/AggregatedState.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/AggregatedState.java
@@ -10,11 +10,11 @@ package com.facebook.openwifi.cloudsdk;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
+import com.facebook.openwifi.cloudsdk.models.ap.State.Interface.Counters;
 import com.facebook.openwifi.cloudsdk.models.ap.State.Interface.SSID.Association;
-import com.facebook.openwifi.cloudsdk.models.ap.State.Interface.SSID.Association.Rate;
+import com.google.gson.JsonObject;
 
 /**
  * Aggregation model for State aggregation. Only contains info useful for
@@ -23,73 +23,57 @@ import com.facebook.openwifi.cloudsdk.models.ap.State.Interface.SSID.Association
 public class AggregatedState {
 
 	/** Rate information with aggregated fields. */
-	public static class AggregatedRate {
+	public static class Rate {
 		/**
-		 * This is the common bitRate for all the aggregated fields.
+		 * Aggregated fields bitRate
 		 */
 		public long bitRate;
 
 		/**
-		 * This is the common channel width for all the aggregated fields.
+		 * Aggregated fields chWidth
 		 */
 		public int chWidth;
 
 		/**
 		 * Aggregated fields mcs
 		 */
-		public List<Integer> mcs = new ArrayList<>();
+		public int mcs;
 
 		/** Constructor with no args */
-		private AggregatedRate() {}
+		private Rate() {}
 
-		/** Add a Rate to the AggregatedRate */
-		private void add(Rate rate) {
-			if (rate == null) {
-				return;
-			}
-			if (mcs.isEmpty()) {
-				bitRate = rate.bitrate;
-				chWidth = rate.chwidth;
-			}
-			mcs.add(rate.mcs);
-		}
-
-		/**
-		 * Add an AggregatedRate with the same channel_width to the
-		 * AggregatedRate
-		 */
-		private void add(AggregatedRate rate) {
-			if (rate == null || rate.chWidth != chWidth) {
-				return;
-			}
-			if (mcs.isEmpty()) {
-				bitRate = rate.bitRate;
-				chWidth = rate.chWidth;
-			}
-			mcs.addAll(rate.mcs);
+		/** Constructor with args */
+		private Rate(long bitRate, int chWidth, int mcs) {
+			this.bitRate = bitRate;
+			this.chWidth = chWidth;
+			this.mcs = mcs;
 		}
 	}
 
 	/**
 	 * Radio information with channel, channel_width and tx_power.
 	 */
-	public static class Radio {
+	public static class RadioConfig {
 		public int channel;
 		public int channelWidth;
 		public int txPower;
+		public String phy;
 
-		private Radio() {}
+		/** Default constructor with no args */
+		private RadioConfig() {}
 
-		public Radio(int channel, int channelWidth, int txPower) {
+		/** Constructor with args */
+		public RadioConfig(JsonObject radio) {
+			this.channel = radio.get("channel").getAsInt();
+			this.channelWidth = radio.get("channel_width").getAsInt();
+			this.txPower = radio.get("tx_power").getAsInt();
+			this.phy = radio.get("phy").getAsString();
+		}
+
+		public RadioConfig(int channel, int channelWidth, int txPower) {
 			this.channel = channel;
 			this.channelWidth = channelWidth;
 			this.txPower = txPower;
-		}
-
-		private Radio(Map<String, Integer> radioInfo) {
-			channel = radioInfo.getOrDefault("channel", -1);
-			channelWidth = radioInfo.getOrDefault("channel_width", -1);
-			txPower = radioInfo.getOrDefault("tx_power", -1);
 		}
 
 		@Override
@@ -109,64 +93,128 @@ public class AggregatedState {
 				return false;
 			}
 
-			Radio other = (Radio) obj;
+			RadioConfig other = (RadioConfig) obj;
 			return channel == other.channel &&
 				channelWidth == other.channelWidth && txPower == other.txPower;
 		}
 	}
 
+	/** 
+	 * Data model to keep raw data from {@link State.Interface.SSID.Association}, 
+	 * {@link State.Radio} and {@link State.Interface.Counters}.
+	 */
+	public static class AssociationInfo {
+		public long connected;
+		public long inactive;
+		public int rssi;
+		public long rxBytes;
+		public long rxPackets;
+		public Rate rxRate;
+		public long txBytes;
+		public long txDuration;
+		public long txFailed;
+		public long txPackets;
+		public Rate txRate;
+		public long txRetries;
+		public int ackSignal;
+		public int ackSignalAvg;
+		public long txPacketsCounters;
+		public long txErrorsCounters;
+		public long txDroppedCounters;
+		public long activeMsRadio;
+		public long busyMsRadio;
+		public long noiseRadio;
+		public long receiveMsRadio;
+		public long transmitMsRadio;
+		public long timeStamp;
+
+		/** Default Constructor. */
+		public AssociationInfo() {}
+
+		/** Constructor with only rssi(for test purpose) */
+		public AssociationInfo(int rssi) {
+			this.rssi = rssi;
+		}
+
+		/** Constructor with args */
+		public AssociationInfo(
+			Association association,
+			Counters counters,
+			JsonObject radio,
+			long timeStamp
+		) {
+			// Association info
+			connected = association.connected;
+			inactive = association.inactive;
+			rssi = association.rssi;
+			rxBytes = association.rx_bytes;
+			rxPackets = association.rx_packets;
+			if (association.rx_rate != null) {
+				rxRate = new Rate(
+					association.rx_rate.bitrate,
+					association.rx_rate.chwidth,
+					association.rx_rate.mcs
+				);
+			} else {
+				rxRate = new Rate();
+			}
+
+			txBytes = association.tx_bytes;
+			txPackets = association.tx_packets;
+
+			if (association.tx_rate != null) {
+				txRate = new Rate(
+					association.tx_rate.bitrate,
+					association.tx_rate.chwidth,
+					association.tx_rate.mcs
+				);
+			} else {
+				txRate = new Rate();
+			}
+			txRetries = association.tx_retries;
+			ackSignal = association.ack_signal;
+			ackSignalAvg = association.ack_signal_avg;
+
+			//Counters info
+			txPacketsCounters = counters.tx_packets;
+			txErrorsCounters = counters.tx_errors;
+			txDroppedCounters = counters.tx_dropped;
+
+			// Radio info
+			activeMsRadio = radio.get("active_ms").getAsLong();
+			busyMsRadio = radio.get("busy_ms").getAsLong();
+			transmitMsRadio = radio.get("transmit_ms").getAsLong();
+			receiveMsRadio = radio.get("receive_ms").getAsLong();
+			noiseRadio = radio.get("noise").getAsLong();
+
+			this.timeStamp = timeStamp;
+		}
+	}
+
 	public String bssid;
 	public String station;
-	public long connected;
-	public long inactive;
-	public List<Integer> rssi;
-	public long rxBytes;
-	public long rxPackets;
-	public AggregatedRate rxRate;
-	public long txBytes;
-	public long txDuration;
-	public long txFailed;
-	public long txPackets;
-	public AggregatedRate txRate;
-	public long txRetries;
-	public int ackSignal;
-	public int ackSignalAvg;
-	public Radio radio;
+	public RadioConfig radioConfig;
+	public List<AssociationInfo> associationInfoList;
 
 	/** Constructor with no args */
 	public AggregatedState() {
-		this.rxRate = new AggregatedRate();
-		this.txRate = new AggregatedRate();
-		this.rssi = new ArrayList<>();
-		this.radio = new Radio();
+		this.associationInfoList = new ArrayList<>();
+		this.radioConfig = new RadioConfig();
 	}
 
-	/** Construct from Association and radio */
+	/** Construct from Association, Counters, Radio and time stamp */
 	public AggregatedState(
 		Association association,
-		Map<String, Integer> radioInfo
+		Counters counters,
+		JsonObject radio,
+		long timeStamp
 	) {
-		this.rxRate = new AggregatedRate();
-		this.txRate = new AggregatedRate();
-		this.rssi = new ArrayList<>();
-
 		this.bssid = association.bssid;
 		this.station = association.station;
-		this.connected = association.connected;
-		this.inactive = association.inactive;
-		this.rssi.add(association.rssi);
-		this.rxBytes = association.rx_bytes;
-		this.rxPackets = association.rx_packets;
-		this.rxRate.add(association.rx_rate);
-		this.txBytes = association.tx_bytes;
-		this.txDuration = association.tx_duration;
-		this.txFailed = association.tx_failed;
-		this.txPackets = association.tx_packets;
-		this.txRate.add(association.tx_rate);
-		this.txRetries = association.tx_retries;
-		this.ackSignal = association.ack_signal;
-		this.ackSignalAvg = association.ack_signal_avg;
-		this.radio = new Radio(radioInfo);
+		this.associationInfoList = new ArrayList<>();
+		associationInfoList
+			.add(new AssociationInfo(association, counters, radio, timeStamp));
+		this.radioConfig = new RadioConfig(radio);
 	}
 
 	/**
@@ -178,7 +226,7 @@ public class AggregatedState {
 	 */
 	public boolean matchesForAggregation(AggregatedState state) {
 		return bssid == state.bssid && station == state.station &&
-			Objects.equals(radio, state.radio);
+			Objects.equals(radioConfig, state.radioConfig);
 	}
 
 	/**
@@ -191,9 +239,7 @@ public class AggregatedState {
 	 */
 	public boolean add(AggregatedState state) {
 		if (matchesForAggregation(state)) {
-			this.rssi.addAll(state.rssi);
-			this.rxRate.add(state.rxRate);
-			this.txRate.add(state.txRate);
+			associationInfoList.addAll(state.associationInfoList);
 			return true;
 		}
 		return false;

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/StateInfo.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/StateInfo.java
@@ -19,10 +19,4 @@ public class StateInfo extends State {
 
 	/** Default Constructor. */
 	public StateInfo() {}
-
-	/** Copy Constructor. */
-	public StateInfo(StateInfo stateInfo) {
-		super(stateInfo);
-		this.timestamp = stateInfo.timestamp;
-	}
 }

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/StateInfo.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/StateInfo.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifi.cloudsdk;
+
+import com.facebook.openwifi.cloudsdk.models.ap.State;
+
+public class StateInfo extends State {
+	/**
+	 * Unix time in milliseconds (ms). This is added it because {@link State} is an unknown
+	 * time reference.
+	 */
+	public long timestamp;
+
+	/** Default Constructor. */
+	public StateInfo() {}
+
+	/** Copy Constructor. */
+	public StateInfo(StateInfo stateInfo) {
+		super(stateInfo);
+		this.timestamp = stateInfo.timestamp;
+	}
+}

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/StateInfo.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/StateInfo.java
@@ -12,11 +12,8 @@ import com.facebook.openwifi.cloudsdk.models.ap.State;
 
 public class StateInfo extends State {
 	/**
-	 * Unix time in milliseconds (ms). This is added it because {@link State} is an unknown
+	 * Unix time in milliseconds (ms). This is added it because State.unit.localtime is an unknown
 	 * time reference.
 	 */
 	public long timestamp;
-
-	/** Default Constructor. */
-	public StateInfo() {}
 }

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
@@ -387,11 +387,11 @@ public class UCentralUtils {
 	 * Returns the results map
 	 */
 	public static Map<String, String> getBssidsMap(
-		Map<String, State> latestState
+		Map<String, StateInfo> latestState
 	) {
 		Map<String, String> bssidMap = new HashMap<>();
-		for (Map.Entry<String, State> e : latestState.entrySet()) {
-			State state = e.getValue();
+		for (Map.Entry<String, StateInfo> e : latestState.entrySet()) {
+			StateInfo state = e.getValue();
 			for (
 				int interfaceIndex = 0;
 				interfaceIndex < state.interfaces.length;

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralUtils.java
@@ -387,11 +387,11 @@ public class UCentralUtils {
 	 * Returns the results map
 	 */
 	public static Map<String, String> getBssidsMap(
-		Map<String, StateInfo> latestState
+		Map<String, ? extends State> latestState
 	) {
 		Map<String, String> bssidMap = new HashMap<>();
-		for (Map.Entry<String, StateInfo> e : latestState.entrySet()) {
-			StateInfo state = e.getValue();
+		for (Entry<String, ? extends State> e : latestState.entrySet()) {
+			State state = e.getValue();
 			for (
 				int interfaceIndex = 0;
 				interfaceIndex < state.interfaces.length;

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
@@ -8,7 +8,6 @@
 
 package com.facebook.openwifi.cloudsdk.models.ap;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
@@ -136,21 +135,4 @@ public class State {
 
 	/** Default Constructor with no args */
 	public State() {}
-
-	/** Copy Constructor */
-	public State(State state) {
-		Gson gson = new Gson();
-		this.radios = new Radio[state.radios.length];
-		for (int i = 0; i < radios.length; i++) {
-			radios[i] = gson.fromJson(gson.toJson(state.radios[i]), Radio.class);
-		}
-		this.interfaces = new Interface[state.interfaces.length];
-		for (int i = 0; i < radios.length; i++) {
-			interfaces[i] = gson.fromJson(gson.toJson(state.interfaces[i]), Interface.class);
-		}
-		this.linkState = state.linkState.deepCopy();
-		this.gps = state.gps.deepCopy();
-		this.poe = state.poe.deepCopy();
-		this.unit = gson.fromJson(gson.toJson(state.unit), Unit.class);
-	}
 }

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
@@ -8,6 +8,7 @@
 
 package com.facebook.openwifi.cloudsdk.models.ap;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
@@ -132,5 +133,24 @@ public class State {
 	@SerializedName("link-state") public JsonObject linkState;
 	public JsonObject gps;
 	public JsonObject poe;
-	public long timeStamp;
+
+	/** Default Constructor with no args */
+	public State() {}
+
+	/** Copy Constructor */
+	public State(State state) {
+		Gson gson = new Gson();
+		this.radios = new Radio[state.radios.length];
+		for (int i = 0; i < radios.length; i++) {
+			radios[i] = gson.fromJson(gson.toJson(state.radios[i]), Radio.class);
+		}
+		this.interfaces = new Interface[state.interfaces.length];
+		for (int i = 0; i < radios.length; i++) {
+			interfaces[i] = gson.fromJson(gson.toJson(state.interfaces[i]), Interface.class);
+		}
+		this.linkState = state.linkState.deepCopy();
+		this.gps = state.gps.deepCopy();
+		this.poe = state.poe.deepCopy();
+		this.unit = gson.fromJson(gson.toJson(state.unit), Unit.class);
+	}
 }

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
@@ -132,7 +132,4 @@ public class State {
 	@SerializedName("link-state") public JsonObject linkState;
 	public JsonObject gps;
 	public JsonObject poe;
-
-	/** Default Constructor with no args */
-	public State() {}
 }

--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/State.java
@@ -132,4 +132,5 @@ public class State {
 	@SerializedName("link-state") public JsonObject linkState;
 	public JsonObject gps;
 	public JsonObject poe;
+	public long timeStamp;
 }

--- a/owrrm/.gitignore
+++ b/owrrm/.gitignore
@@ -1,4 +1,0 @@
-/*.log*
-/device_config.json
-/settings.json
-/topology.json

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/Modeler.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/Modeler.java
@@ -312,12 +312,15 @@ public class Modeler implements Runnable {
 				JsonObject state = record.payload.getAsJsonObject("state");
 				if (state != null) {
 					try {
-						State stateModel = gson.fromJson(state, State.class);
-						List<State> latestStatesList = dataModel.latestStates
-							.computeIfAbsent(
-								record.serialNumber,
-								k -> new LinkedList<>()
-							);
+						State stateModel =
+							gson.fromJson(state, State.class);
+						stateModel.timeStamp = record.timestampMs;
+						List<State> latestStatesList =
+							dataModel.latestStates
+								.computeIfAbsent(
+									record.serialNumber,
+									k -> new LinkedList<>()
+								);
 						while (
 							latestStatesList.size() >= params.stateBufferSize
 						) {

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/Modeler.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/Modeler.java
@@ -25,10 +25,10 @@ import com.facebook.openwifi.cloudsdk.UCentralApConfiguration;
 import com.facebook.openwifi.cloudsdk.UCentralClient;
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.kafka.UCentralKafkaConsumer;
 import com.facebook.openwifi.cloudsdk.kafka.UCentralKafkaConsumer.KafkaRecord;
 import com.facebook.openwifi.cloudsdk.models.ap.Capabilities;
-import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.cloudsdk.models.gw.DeviceCapabilities;
 import com.facebook.openwifi.cloudsdk.models.gw.DeviceWithStatus;
 import com.facebook.openwifi.cloudsdk.models.gw.ServiceEvent;
@@ -96,7 +96,7 @@ public class Modeler implements Runnable {
 			new ConcurrentHashMap<>();
 
 		/** List of latest states per device. */
-		public Map<String, List<State>> latestStates =
+		public Map<String, List<StateInfo>> latestStates =
 			new ConcurrentHashMap<>();
 
 		/** List of radio info per device. */
@@ -277,7 +277,8 @@ public class Modeler implements Runnable {
 			JsonObject state = records.data.get(0).data;
 			if (state != null) {
 				try {
-					State stateModel = gson.fromJson(state, State.class);
+					StateInfo stateModel =
+						gson.fromJson(state, StateInfo.class);
 					dataModel.latestStates.computeIfAbsent(
 						device.serialNumber,
 						k -> new LinkedList<>()
@@ -312,10 +313,10 @@ public class Modeler implements Runnable {
 				JsonObject state = record.payload.getAsJsonObject("state");
 				if (state != null) {
 					try {
-						State stateModel =
-							gson.fromJson(state, State.class);
-						stateModel.timeStamp = record.timestampMs;
-						List<State> latestStatesList =
+						StateInfo stateModel =
+							gson.fromJson(state, StateInfo.class);
+						stateModel.timestamp = record.timestampMs;
+						List<StateInfo> latestStatesList =
 							dataModel.latestStates
 								.computeIfAbsent(
 									record.serialNumber,

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/Modeler.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/Modeler.java
@@ -275,10 +275,12 @@ public class Modeler implements Runnable {
 				continue;
 			}
 			JsonObject state = records.data.get(0).data;
+			long timestamp = records.data.get(0).recorded;
 			if (state != null) {
 				try {
 					StateInfo stateModel =
 						gson.fromJson(state, StateInfo.class);
+					stateModel.timestamp = timestamp;
 					dataModel.latestStates.computeIfAbsent(
 						device.serialNumber,
 						k -> new LinkedList<>()

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ModelerUtils.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ModelerUtils.java
@@ -411,15 +411,6 @@ public class ModelerUtils {
 				continue;
 			}
 			for (SSID ssid : stateInterface.ssids) {
-				Map<String, Integer> radioInfo = new HashMap<>();
-				radioInfo.put("channel", ssid.radio.get("channel").getAsInt());
-				radioInfo.put(
-					"channel_width",
-					ssid.radio.get("channel_width").getAsInt()
-				);
-				radioInfo
-					.put("tx_power", ssid.radio.get("tx_power").getAsInt());
-
 				for (Association association : ssid.associations) {
 					if (association == null) {
 						continue;
@@ -432,7 +423,12 @@ public class ModelerUtils {
 						bssidToAggregatedStates
 							.computeIfAbsent(key, k -> new ArrayList<>());
 					AggregatedState aggState =
-						new AggregatedState(association, radioInfo);
+						new AggregatedState(
+							association,
+							ssid.counters,
+							ssid.radio,
+							state.timeStamp
+						);
 
 					/**
 					 * Indicate if the aggState can be merged into some old AggregatedState.
@@ -535,7 +531,8 @@ public class ModelerUtils {
 	) {
 		Map<String, State> latestState = new ConcurrentHashMap<>();
 		for (
-			Map.Entry<String, List<State>> stateEntry : latestStates.entrySet()
+			Map.Entry<String, List<State>> stateEntry : latestStates
+				.entrySet()
 		) {
 			String key = stateEntry.getKey();
 			List<State> value = stateEntry.getValue();

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ModelerUtils.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/ModelerUtils.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import com.facebook.openwifi.cloudsdk.models.ap.Capabilities;
 import com.facebook.openwifi.cloudsdk.AggregatedState;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.ies.HTOperation;
 import com.facebook.openwifi.cloudsdk.ies.VHTOperation;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
@@ -404,7 +405,7 @@ public class ModelerUtils {
 	 */
 	static void addStateToAggregation(
 		Map<String, List<AggregatedState>> bssidToAggregatedStates,
-		State state
+		StateInfo state
 	) {
 		for (Interface stateInterface : state.interfaces) {
 			if (stateInterface.ssids == null) {
@@ -427,7 +428,7 @@ public class ModelerUtils {
 							association,
 							ssid.counters,
 							ssid.radio,
-							state.timeStamp
+							state.timestamp
 						);
 
 					/**
@@ -485,11 +486,11 @@ public class ModelerUtils {
 			new HashMap<>();
 
 		for (
-			Map.Entry<String, List<State>> deviceToStateList : dataModel.latestStates
+			Map.Entry<String, List<StateInfo>> deviceToStateList : dataModel.latestStates
 				.entrySet()
 		) {
 			String serialNumber = deviceToStateList.getKey();
-			List<State> states = deviceToStateList.getValue();
+			List<StateInfo> states = deviceToStateList.getValue();
 
 			if (states.isEmpty()) {
 				continue;
@@ -508,7 +509,7 @@ public class ModelerUtils {
 				aggregatedStates
 					.computeIfAbsent(serialNumber, k -> new HashMap<>());
 
-			for (State state : states) {
+			for (StateInfo state : states) {
 				if (refTimeMs - state.unit.localtime > obsoletionPeriodMs) {
 					// discard obsolete entries
 					break;
@@ -526,16 +527,16 @@ public class ModelerUtils {
 	 * @param latestStates list of latest States per device
 	 * @return map from device String to latest State
 	 */
-	public static Map<String, State> getLatestState(
-		Map<String, List<State>> latestStates
+	public static Map<String, StateInfo> getLatestState(
+		Map<String, List<StateInfo>> latestStates
 	) {
-		Map<String, State> latestState = new ConcurrentHashMap<>();
+		Map<String, StateInfo> latestState = new ConcurrentHashMap<>();
 		for (
-			Map.Entry<String, List<State>> stateEntry : latestStates
+			Map.Entry<String, List<StateInfo>> stateEntry : latestStates
 				.entrySet()
 		) {
 			String key = stateEntry.getKey();
-			List<State> value = stateEntry.getValue();
+			List<StateInfo> value = stateEntry.getValue();
 			if (value.isEmpty()) {
 				latestState.put(key, null);
 			} else {

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizer.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import com.facebook.openwifi.cloudsdk.UCentralConstants;
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
-import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
@@ -342,7 +341,7 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 				UCentralUtils.AVAILABLE_CHANNELS_BAND
 			);
 
-		Map<String, StateInfo> latestState =
+		Map<String, ? extends State> latestState =
 			ModelerUtils.getLatestState(model.latestStates);
 		Map<String, String> bssidsMap =
 			UCentralUtils.getBssidsMap(latestState);

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/LeastUsedChannelOptimizer.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import com.facebook.openwifi.cloudsdk.UCentralConstants;
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
@@ -341,7 +342,7 @@ public class LeastUsedChannelOptimizer extends ChannelOptimizer {
 				UCentralUtils.AVAILABLE_CHANNELS_BAND
 			);
 
-		Map<String, State> latestState =
+		Map<String, StateInfo> latestState =
 			ModelerUtils.getLatestState(model.latestStates);
 		Map<String, String> bssidsMap =
 			UCentralUtils.getBssidsMap(latestState);

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/RandomChannelInitializer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/RandomChannelInitializer.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
@@ -129,7 +130,7 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 				UCentralUtils.AVAILABLE_CHANNELS_BAND
 			);
 
-		Map<String, State> latestState =
+		Map<String, StateInfo> latestState =
 			ModelerUtils.getLatestState(model.latestStates);
 		Map<String, String> bssidsMap =
 			UCentralUtils.getBssidsMap(latestState);

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/RandomChannelInitializer.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/channel/RandomChannelInitializer.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
-import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
@@ -130,7 +129,7 @@ public class RandomChannelInitializer extends ChannelOptimizer {
 				UCentralUtils.AVAILABLE_CHANNELS_BAND
 			);
 
-		Map<String, StateInfo> latestState =
+		Map<String, ? extends State> latestState =
 			ModelerUtils.getLatestState(model.latestStates);
 		Map<String, String> bssidsMap =
 			UCentralUtils.getBssidsMap(latestState);

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -19,8 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifi.rrm.DeviceConfig;
-import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.rrm.DeviceDataManager;
+import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
 import com.facebook.openwifi.rrm.modules.ModelerUtils;
 
@@ -175,8 +175,8 @@ public class LocationBasedOptimalTPC extends TPC {
 		// Filter out the invalid APs (e.g., no radio, no location data)
 		// Update txPowerChoices, boundary, apLocX, apLocY for the optimization
 		for (String serialNumber : serialNumbers) {
-			List<StateInfo> states = model.latestStates.get(serialNumber);
-			StateInfo state = states.get(states.size() - 1);
+			List<? extends State> states = model.latestStates.get(serialNumber);
+			State state = states.get(states.size() - 1);
 
 			// Ignore the device if its radio is not active
 			if (state.radios == null || state.radios.length == 0) {

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/LocationBasedOptimalTPC.java
@@ -18,8 +18,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceConfig;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
 import com.facebook.openwifi.rrm.modules.ModelerUtils;
@@ -175,8 +175,8 @@ public class LocationBasedOptimalTPC extends TPC {
 		// Filter out the invalid APs (e.g., no radio, no location data)
 		// Update txPowerChoices, boundary, apLocX, apLocY for the optimization
 		for (String serialNumber : serialNumbers) {
-			List<State> states = model.latestStates.get(serialNumber);
-			State state = states.get(states.size() - 1);
+			List<StateInfo> states = model.latestStates.get(serialNumber);
+			StateInfo state = states.get(states.size() - 1);
 
 			// Ignore the device if its radio is not active
 			if (state.radios == null || state.radios.length == 0) {

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -161,15 +161,15 @@ public class MeasurementBasedApApTPC extends TPC {
 			Map.Entry<String, List<StateInfo>> e : model.latestStates.entrySet()
 		) {
 			List<StateInfo> states = e.getValue();
-			StateInfo state = states.get(states.size() - 1);
+			State state = states.get(states.size() - 1);
 			if (state.interfaces == null) {
 				continue;
 			}
-			for (StateInfo.Interface iface : state.interfaces) {
+			for (State.Interface iface : state.interfaces) {
 				if (iface.ssids == null) {
 					continue;
 				}
-				for (StateInfo.Interface.SSID ssid : iface.ssids) {
+				for (State.Interface.SSID ssid : iface.ssids) {
 					if (ssid.bssid == null) {
 						continue;
 					}
@@ -325,8 +325,8 @@ public class MeasurementBasedApApTPC extends TPC {
 			buildRssiMap(managedBSSIDs, model.latestWifiScans, band);
 		logger.debug("Starting TPC for the {} band", band);
 		for (String serialNumber : serialNumbers) {
-			List<StateInfo> states = model.latestStates.get(serialNumber);
-			StateInfo state = states.get(states.size() - 1);
+			List<? extends State> states = model.latestStates.get(serialNumber);
+			State state = states.get(states.size() - 1);
 			if (
 				state == null || state.radios == null ||
 					state.radios.length == 0

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApApTPC.java
@@ -24,6 +24,7 @@ import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
 import com.facebook.openwifi.cloudsdk.models.ap.Capabilities;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
 import com.facebook.openwifi.rrm.modules.ModelerUtils;
@@ -156,17 +157,19 @@ public class MeasurementBasedApApTPC extends TPC {
 	 */
 	protected static Set<String> getManagedBSSIDs(DataModel model) {
 		Set<String> managedBSSIDs = new HashSet<>();
-		for (Map.Entry<String, List<State>> e : model.latestStates.entrySet()) {
-			List<State> states = e.getValue();
-			State state = states.get(states.size() - 1);
+		for (
+			Map.Entry<String, List<StateInfo>> e : model.latestStates.entrySet()
+		) {
+			List<StateInfo> states = e.getValue();
+			StateInfo state = states.get(states.size() - 1);
 			if (state.interfaces == null) {
 				continue;
 			}
-			for (State.Interface iface : state.interfaces) {
+			for (StateInfo.Interface iface : state.interfaces) {
 				if (iface.ssids == null) {
 					continue;
 				}
-				for (State.Interface.SSID ssid : iface.ssids) {
+				for (StateInfo.Interface.SSID ssid : iface.ssids) {
 					if (ssid.bssid == null) {
 						continue;
 					}
@@ -322,8 +325,8 @@ public class MeasurementBasedApApTPC extends TPC {
 			buildRssiMap(managedBSSIDs, model.latestWifiScans, band);
 		logger.debug("Starting TPC for the {} band", band);
 		for (String serialNumber : serialNumbers) {
-			List<State> states = model.latestStates.get(serialNumber);
-			State state = states.get(states.size() - 1);
+			List<StateInfo> states = model.latestStates.get(serialNumber);
+			StateInfo state = states.get(states.size() - 1);
 			if (
 				state == null || state.radios == null ||
 					state.radios.length == 0

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -299,7 +299,7 @@ public class MeasurementBasedApClientTPC extends TPC {
 		) {
 			String serialNumber = e.getKey();
 			List<StateInfo> states = e.getValue();
-			StateInfo state = states.get(states.size() - 1);
+			State state = states.get(states.size() - 1);
 			if (state.radios == null || state.radios.length == 0) {
 				logger.debug(
 					"Device {}: No radios found, skipping...",
@@ -309,7 +309,7 @@ public class MeasurementBasedApClientTPC extends TPC {
 			}
 
 			Map<String, Integer> radioMap = new TreeMap<>();
-			for (StateInfo.Radio radio : state.radios) {
+			for (State.Radio radio : state.radios) {
 				Map<String, Capabilities.Phy> capabilityPhy =
 					model.latestDeviceCapabilitiesPhy
 						.get(serialNumber);

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/MeasurementBasedApClientTPC.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifi.cloudsdk.models.ap.Capabilities;
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
@@ -293,10 +294,12 @@ public class MeasurementBasedApClientTPC extends TPC {
 	public Map<String, Map<String, Integer>> computeTxPowerMap() {
 		Map<String, Map<String, Integer>> txPowerMap = new TreeMap<>();
 
-		for (Map.Entry<String, List<State>> e : model.latestStates.entrySet()) {
+		for (
+			Map.Entry<String, List<StateInfo>> e : model.latestStates.entrySet()
+		) {
 			String serialNumber = e.getKey();
-			List<State> states = e.getValue();
-			State state = states.get(states.size() - 1);
+			List<StateInfo> states = e.getValue();
+			StateInfo state = states.get(states.size() - 1);
 			if (state.radios == null || state.radios.length == 0) {
 				logger.debug(
 					"Device {}: No radios found, skipping...",
@@ -306,7 +309,7 @@ public class MeasurementBasedApClientTPC extends TPC {
 			}
 
 			Map<String, Integer> radioMap = new TreeMap<>();
-			for (State.Radio radio : state.radios) {
+			for (StateInfo.Radio radio : state.radios) {
 				Map<String, Capabilities.Phy> capabilityPhy =
 					model.latestDeviceCapabilitiesPhy
 						.get(serialNumber);

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/TPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/TPC.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import com.facebook.openwifi.cloudsdk.models.ap.Capabilities;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.rrm.DeviceConfig;
 import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.modules.ConfigManager;
@@ -186,10 +187,12 @@ public abstract class TPC {
 	 */
 	protected Map<String, Map<Integer, List<String>>> getApsPerChannel() {
 		Map<String, Map<Integer, List<String>>> apsPerChannel = new TreeMap<>();
-		for (Map.Entry<String, List<State>> e : model.latestStates.entrySet()) {
+		for (
+			Map.Entry<String, List<StateInfo>> e : model.latestStates.entrySet()
+		) {
 			String serialNumber = e.getKey();
-			List<State> states = e.getValue();
-			State state = states.get(states.size() - 1);
+			List<StateInfo> states = e.getValue();
+			StateInfo state = states.get(states.size() - 1);
 
 			if (state.radios == null || state.radios.length == 0) {
 				logger.debug(

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/TPC.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/optimizers/tpc/TPC.java
@@ -192,7 +192,7 @@ public abstract class TPC {
 		) {
 			String serialNumber = e.getKey();
 			List<StateInfo> states = e.getValue();
-			StateInfo state = states.get(states.size() - 1);
+			State state = states.get(states.size() - 1);
 
 			if (state.radios == null || state.radios.length == 0) {
 				logger.debug(

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ModelerUtilsTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ModelerUtilsTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.facebook.openwifi.cloudsdk.AggregatedState;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.aggregators.MeanAggregator;
 import com.facebook.openwifi.rrm.modules.Modeler.DataModel;
@@ -615,7 +616,7 @@ public class ModelerUtilsTest {
 			new ArrayList<>(Arrays.asList(aggStateC))
 		);
 
-		State toBeAggregated1 = TestUtils.createState(
+		StateInfo toBeAggregated1 = TestUtils.createState(
 			6,
 			20,
 			10,
@@ -667,7 +668,7 @@ public class ModelerUtilsTest {
 			Arrays.asList(20, 30, 40, 60)
 		);
 
-		State toBeAggregated2 = TestUtils.createState(
+		StateInfo toBeAggregated2 = TestUtils.createState(
 			11,
 			20,
 			20,
@@ -714,7 +715,7 @@ public class ModelerUtilsTest {
 		DataModel dataModel = new DataModel();
 
 		// This serie of StateA is used to test a valid input states.
-		State time1StateA = TestUtils.createState(
+		StateInfo time1StateA = TestUtils.createState(
 			1,
 			80,
 			10,
@@ -730,7 +731,7 @@ public class ModelerUtilsTest {
 			TestUtils.DEFAULT_LOCAL_TIME
 		);
 
-		State time2StateA = TestUtils.createState(
+		StateInfo time2StateA = TestUtils.createState(
 			1,
 			80,
 			10,
@@ -747,7 +748,7 @@ public class ModelerUtilsTest {
 		);
 
 		//As State time3StateA is obsolete, it should not be aggregated.
-		State time3StateA = TestUtils.createState(
+		StateInfo time3StateA = TestUtils.createState(
 			1,
 			80,
 			10,
@@ -875,7 +876,7 @@ public class ModelerUtilsTest {
 		);
 
 		// Test more clients operate on the same channel (stationB and stationA)
-		State time1StateB = TestUtils.createState(
+		StateInfo time1StateB = TestUtils.createState(
 			1,
 			80,
 			10,
@@ -888,7 +889,7 @@ public class ModelerUtilsTest {
 			.computeIfAbsent(serialNumberB, k -> new ArrayList<>())
 			.add(time1StateB);
 
-		State time1StateC = TestUtils.createState(
+		StateInfo time1StateC = TestUtils.createState(
 			6,
 			40,
 			20,

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ModelerUtilsTest.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/modules/ModelerUtilsTest.java
@@ -628,23 +628,42 @@ public class ModelerUtilsTest {
 		ModelerUtils
 			.addStateToAggregation(bssidToAggregatedStates, toBeAggregated1);
 
-		assertEquals(
-			bssidToAggregatedStates
+		List rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : bssidToAggregatedStates
 				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1))
-				.get(0).rssi,
+				.get(0).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
+		assertEquals(
+			rssiList,
 			Arrays.asList(10, 20, 30)
 		);
 
-		assertEquals(
-			bssidToAggregatedStates
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : bssidToAggregatedStates
 				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1))
-				.get(1).rssi,
+				.get(1).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
+		assertEquals(
+			rssiList,
 			Arrays.asList(40, 50)
 		);
-		assertEquals(
-			bssidToAggregatedStates
+
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : bssidToAggregatedStates
 				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2))
-				.get(0).rssi,
+				.get(0).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
+		assertEquals(
+			rssiList,
 			Arrays.asList(20, 30, 40, 60)
 		);
 
@@ -659,10 +678,17 @@ public class ModelerUtilsTest {
 		);
 		ModelerUtils
 			.addStateToAggregation(bssidToAggregatedStates, toBeAggregated2);
-		assertEquals(
-			bssidToAggregatedStates
+
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : bssidToAggregatedStates
 				.get(ModelerUtils.getBssidStationKeyPair(bssidB, stationB))
-				.get(0).rssi,
+				.get(0).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
+		assertEquals(
+			rssiList,
 			Arrays.asList(10, 20, 30, 40)
 		);
 	}
@@ -758,43 +784,93 @@ public class ModelerUtilsTest {
 			2
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(0).radio,
-			new AggregatedState.Radio(1, 80, 10)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(0).radioConfig,
+			new AggregatedState.RadioConfig(1, 80, 10)
 		);
+
+		List rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : aggregatedMap
+				.get(serialNumberA)
+				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1))
+				.get(0).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(0).rssi,
+			rssiList,
 			Arrays.asList(-84, 27)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(1).radio,
-			new AggregatedState.Radio(6, 40, 20)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(1).radioConfig,
+			new AggregatedState.RadioConfig(6, 40, 20)
 		);
+
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : aggregatedMap
+				.get(serialNumberA)
+				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1))
+				.get(1).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA1)).get(1).rssi,
+			rssiList,
 			Arrays.asList(-80)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(0).radio,
-			new AggregatedState.Radio(1, 80, 10)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(0).radioConfig,
+			new AggregatedState.RadioConfig(1, 80, 10)
 		);
+
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : aggregatedMap
+				.get(serialNumberA)
+				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2))
+				.get(0).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(0).rssi,
+			rssiList,
 			Arrays.asList(-67, -67)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(1).radio,
-			new AggregatedState.Radio(6, 40, 20)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(1).radioConfig,
+			new AggregatedState.RadioConfig(6, 40, 20)
 		);
+
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : aggregatedMap
+				.get(serialNumberA)
+				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2))
+				.get(1).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA2)).get(1).rssi,
+			rssiList,
 			Arrays.asList(180, 67)
 		);
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA3)).get(0).radio,
-			new AggregatedState.Radio(1, 80, 10)
+			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA3)).get(0).radioConfig,
+			new AggregatedState.RadioConfig(1, 80, 10)
 		);
+
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : aggregatedMap
+				.get(serialNumberA)
+				.get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA3))
+				.get(0).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
 		assertEquals(
-			aggregatedMap.get(serialNumberA).get(ModelerUtils.getBssidStationKeyPair(bssidA, stationA3)).get(0).rssi,
+			rssiList,
 			Arrays.asList(10, 100)
 		);
 
@@ -829,12 +905,32 @@ public class ModelerUtilsTest {
 			ModelerUtils
 				.getAggregatedStates(dataModel, obsoletionPeriodMs, refTimeMs);
 
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : aggregatedMap2
+				.get(serialNumberB)
+				.get(ModelerUtils.getBssidStationKeyPair(bssidB, stationB))
+				.get(0).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
 		assertEquals(
-			aggregatedMap2.get(serialNumberB).get(ModelerUtils.getBssidStationKeyPair(bssidB, stationB)).get(0).rssi, Arrays.asList(-30)
+			rssiList,
+			Arrays.asList(-30)
 		);
 
+		rssiList = new ArrayList<>();
+		for (
+			AggregatedState.AssociationInfo associationInfo : aggregatedMap2
+				.get(serialNumberC)
+				.get(ModelerUtils.getBssidStationKeyPair(bssidC, stationC))
+				.get(0).associationInfoList
+		) {
+			rssiList.add(associationInfo.rssi);
+		}
 		assertEquals(
-			aggregatedMap2.get(serialNumberC).get(ModelerUtils.getBssidStationKeyPair(bssidC, stationC)).get(0).rssi, Arrays.asList(-100)
+			rssiList,
+			Arrays.asList(-100)
 		);
 
 		assertEquals(

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
@@ -22,6 +22,7 @@ import com.facebook.openwifi.cloudsdk.AggregatedState;
 import com.facebook.openwifi.cloudsdk.UCentralConstants;
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.models.ap.Capabilities;
 import com.facebook.openwifi.cloudsdk.models.ap.State;
 import com.facebook.openwifi.rrm.DeviceTopology;
@@ -535,7 +536,7 @@ public class TestUtils {
 	 * @param localtime unix timestamp in seconds.
 	 * @return the state of an AP with radios described by the given parameters
 	 */
-	public static State createState(
+	public static StateInfo createState(
 		int[] channels,
 		int[] channelWidths,
 		int[] txPowers,
@@ -556,13 +557,13 @@ public class TestUtils {
 			);
 		}
 		final int numRadios = channels.length;
-		State state = new State();
-		state.interfaces = new State.Interface[numRadios + 1];
+		StateInfo state = new StateInfo();
+		state.interfaces = new StateInfo.Interface[numRadios + 1];
 		for (int index = 0; index < numRadios; index++) {
 			state.interfaces[index] = createUpStateInterface(index);
 		}
 		state.interfaces[numRadios] = createDownStateInterface(numRadios);
-		state.radios = new State.Radio[numRadios];
+		state.radios = new StateInfo.Radio[numRadios];
 		for (int i = 0; i < numRadios; i++) {
 			state.radios[i] = createStateRadio(i);
 			state.radios[i].channel = channels[i];
@@ -570,10 +571,10 @@ public class TestUtils {
 			state.radios[i].tx_power = txPowers[i];
 			state.interfaces[i].ssids[0].bssid = bssids[i];
 			state.interfaces[i].ssids[0].associations =
-				new State.Interface.SSID.Association[clientRssis[i].length];
+				new StateInfo.Interface.SSID.Association[clientRssis[i].length];
 			for (int j = 0; j < clientRssis[i].length; j++) {
 				state.interfaces[i].ssids[0].associations[j] =
-					new State.Interface.SSID.Association();
+					new StateInfo.Interface.SSID.Association();
 				state.interfaces[i].ssids[0].associations[j].rssi =
 					clientRssis[i][j];
 				state.interfaces[i].ssids[0].associations[j].station =
@@ -599,7 +600,7 @@ public class TestUtils {
 	 * @param localtime unix timestamp in seconds.
 	 * @return the state of an AP with one radio
 	 */
-	public static State createState(
+	public static StateInfo createState(
 		int channel,
 		int channelWidth,
 		int txPower,
@@ -627,7 +628,7 @@ public class TestUtils {
 	 * @param bssid bssid
 	 * @return the state of an AP with one radio
 	 */
-	public static State createState(
+	public static StateInfo createState(
 		int channel,
 		int channelWidth,
 		String bssid
@@ -644,7 +645,7 @@ public class TestUtils {
 	 * @param bssid bssid
 	 * @return the state of an AP with one radio
 	 */
-	public static State createState(
+	public static StateInfo createState(
 		int channel,
 		int channelWidth,
 		int txPower,
@@ -669,7 +670,7 @@ public class TestUtils {
 	 * @param clientRssis array of client RSSIs
 	 * @return the state of an AP with one radio
 	 */
-	public static State createState(
+	public static StateInfo createState(
 		int channel,
 		int channelWidth,
 		int txPower,
@@ -700,7 +701,7 @@ public class TestUtils {
 	 * @param bssidB bssid for radio on channelB
 	 * @return the state of an AP with two radios
 	 */
-	public static State createState(
+	public static StateInfo createState(
 		int channelA,
 		int channelWidthA,
 		int txPowerA,
@@ -737,7 +738,7 @@ public class TestUtils {
 	* @param localtime local time for the State
 	* @return the state of an AP with two radios
 	*/
-	public static State createState(
+	public static StateInfo createState(
 		int channelA,
 		int channelWidthA,
 		int txPowerA,

--- a/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
+++ b/owrrm/src/test/java/com/facebook/openwifi/rrm/optimizers/TestUtils.java
@@ -823,11 +823,15 @@ public class TestUtils {
 		int[] clientRssi
 	) {
 		AggregatedState state = new AggregatedState();
-		state.radio = new AggregatedState.Radio(channel, channelWidth, txPower);
+		state.radioConfig =
+			new AggregatedState.RadioConfig(channel, channelWidth, txPower);
 		state.bssid = bssid;
 		state.station = station;
+		state.associationInfoList = new ArrayList<>();
 		for (int rssi : clientRssi) {
-			state.rssi.add(rssi);
+			AggregatedState.AssociationInfo associationInfo =
+				new AggregatedState.AssociationInfo(rssi);
+			state.associationInfoList.add(associationInfo);
 		}
 		return state;
 	}

--- a/runner.sh
+++ b/runner.sh
@@ -12,6 +12,7 @@ COMMON_PARAMETERS=" \
 "
 
 JVM_IMPL="${JVM_IMPL:-openj9}"
+EXTRA_JVM_FLAGS="${EXTRA_JVM_FLAGS:-}"
 
 if [ "$JVM_IMPL" = "hotspot" ]; then
 # for hotspot
@@ -19,6 +20,7 @@ PARAMETERS="\
 $COMMON_PARAMETERS \
 -XX:+UseG1GC \
 -XX:+UseStringDeduplication \
+$EXTRA_JVM_FLAGS \
 "
 elif [ "$JVM_IMPL" = "openj9" ]; then
 # for openj9
@@ -26,6 +28,7 @@ PARAMETERS=" \
 $COMMON_PARAMETERS \
 -XX:+IdleTuningGcOnIdle \
 -Xtune:virtualized
+$EXTRA_JVM_FLAGS \
 "
 else
 echo "Invalid JVM_IMPL option"


### PR DESCRIPTION
Signed-off-by: zhiqiand <zhiqian@fb.com>

This PR refactor `AggregatedState` to meet the input data standard of RCA. The input data structure of RCA will be defined later in a separate PR.

Quick review:
```
public class AggregatedState {   
   public static class RadioConfig {
       public int channel;
       public int channelWidth;
       public int txPower;
       public String phy;
   }
   public class AssociationInfo {
       public long activeMsRadio;
       public long busyMsRadio;
       public long noiseRadio;
       public long receiveMsRadio;
       public long transmitMsRadio;
 
       public long connected;
       public long inactive;
       public int rssi;
       public long rxBytes;
       public long rxPackets;
       public Rate rxRate;
       public long txBytes;
       public long txDuration;
       public long txFailed;
       public long txPackets;
       public Rate txRate;
       public long txRetries;
       public int ackSignal;
       public int ackSignalAvg;
       public long txPacketsCounters;
       public long txErrorsCounters;
       public long txDroppedCounters;
       public long timeStamp;
   }
 
   public String bssid;
   public String station;
   public RadioConfig radioConfig;
   public List<AssociationInfo> associationInfoList;
}
```
