### PR TITLE
Fix owprov API handler /inventory/<serial>?rrmSettings=true

### DIFF
--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralClient.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/UCentralClient.java
@@ -690,6 +690,19 @@ public class UCentralClient {
 		try {
 			return gson.fromJson(response.getBody(), RRMDetails.class);
 		} catch (JsonSyntaxException e) {
+			// catch strings like "no", "inherit", "invalid" (???)
+			JSONObject respBody;
+			try {
+				respBody = new JSONObject(response.getBody());
+				respBody.getString("rrm");
+				logger.error(
+					"RRMDetails returned unexpected string body: {}",
+					respBody
+				);
+				return null;
+			} catch (JSONException e2) { /* ignore and fall through */}
+
+			// otherwise, log as a deserialization error
 			String errMsg = String.format(
 				"Failed to deserialize to RRMDetails: %s",
 				response.getBody()


### PR DESCRIPTION
Signed-off-by: Jeffrey Han <39203126+elludraon@users.noreply.github.com>

Starting to see `{"rrm":"no"}` returned from this endpoint, don't know why. Don't treat this as a deserialization error.

Ref: https://github.com/Telecominfraproject/wlan-cloud-owprov/blob/6aee513a4511b07f651708786e5fdf02862939ca/src/RESTAPI/RESTAPI_inventory_handler.cpp#L72-L73