### PR TITLE
Add UCentralSchema and convert Modeler.DataModel.latestDeviceStatusRadios

### DIFF
--- a/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/UCentralSchema.java
+++ b/lib-cloudsdk/src/main/java/com/facebook/openwifi/cloudsdk/models/ap/UCentralSchema.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.openwifi.cloudsdk.models.ap;
+
+import java.util.List;
+
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.SerializedName;
+
+public class UCentralSchema {
+	public static class Radio {
+		public String band;
+		public int bandwidth;
+		public JsonPrimitive channel; // either "auto" or int
+		@SerializedName("valid-channels") public int[] validChannels;
+		public String country;
+		@SerializedName("allow-dfs") public boolean allowDfs;
+		@SerializedName("channel-mode") public String channelMode;
+		@SerializedName("channel-width") public int channelWidth;
+		@SerializedName("require-mode") public String requireMode;
+		public String mimo;
+		@SerializedName("tx-power") public int txPower;
+		@SerializedName("legacy-rates") public boolean legacyRates;
+		@SerializedName("beacon-interval") public int beaconInterval;
+		@SerializedName("dtim-period") public int dtimPeriod;
+		@SerializedName("maximum-clients") public int maximumClients;
+
+		public static class Rates {
+			public int beacon;
+			public int multicast;
+		}
+
+		public Rates rates;
+
+		public static class HESettings {
+			@SerializedName("multiple-bssid") public boolean multipleBssid;
+			public boolean ema;
+			@SerializedName("bss-color") public int bssColor;
+		}
+
+		@SerializedName("he-settings") public HESettings heSettings;
+
+		@SerializedName("hostapd-iface-raw") public String[] hostapdIfaceRaw;
+	}
+
+	public List<Radio> radios;
+
+	public static class Metrics {
+		public static class Statistics {
+			public int interval;
+			public List<String> types;
+		}
+
+		public Statistics statistics;
+
+		public static class Health {
+			public int interval;
+		}
+
+		public Health health;
+
+		public static class WifiFrames {
+			public List<String> filters;
+		}
+
+		@SerializedName("wifi-frames") public WifiFrames wifiFrames;
+
+		public static class DhcpSnooping {
+			public List<String> filters;
+		}
+
+		@SerializedName("dhcp-snooping") public DhcpSnooping dhcpSnooping;
+	}
+
+	public Metrics metrics;
+
+	// TODO also add fields below as needed
+	// unit
+	// globals
+	// definitions
+	// ethernet
+	// switch
+	// interfaces
+	// services
+}

--- a/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/Modeler.java
+++ b/owrrm/src/main/java/com/facebook/openwifi/rrm/modules/Modeler.java
@@ -21,14 +21,15 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.UCentralApConfiguration;
 import com.facebook.openwifi.cloudsdk.UCentralClient;
 import com.facebook.openwifi.cloudsdk.UCentralUtils;
 import com.facebook.openwifi.cloudsdk.WifiScanEntry;
-import com.facebook.openwifi.cloudsdk.StateInfo;
 import com.facebook.openwifi.cloudsdk.kafka.UCentralKafkaConsumer;
 import com.facebook.openwifi.cloudsdk.kafka.UCentralKafkaConsumer.KafkaRecord;
 import com.facebook.openwifi.cloudsdk.models.ap.Capabilities;
+import com.facebook.openwifi.cloudsdk.models.ap.UCentralSchema;
 import com.facebook.openwifi.cloudsdk.models.gw.DeviceCapabilities;
 import com.facebook.openwifi.cloudsdk.models.gw.DeviceWithStatus;
 import com.facebook.openwifi.cloudsdk.models.gw.ServiceEvent;
@@ -38,7 +39,6 @@ import com.facebook.openwifi.rrm.DeviceDataManager;
 import com.facebook.openwifi.rrm.RRMConfig.ModuleConfig.ModelerParams;
 import com.facebook.openwifi.rrm.Utils;
 import com.google.gson.Gson;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 
@@ -100,7 +100,7 @@ public class Modeler implements Runnable {
 			new ConcurrentHashMap<>();
 
 		/** List of radio info per device. */
-		public Map<String, JsonArray> latestDeviceStatusRadios =
+		public Map<String, List<UCentralSchema.Radio>> latestDeviceStatusRadios =
 			new ConcurrentHashMap<>();
 
 		/** List of capabilities per device. */
@@ -406,10 +406,11 @@ public class Modeler implements Runnable {
 		UCentralApConfiguration config
 	) {
 		// Get old vs new radios info and store the new radios info
-		JsonArray newRadioList = config.getRadioConfigList();
+		List<UCentralSchema.Radio> newRadioList = config.getRadioConfigList();
 		Set<String> newRadioBandsSet = config.getRadioBandsSet(newRadioList);
-		JsonArray oldRadioList = dataModel.latestDeviceStatusRadios
-			.put(serialNumber, newRadioList);
+		List<UCentralSchema.Radio> oldRadioList =
+			dataModel.latestDeviceStatusRadios
+				.put(serialNumber, newRadioList);
 		Set<String> oldRadioBandsSet = config.getRadioBandsSet(oldRadioList);
 
 		// Print info only when there are any updates


### PR DESCRIPTION
Convert `Modeler.DataModel.latestDeviceStatusRadios` value type from `JsonArray` to `UCentralSchema.Radio`, which brings some memory savings.

Supersedes #110, but omits the full switch of the `UCentralApConfiguration` underlying structure (still uses `JsonObject` instead of the new `UCentralSchema`) as that would require larger changes.
